### PR TITLE
feat: ユーザーの投稿一覧ページを実装

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -179,6 +179,12 @@ export async function getUserPosts(userId: string) {
 					name: true,
 				},
 			},
+			user: {
+				select: {
+					id: true,
+					nickname: true,
+				},
+			},
 		},
 		orderBy: {
 			createdAt: "desc",
@@ -196,6 +202,10 @@ export async function getUserPosts(userId: string) {
 		bar: {
 			id: post.bar.id,
 			name: post.bar.name,
+		},
+		user: {
+			id: post.user.id,
+			nickname: post.user.nickname,
 		},
 	}));
 }

--- a/src/app/signup/confirm/confirm-form.tsx
+++ b/src/app/signup/confirm/confirm-form.tsx
@@ -14,15 +14,10 @@ interface ProfileData {
 
 interface ConfirmFormProps {
 	profileData: ProfileData;
-	genderLabel: string;
 	backUrl: string;
 }
 
-export function ConfirmForm({
-	profileData,
-	genderLabel,
-	backUrl,
-}: ConfirmFormProps) {
+export function ConfirmForm({ profileData, backUrl }: ConfirmFormProps) {
 	const [state, formAction, isPending] = useActionState(
 		confirmAndSaveProfile,
 		undefined,

--- a/src/app/signup/confirm/page.tsx
+++ b/src/app/signup/confirm/page.tsx
@@ -80,7 +80,6 @@ export default async function ConfirmPage({
 
 					<ConfirmForm
 						profileData={profileData}
-						genderLabel={genderLabel}
 						backUrl={`/signup/profile?data=${encodeURIComponent(params.data)}`}
 					/>
 				</div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -26,6 +26,7 @@ export default async function SignUpPage({
 									stroke="currentColor"
 									viewBox="0 0 24 24"
 								>
+									<title>確認完了</title>
 									<path
 										strokeLinecap="round"
 										strokeLinejoin="round"

--- a/src/app/users/[userId]/posts/page.tsx
+++ b/src/app/users/[userId]/posts/page.tsx
@@ -1,0 +1,100 @@
+import Image from "next/image";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentUser, getUserById, getUserPosts } from "@/actions/user";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+
+type UserPostsPageProps = {
+	params: Promise<{
+		userId: string;
+	}>;
+};
+
+export default async function UserPostsPage({ params }: UserPostsPageProps) {
+	const { userId } = await params;
+	const currentUser = await getCurrentUser();
+
+	if (!currentUser) {
+		redirect("/login");
+	}
+
+	const user = await getUserById(userId);
+
+	if (!user) {
+		redirect("/");
+	}
+
+	const posts = await getUserPosts(userId);
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-7xl mx-auto px-4 py-6">
+				<div className="bg-white rounded-lg shadow-md overflow-hidden">
+					<div className="p-6 border-b border-gray-200">
+						<h1 className="text-2xl font-bold text-gray-900">
+							{user.nickname} の投稿
+						</h1>
+					</div>
+
+					<div className="p-6">
+						{posts.length === 0 ? (
+							<div className="p-8 text-center">
+								<p className="text-gray-500">投稿がありません</p>
+							</div>
+						) : (
+							<div className="space-y-6">
+								{posts.map((post) => (
+									<div
+										key={post.id}
+										className="border border-gray-200 rounded-lg p-4"
+									>
+										<div className="flex items-center mb-3">
+											<Link
+												href={`/users/${post.user.id}`}
+												className="text-blue-600 hover:underline font-semibold"
+											>
+												{post.user.nickname}
+											</Link>
+											<span className="text-gray-500 ml-auto text-sm">
+												{new Date(post.createdAt).toLocaleDateString("ja-JP")}
+											</span>
+										</div>
+
+										{post.images.length > 0 && (
+											<div className="grid grid-cols-2 gap-2 mb-4">
+												{post.images.map((image) => (
+													<div
+														key={image.id}
+														className="aspect-square relative"
+													>
+														<Image
+															src={image.url}
+															alt=""
+															fill
+															className="object-cover rounded-md"
+														/>
+													</div>
+												))}
+											</div>
+										)}
+
+										<p className="text-gray-800 mb-2">{post.body}</p>
+
+										<div className="flex items-center text-sm">
+											<Link
+												href={`/bars/${post.bar.id}`}
+												className="text-blue-600 hover:underline"
+											>
+												{post.bar.name}
+											</Link>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</AuthenticatedLayout>
+	);
+}

--- a/src/components/bar/bar-card.tsx
+++ b/src/components/bar/bar-card.tsx
@@ -1,4 +1,5 @@
 import { MapPin } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 
 interface BarCardProps {
@@ -23,11 +24,7 @@ export function BarCard({
 		>
 			<div className="aspect-video bg-gray-200 relative">
 				{imageUrl ? (
-					<img
-						src={imageUrl}
-						alt={name}
-						className="w-full h-full object-cover"
-					/>
+					<Image src={imageUrl} alt={name} fill className="object-cover" />
 				) : (
 					<div className="w-full h-full flex items-center justify-center text-gray-400">
 						<MapPin className="w-12 h-12" />

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,12 @@
 import { createBrowserClient } from "@supabase/ssr";
 
 export function createClient() {
-	return createBrowserClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-	);
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+	if (!url || !anonKey) {
+		throw new Error("Supabase environment variables are not defined");
+	}
+
+	return createBrowserClient(url, anonKey);
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -4,25 +4,28 @@ import { cookies } from "next/headers";
 export async function createClient() {
 	const cookieStore = await cookies();
 
-	return createServerClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				getAll() {
-					return cookieStore.getAll();
-				},
-				setAll(cookiesToSet) {
-					try {
-						for (const { name, value, options } of cookiesToSet) {
-							cookieStore.set(name, value, options);
-						}
-					} catch {
-						// Server Componentから呼ばれた場合はcookieの設定ができない
-						// ミドルウェアやServer Actionから呼ぶ必要がある
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+	if (!url || !anonKey) {
+		throw new Error("Supabase environment variables are not defined");
+	}
+
+	return createServerClient(url, anonKey, {
+		cookies: {
+			getAll() {
+				return cookieStore.getAll();
+			},
+			setAll(cookiesToSet) {
+				try {
+					for (const { name, value, options } of cookiesToSet) {
+						cookieStore.set(name, value, options);
 					}
-				},
+				} catch {
+					// Server Componentから呼ばれた場合はcookieの設定ができない
+					// ミドルウェアやServer Actionから呼ぶ必要がある
+				}
 			},
 		},
-	);
+	});
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,28 +11,31 @@ export async function middleware(request: NextRequest) {
 		request,
 	});
 
-	const supabase = createServerClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				getAll() {
-					return request.cookies.getAll();
-				},
-				setAll(cookiesToSet) {
-					for (const { name, value } of cookiesToSet) {
-						request.cookies.set(name, value);
-					}
-					supabaseResponse = NextResponse.next({
-						request,
-					});
-					for (const { name, value, options } of cookiesToSet) {
-						supabaseResponse.cookies.set(name, value, options);
-					}
-				},
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+	if (!url || !anonKey) {
+		throw new Error("Supabase environment variables are not defined");
+	}
+
+	const supabase = createServerClient(url, anonKey, {
+		cookies: {
+			getAll() {
+				return request.cookies.getAll();
+			},
+			setAll(cookiesToSet) {
+				for (const { name, value } of cookiesToSet) {
+					request.cookies.set(name, value);
+				}
+				supabaseResponse = NextResponse.next({
+					request,
+				});
+				for (const { name, value, options } of cookiesToSet) {
+					supabaseResponse.cookies.set(name, value, options);
+				}
 			},
 		},
-	);
+	});
 
 	const {
 		data: { user },


### PR DESCRIPTION
## 概要
Issue #21 に基づき、ユーザーの投稿一覧ページ (`/users/[userId]/posts`) を実装しました。

## 実装内容

### 新規追加
- `/users/[userId]/posts` ページを新規作成
  - 投稿カードに投稿者、画像（最大4枚）、本文、店舗情報を表示
  - 投稿0件の場合は空状態（「投稿がありません」）を表示
  - ユーザー名をページ上部に表示

### 変更・修正
- `getUserPosts` 関数に投稿者情報を追加
- 既存のlintエラーを修正（9件）
  - 未使用パラメータの削除
  - non-null assertion の削除
  - `<img>` タグを `<Image>` コンポーネントに変更
  - SVGに `<title>` を追加

## 技術的な詳細
- Server Components を使用
- 認証チェックを実装（未ログインは `/login` にリダイレクト）
- 既存の `getUserById` と `getUserPosts` アクションを活用

## 受入条件の確認結果
- ✅ `/users/[userId]/posts` にアクセスできる
- ✅ 投稿0件のときに空状態が表示される
- ✅ ユーザー名がページ上部に表示される
- ✅ 認証が必要（ログイン状態で動作）
- ⚠️ 投稿データがないため、投稿カード表示・投稿者クリック・タグクリックの確認はできず

## 注意事項
- タグ機能は database.md にテーブル定義がないため、今回はスキップしました
- 投稿のあるユーザーで動作確認を行う必要があります

## 関連Issue
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)