### PR TITLE
feat: 他人のユーザーアカウント詳細ページを実装

### DIFF
--- a/src/app/users/[userId]/_components/follow-button.tsx
+++ b/src/app/users/[userId]/_components/follow-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { followUser, unfollowUser } from "@/actions/user";
+
+type FollowButtonProps = {
+	userId: string;
+	initialIsFollowing: boolean;
+};
+
+export function FollowButton({
+	userId,
+	initialIsFollowing,
+}: FollowButtonProps) {
+	const router = useRouter();
+	const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+	const [isLoading, setIsLoading] = useState(false);
+
+	const handleToggleFollow = async () => {
+		setIsLoading(true);
+		try {
+			if (isFollowing) {
+				await unfollowUser(userId);
+				setIsFollowing(false);
+			} else {
+				await followUser(userId);
+				setIsFollowing(true);
+			}
+			router.refresh();
+		} catch (error) {
+			console.error("Failed to toggle follow:", error);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleToggleFollow}
+			disabled={isLoading}
+			className={`px-6 py-2 rounded-md font-medium transition-colors ${
+				isFollowing
+					? "bg-gray-200 text-gray-700 hover:bg-gray-300"
+					: "bg-blue-600 text-white hover:bg-blue-700"
+			} disabled:opacity-50`}
+		>
+			{isLoading ? "処理中..." : isFollowing ? "フォロー中" : "フォロー"}
+		</button>
+	);
+}

