### PR TITLE
feat: 投稿ページ(/posts/new)を実装

### DIFF
--- a/src/app/posts/new/actions.ts
+++ b/src/app/posts/new/actions.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { createPostSchema } from "@/lib/validations/post";
+
+type FormState = {
+	error?: string;
+	barId?: string;
+};
+
+export async function createPost(
+	_prevState: FormState | undefined,
+	formData: FormData,
+): Promise<FormState | undefined> {
+	const supabase = await createClient();
+
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return {
+			error: "認証が必要です",
+		};
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: { userAuthId: user.id },
+	});
+
+	if (!userProfile) {
+		return {
+			error: "ユーザープロフィールが見つかりません",
+		};
+	}
+
+	const barId = formData.get("barId") as string;
+	const body = formData.get("body") as string;
+
+	const images: File[] = [];
+	for (let i = 0; i < 4; i++) {
+		const image = formData.get(`image-${i}`) as File | null;
+		if (image && image instanceof File && image.size > 0) {
+			images.push(image);
+		}
+	}
+
+	const data = {
+		barId,
+		body,
+		images,
+	};
+
+	const result = createPostSchema.safeParse(data);
+	if (!result.success) {
+		return {
+			error: result.error.issues[0].message,
+			barId,
+		};
+	}
+
+	try {
+		const post = await prisma.post.create({
+			data: {
+				userId: userProfile.id,
+				barId: result.data.barId,
+				body: result.data.body,
+			},
+		});
+
+		if (result.data.images && result.data.images.length > 0) {
+			for (let i = 0; i < result.data.images.length; i++) {
+				const image = result.data.images[i];
+				const fileExt = image.name.split(".").pop();
+				const fileName = `${crypto.randomUUID()}.${fileExt}`;
+				const filePath = `posts/${post.id}/${fileName}`;
+
+				const arrayBuffer = await image.arrayBuffer();
+				const buffer = Buffer.from(arrayBuffer);
+
+				const { error: uploadError } = await supabase.storage
+					.from("post-images")
+					.upload(filePath, buffer, {
+						contentType: image.type,
+					});
+
+				if (uploadError) {
+					console.error("画像アップロードエラー:", uploadError);
+					continue;
+				}
+
+				const {
+					data: { publicUrl },
+				} = supabase.storage.from("post-images").getPublicUrl(filePath);
+
+				await prisma.postImage.create({
+					data: {
+						postId: post.id,
+						imageUrl: publicUrl,
+						sortOrder: i,
+					},
+				});
+			}
+		}
+	} catch (error) {
+		console.error("投稿作成エラー:", error);
+		return {
+			error: "投稿の作成に失敗しました",
+			barId,
+		};
+	}
+
+	redirect(`/bars/${result.data.barId}`);
+}

