### PR TITLE
feat: お気に入りバーページを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"react": "19.2.1",
 		"react-dom": "19.2.1",
 		"react-hook-form": "^7.68.0",
+		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.4.0",
 		"zod": "^4.1.13"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-hook-form:
         specifier: ^7.68.0
         version: 7.68.0(react@19.2.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1992,6 +1995,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3935,6 +3944,11 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/favorites/bars/favorite-bars-client.tsx
+++ b/src/app/favorites/bars/favorite-bars-client.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { FavoriteBarCard } from "@/components/bar/favorite-bar-card";
+
+interface FavoriteBar {
+	id: string;
+	createdAt: Date;
+	bar: {
+		id: string;
+		name: string;
+		prefecture: string;
+		city: string;
+		images: Array<{
+			id: string;
+			imageUrl: string;
+			imageType: string;
+		}>;
+	};
+}
+
+interface FavoriteBarsClientProps {
+	initialFavorites: FavoriteBar[];
+}
+
+export function FavoriteBarsClient({
+	initialFavorites,
+}: FavoriteBarsClientProps) {
+	const [favorites, setFavorites] = useState(initialFavorites);
+
+	const handleRemove = (barId: string) => {
+		setFavorites((prev) => prev.filter((fav) => fav.bar.id !== barId));
+	};
+
+	if (favorites.length === 0) {
+		return (
+			<div className="text-center py-12 text-gray-500">
+				<p className="mb-2">お気に入りのバーがありません</p>
+				<p className="text-sm">
+					気になるバーを見つけたら、お気に入りに登録してみましょう
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+			{favorites.map((favorite) => (
+				<FavoriteBarCard
+					key={favorite.bar.id}
+					id={favorite.bar.id}
+					name={favorite.bar.name}
+					prefecture={favorite.bar.prefecture}
+					city={favorite.bar.city}
+					images={favorite.bar.images}
+					onRemove={handleRemove}
+				/>
+			))}
+		</div>
+	);
+}

--- a/src/app/favorites/bars/page.tsx
+++ b/src/app/favorites/bars/page.tsx
@@ -1,0 +1,18 @@
+import { getFavoriteBars } from "@/actions/bar";
+import { FavoriteBarsClient } from "./favorite-bars-client";
+
+export default async function FavoriteBarsPage() {
+	const favoriteBars = await getFavoriteBars();
+
+	return (
+		<div className="min-h-screen bg-gray-50 p-4">
+			<div className="max-w-7xl mx-auto">
+				<h1 className="text-2xl font-bold text-gray-900 mb-6">
+					お気に入りバー
+				</h1>
+
+				<FavoriteBarsClient initialFavorites={favoriteBars || []} />
+			</div>
+		</div>
+	);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +29,7 @@ export default function RootLayout({
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
 			>
 				{children}
+				<Toaster />
 			</body>
 		</html>
 	);

--- a/src/components/bar/favorite-bar-card.tsx
+++ b/src/components/bar/favorite-bar-card.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { MapPin, Star } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
+import { removeFavoriteBar } from "@/actions/bar";
+
+interface FavoriteBarCardProps {
+	id: string;
+	name: string;
+	prefecture: string;
+	city: string;
+	images: Array<{
+		id: string;
+		imageUrl: string;
+		imageType: string;
+	}>;
+	onRemove: (barId: string) => void;
+}
+
+export function FavoriteBarCard({
+	id,
+	name,
+	prefecture,
+	city,
+	images,
+	onRemove,
+}: FavoriteBarCardProps) {
+	const [isRemoving, setIsRemoving] = useState(false);
+
+	const handleRemoveFavorite = async (
+		e: React.MouseEvent<HTMLButtonElement>,
+	) => {
+		e.preventDefault();
+
+		if (isRemoving) return;
+
+		setIsRemoving(true);
+
+		try {
+			await removeFavoriteBar(id);
+			toast.success("お気に入りから削除しました");
+			onRemove(id);
+		} catch (error) {
+			console.error("Failed to remove favorite:", error);
+			toast.error("お気に入りの削除に失敗しました");
+			setIsRemoving(false);
+		}
+	};
+
+	const displayImage = images[0]?.imageUrl;
+
+	return (
+		<div className="block bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow overflow-hidden relative">
+			<Link href={`/bars/${id}`}>
+				<div className="aspect-video bg-gray-200 relative">
+					{displayImage ? (
+						<Image
+							src={displayImage}
+							alt={name}
+							fill
+							className="object-cover"
+						/>
+					) : (
+						<div className="w-full h-full flex items-center justify-center text-gray-400">
+							<MapPin className="w-12 h-12" />
+						</div>
+					)}
+				</div>
+
+				<div className="p-4">
+					<h3 className="font-bold text-lg text-gray-900 mb-2">{name}</h3>
+					<p className="text-sm text-gray-600">
+						{prefecture} {city}
+					</p>
+				</div>
+			</Link>
+
+			<button
+				type="button"
+				onClick={handleRemoveFavorite}
+				disabled={isRemoving}
+				className="absolute top-2 right-2 p-2 bg-white/90 hover:bg-white rounded-full shadow-md transition-colors disabled:opacity-50"
+				aria-label="お気に入りから削除"
+			>
+				<Star className="w-5 h-5 text-yellow-500 fill-yellow-500" />
+			</button>
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要
Issue #26 の対応として、お気に入り登録した店舗を一覧表示するページを実装しました。

## 実装内容
- `/favorites/bars` ページの実装
- お気に入り店舗一覧の表示（登録日時の新しい順）
- お気に入り解除機能
- 空状態の表示
- トースト通知の実装（sonner）

## 変更ファイル
- `src/actions/bar.ts`: お気に入り関連のServer Actionを追加
- `src/app/favorites/bars/page.tsx`: お気に入りバー一覧ページ
- `src/app/favorites/bars/favorite-bars-client.tsx`: クライアントコンポーネント
- `src/components/bar/favorite-bar-card.tsx`: お気に入りバーカードコンポーネント
- `src/app/layout.tsx`: Toasterコンポーネントの追加
- `package.json`, `pnpm-lock.yaml`: sonnerパッケージの追加

## 受入条件の確認
- ✅ お気に入り登録した店舗のみが表示されること
- ✅ 店舗が登録日時の新しい順で表示されること
- ✅ 各店舗の情報（画像、店名、都道府県、市町村）が正しく表示されること
- ✅ 店舗カードクリックで店舗詳細ページへ正しく遷移すること
- ✅ お気に入り解除ボタンが機能すること
- ✅ クリックで該当店舗がリストから削除されること
- ✅ トースト通知が表示されること
- ✅ 空状態が仕様通り表示されること
- ✅ Playwright MCPで動作確認済み

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)