--- a/src/app/users/[userId]/followers/page.tsx
+++ b/src/app/users/[userId]/followers/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentUser, getUserById, getUserFollowers } from "@/actions/user";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+
+type UserFollowersPageProps = {
+	params: Promise<{
+		userId: string;
+	}>;
+};
+
+export default async function UserFollowersPage({
+	params,
+}: UserFollowersPageProps) {
+	const { userId } = await params;
+	const currentUser = await getCurrentUser();
+
+	if (!currentUser) {
+		redirect("/login");
+	}
+
+	const user = await getUserById(userId);
+
+	if (!user) {
+		redirect("/");
+	}
+
+	const followers = await getUserFollowers(userId);
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-7xl mx-auto px-4 py-6">
+				<div className="bg-white rounded-lg shadow-md overflow-hidden">
+					<div className="p-6 border-b border-gray-200">
+						<h1 className="text-2xl font-bold text-gray-900">
+							{user.nickname}のフォロワー
+						</h1>
+					</div>
+
+					{followers.length === 0 ? (
+						<div className="p-8 text-center">
+							<p className="text-gray-500">フォロワーはいません</p>
+						</div>
+					) : (
+						<div className="divide-y divide-gray-200">
+							{followers.map((follower) => (
+								<Link
+									key={follower.id}
+									href={`/users/${follower.id}`}
+									className="flex items-center justify-between p-4 hover:bg-gray-50 transition-colors"
+								>
+									<div className="flex flex-col">
+										<span className="text-gray-900 font-medium">
+											{follower.nickname}
+										</span>
+										<span className="text-sm text-gray-500">
+											{follower.lastName} {follower.firstName}
+										</span>
+									</div>
+									<svg
+										className="w-5 h-5 text-gray-400"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										role="img"
+										aria-label="次へ"
+									>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M9 5l7 7-7 7"
+										/>
+									</svg>
+								</Link>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+		</AuthenticatedLayout>
+	);
+}

--- a/src/app/users/[userId]/following/page.tsx
+++ b/src/app/users/[userId]/following/page.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentUser, getUserById, getUserFollowing } from "@/actions/user";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+
+type UserFollowingPageProps = {
+	params: Promise<{
+		userId: string;
+	}>;
+};
+
+export default async function UserFollowingPage({
+	params,
+}: UserFollowingPageProps) {
+	const { userId } = await params;
+	const currentUser = await getCurrentUser();
+
+	if (!currentUser) {
+		redirect("/login");
+	}
+
+	const user = await getUserById(userId);
+
+	if (!user) {
+		redirect("/");
+	}
+
+	const followingUsers = await getUserFollowing(userId);
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-7xl mx-auto px-4 py-6">
+				<div className="bg-white rounded-lg shadow-md overflow-hidden">
+					<div className="p-6 border-b border-gray-200">
+						<h1 className="text-2xl font-bold text-gray-900">
+							{user.nickname}のフォロー
+						</h1>
+					</div>
+
+					{followingUsers.length === 0 ? (
+						<div className="p-8 text-center">
+							<p className="text-gray-500">
+								フォローしているユーザーはいません
+							</p>
+						</div>
+					) : (
+						<div className="divide-y divide-gray-200">
+							{followingUsers.map((followingUser) => (
+								<Link
+									key={followingUser.id}
+									href={`/users/${followingUser.id}`}
+									className="flex items-center justify-between p-4 hover:bg-gray-50 transition-colors"
+								>
+									<div className="flex flex-col">
+										<span className="text-gray-900 font-medium">
+											{followingUser.nickname}
+										</span>
+										<span className="text-sm text-gray-500">
+											{followingUser.lastName} {followingUser.firstName}
+										</span>
+									</div>
+									<svg
+										className="w-5 h-5 text-gray-400"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										role="img"
+										aria-label="次へ"
+									>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M9 5l7 7-7 7"
+										/>
+									</svg>
+								</Link>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+		</AuthenticatedLayout>
+	);
+}

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -1,0 +1,132 @@
+import Image from "next/image";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import {
+	getCurrentUser,
+	getUserById,
+	getUserPosts,
+	isFollowing,
+} from "@/actions/user";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { FollowButton } from "./_components/follow-button";
+
+type UserDetailPageProps = {
+	params: Promise<{
+		userId: string;
+	}>;
+};
+
+export default async function UserDetailPage({ params }: UserDetailPageProps) {
+	const { userId } = await params;
+	const currentUser = await getCurrentUser();
+
+	if (!currentUser) {
+		redirect("/login");
+	}
+
+	if (currentUser.id === userId) {
+		redirect("/mypage");
+	}
+
+	const user = await getUserById(userId);
+
+	if (!user) {
+		redirect("/");
+	}
+
+	const [posts, followStatus] = await Promise.all([
+		getUserPosts(userId),
+		isFollowing(userId),
+	]);
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-7xl mx-auto px-4 py-6">
+				<div className="bg-white rounded-lg shadow-md overflow-hidden">
+					<div className="p-6 border-b border-gray-200">
+						<div className="flex items-center justify-between mb-4">
+							<div>
+								<h1 className="text-2xl font-bold text-gray-900 mb-2">
+									{user.nickname}
+								</h1>
+								<p className="text-gray-600">
+									{user.lastName} {user.firstName}
+								</p>
+							</div>
+							<FollowButton userId={userId} initialIsFollowing={followStatus} />
+						</div>
+
+						<div className="flex gap-6 mt-4">
+							<Link
+								href={`/users/${userId}/following`}
+								className="hover:underline"
+							>
+								<span className="font-semibold text-gray-900">
+									{user.followingCount}
+								</span>
+								<span className="text-gray-600 ml-1">フォロー</span>
+							</Link>
+							<Link
+								href={`/users/${userId}/followers`}
+								className="hover:underline"
+							>
+								<span className="font-semibold text-gray-900">
+									{user.followersCount}
+								</span>
+								<span className="text-gray-600 ml-1">フォロワー</span>
+							</Link>
+						</div>
+					</div>
+
+					<div className="p-6">
+						<h2 className="text-xl font-bold text-gray-900 mb-4">投稿</h2>
+						{posts.length === 0 ? (
+							<div className="p-8 text-center">
+								<p className="text-gray-500">投稿はありません</p>
+							</div>
+						) : (
+							<div className="space-y-6">
+								{posts.map((post) => (
+									<div
+										key={post.id}
+										className="border border-gray-200 rounded-lg p-4"
+									>
+										{post.images.length > 0 && (
+											<div className="grid grid-cols-2 gap-2 mb-4">
+												{post.images.map((image) => (
+													<div
+														key={image.id}
+														className="aspect-square relative"
+													>
+														<Image
+															src={image.url}
+															alt=""
+															fill
+															className="object-cover rounded-md"
+														/>
+													</div>
+												))}
+											</div>
+										)}
+										<p className="text-gray-800 mb-2">{post.body}</p>
+										<div className="flex items-center justify-between text-sm">
+											<Link
+												href={`/bars/${post.bar.id}`}
+												className="text-blue-600 hover:underline"
+											>
+												{post.bar.name}
+											</Link>
+											<span className="text-gray-500">
+												{new Date(post.createdAt).toLocaleDateString("ja-JP")}
+											</span>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</AuthenticatedLayout>
+	);
+}


### PR DESCRIPTION
## 概要
他人のユーザーアカウント詳細ページ（/users/[userId]）と関連ページを実装。
フォロー・アンフォロー機能、フォロー/フォロワー一覧表示、投稿一覧表示を含む。

## 対応Issue
Closes #19

## 変更内容

### Server Actions (src/actions/user.ts)
- `getUserById`: ユーザー情報取得
- `getUserPosts`: ユーザーの投稿一覧取得
- `isFollowing`: フォロー状態確認
- `followUser`: フォロー操作
- `unfollowUser`: アンフォロー操作
- `getUserFollowing`: フォロー一覧取得
- `getUserFollowers`: フォロワー一覧取得

### ページ実装
- `/users/[userId]`: ユーザー詳細ページ
- `/users/[userId]/following`: フォロー一覧ページ
- `/users/[userId]/followers`: フォロワー一覧ページ
- `/users/[userId]/_components/follow-button.tsx`: フォロー切り替えボタン

## 実装した機能
- ユーザー基本情報表示（ニックネーム、本名）
- フォロー/フォロワー数表示とリンク
- フォロー/アンフォロー切り替え機能
- 投稿一覧表示（画像、本文、店舗名、投稿日時）
- 自分自身のIDでアクセス時はマイページへリダイレクト

## 受入条件
- [x] 他人のユーザーIDを指定して正しくページが表示される
- [x] フォロー・アンフォロー操作が正しくDBに反映される
- [x] フォロー数・フォロワー数が最新状態で表示される
- [x] 投稿一覧が正しく表示される
- [x] 自分のユーザーIDを指定した場合、マイページにリダイレクトされる
- [x] Playwright MCPで動作確認済み

## 動作確認
- Playwright MCPで以下を確認
  - ページ表示
  - フォロー/アンフォロー切り替え
  - フォロー数の更新
  - フォロー/フォロワー一覧ページ遷移
  - 自分のID指定時のマイページリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)