--- a/src/app/posts/new/page.tsx
+++ b/src/app/posts/new/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { PostForm } from "./post-form";
+
+export default async function NewPostPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ barId?: string }>;
+}) {
+	const supabase = await createClient();
+
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		redirect("/login");
+	}
+
+	const bars = await prisma.bar.findMany({
+		where: {
+			isActive: true,
+		},
+		select: {
+			id: true,
+			name: true,
+			prefecture: true,
+			city: true,
+		},
+		orderBy: {
+			name: "asc",
+		},
+	});
+
+	const params = await searchParams;
+	const selectedBarId = params.barId;
+
+	return (
+		<div className="min-h-screen bg-gray-50 pb-20">
+			<div className="max-w-2xl mx-auto px-4 py-8">
+				<div className="text-center mb-8">
+					<h1 className="text-3xl font-bold text-gray-900">投稿を作成</h1>
+				</div>
+
+				<div className="bg-white p-8 rounded-lg shadow-md">
+					<PostForm bars={bars} selectedBarId={selectedBarId} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/app/posts/new/post-form.tsx
+++ b/src/app/posts/new/post-form.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect, useState, useTransition } from "react";
+import { createPost } from "./actions";
+
+type Bar = {
+	id: bigint;
+	name: string;
+	prefecture: string;
+	city: string;
+};
+
+type PostFormProps = {
+	bars: Bar[];
+	selectedBarId?: string;
+};
+
+export function PostForm({ bars, selectedBarId }: PostFormProps) {
+	const router = useRouter();
+	const [state, formAction] = useActionState(createPost, undefined);
+	const [isPending, startTransition] = useTransition();
+	const [images, setImages] = useState<File[]>([]);
+	const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+	const [imageError, setImageError] = useState<string | null>(null);
+
+	useEffect(() => {
+		return () => {
+			for (const url of previewUrls) {
+				URL.revokeObjectURL(url);
+			}
+		};
+	}, [previewUrls]);
+
+	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = Array.from(e.target.files || []);
+
+		if (images.length + files.length > 4) {
+			setImageError("写真は最大4枚までです");
+			e.target.value = "";
+			return;
+		}
+
+		setImageError(null);
+		const newImages = [...images, ...files].slice(0, 4);
+		setImages(newImages);
+
+		const newUrls = files.map((file) => URL.createObjectURL(file));
+		setPreviewUrls((prev) => [...prev, ...newUrls].slice(0, 4));
+
+		e.target.value = "";
+	};
+
+	const handleRemoveImage = (index: number) => {
+		URL.revokeObjectURL(previewUrls[index]);
+		setImages((prev) => prev.filter((_, i) => i !== index));
+		setPreviewUrls((prev) => prev.filter((_, i) => i !== index));
+		setImageError(null);
+	};
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const formData = new FormData(e.currentTarget);
+
+		for (let i = 0; i < images.length; i++) {
+			formData.append(`image-${i}`, images[i]);
+		}
+
+		startTransition(() => {
+			formAction(formData);
+		});
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="flex flex-col gap-6 w-full">
+			<div className="flex flex-col gap-2">
+				<label htmlFor="barId" className="text-sm font-medium text-gray-700">
+					店舗選択<span className="text-red-500 ml-1">*</span>
+				</label>
+				<select
+					id="barId"
+					name="barId"
+					defaultValue={selectedBarId || state?.barId || ""}
+					className="px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+					required
+				>
+					<option value="">店舗を選択してください</option>
+					{bars.map((bar) => (
+						<option key={bar.id.toString()} value={bar.id.toString()}>
+							{bar.name} ({bar.prefecture} {bar.city})
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label htmlFor="body" className="text-sm font-medium text-gray-700">
+					投稿本文<span className="text-red-500 ml-1">*</span>
+				</label>
+				<textarea
+					id="body"
+					name="body"
+					rows={6}
+					placeholder="お店の感想やビールの味わいなどを投稿してください..."
+					className="px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+					required
+				/>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<div className="text-sm font-medium text-gray-700">
+					写真を追加（最大4枚）
+				</div>
+				<div className="flex flex-col gap-4">
+					{images.length < 4 && (
+						<label
+							htmlFor="image-upload"
+							className="flex items-center justify-center px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-blue-500 transition-colors"
+						>
+							<span className="text-blue-600 font-medium">+ 写真を追加</span>
+							<input
+								id="image-upload"
+								type="file"
+								accept="image/*"
+								multiple
+								onChange={handleImageChange}
+								className="hidden"
+							/>
+						</label>
+					)}
+
+					{previewUrls.length > 0 && (
+						<div className="grid grid-cols-2 gap-4">
+							{previewUrls.map((url, index) => (
+								<div key={url} className="relative aspect-square">
+									{/* biome-ignore lint/performance/noImgElement: blob URL preview */}
+									<img
+										src={url}
+										alt={`Preview ${index + 1}`}
+										className="w-full h-full object-cover rounded-lg"
+									/>
+									<button
+										type="button"
+										onClick={() => handleRemoveImage(index)}
+										className="absolute top-2 right-2 w-8 h-8 bg-red-500 text-white rounded-full hover:bg-red-600 transition-colors flex items-center justify-center"
+									>
+										×
+									</button>
+								</div>
+							))}
+						</div>
+					)}
+
+					{imageError && (
+						<div className="p-3 text-sm text-red-600 bg-red-50 rounded-lg">
+							{imageError}
+						</div>
+					)}
+				</div>
+			</div>
+
+			{state?.error && (
+				<div className="p-3 text-sm text-red-600 bg-red-50 rounded-lg">
+					{state.error}
+				</div>
+			)}
+
+			<div className="flex gap-4">
+				<button
+					type="button"
+					onClick={() => router.back()}
+					className="flex-1 px-4 py-3 text-gray-700 bg-gray-200 rounded-lg font-medium hover:bg-gray-300 transition-colors"
+				>
+					キャンセル
+				</button>
+				<button
+					type="submit"
+					disabled={isPending}
+					className="flex-1 px-4 py-3 text-white bg-blue-600 rounded-lg font-medium hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+				>
+					{isPending ? "投稿中..." : "投稿する"}
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/src/lib/validations/post.ts
+++ b/src/lib/validations/post.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const MAX_IMAGES = 4;
+
+export const createPostSchema = z.object({
+	barId: z
+		.string()
+		.min(1, { message: "店舗を選択してください" })
+		.transform((val) => BigInt(val)),
+	body: z.string().min(1, { message: "投稿本文を入力してください" }),
+	images: z
+		.array(z.instanceof(File))
+		.max(MAX_IMAGES, { message: `写真は最大${MAX_IMAGES}枚までです` })
+		.optional()
+		.default([]),
+});
+
+export type CreatePostFormData = z.infer<typeof createPostSchema>;


### PR DESCRIPTION
## 概要

Issue #29 の投稿ページ(/posts/new)を実装しました。

## 実装内容

### 機能
- 店舗選択機能（ドロップダウン）
- 投稿本文入力（テキストエリア）
- 写真アップロード機能（最大4枚）
  - プレビュー表示
  - 削除機能
  - Supabase Storageへのアップロード
- バリデーション機能
  - 店舗選択必須
  - 投稿本文必須
  - 写真最大4枚制限
- キャンセルボタン（前のページに戻る）
- 投稿作成後は店舗詳細ページへ遷移

### 技術スタック
- Next.js App Router
- React Hook Form (useActionState + useTransition)
- Zod (バリデーション)
- Supabase (Storage)
- Prisma (ORM)
- Tailwind CSS

### データベース
- `posts` テーブルに投稿データを保存
- `post_images` テーブルに画像データを保存
- Supabase Storage の `post-images` バケットに画像ファイルを保存

## テスト

Playwright MCP で以下の受入条件を検証済み：
- ✅ `/posts/new` にアクセスすると投稿作成ページが表示される
- ✅ 店舗選択フィールドが表示され、店舗を選択できる
- ✅ 投稿本文のテキストエリアが表示され、テキストを入力できる
- ✅ 店舗未選択の状態で「投稿する」ボタンをクリックするとバリデーションエラーが表示される
- ✅ 投稿本文が空の状態で「投稿する」ボタンをクリックするとバリデーションエラーが表示される
- ✅ 必須項目を入力し「投稿する」ボタンをクリックすると投稿が作成される
- ✅ 投稿作成後、店舗詳細ページへ遷移する
- ✅ 作成した投稿がデータベースに正しく保存される

## 変更ファイル

- `src/app/posts/new/page.tsx` - 投稿ページコンポーネント
- `src/app/posts/new/post-form.tsx` - 投稿フォームコンポーネント
- `src/app/posts/new/actions.ts` - 投稿作成Server Action
- `src/lib/validations/post.ts` - 投稿バリデーションスキーマ

## 注意事項

- Supabase Storage の `post-images` バケットが作成済みであることを前提としています
- 未ログイン時は `/login` へリダイレクトされます

🤖 Generated with [Claude Code](https://claude.com/claude-code)