### PR TITLE
feat: 通知一覧ページを実装

### DIFF
--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -1,0 +1,84 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+export async function getNotifications() {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return null;
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: {
+			userAuthId: user.id,
+		},
+	});
+
+	if (!userProfile) {
+		return null;
+	}
+
+	const notifications = await prisma.notification.findMany({
+		where: {
+			userId: userProfile.id,
+		},
+		orderBy: {
+			createdAt: "desc",
+		},
+	});
+
+	return notifications.map((notification) => ({
+		id: notification.id.toString(),
+		type: notification.type,
+		title: notification.title,
+		message: notification.message,
+		linkUrl: notification.linkUrl,
+		isRead: notification.isRead,
+		createdAt: notification.createdAt,
+	}));
+}
+
+export async function markNotificationAsRead(notificationId: string) {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		throw new Error("Not authenticated");
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: {
+			userAuthId: user.id,
+		},
+	});
+
+	if (!userProfile) {
+		throw new Error("User profile not found");
+	}
+
+	const notification = await prisma.notification.findUnique({
+		where: {
+			id: BigInt(notificationId),
+		},
+	});
+
+	if (!notification || notification.userId !== userProfile.id) {
+		throw new Error("Notification not found or unauthorized");
+	}
+
+	await prisma.notification.update({
+		where: {
+			id: BigInt(notificationId),
+		},
+		data: {
+			isRead: true,
+		},
+	});
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,39 @@
+import { getNotifications } from "@/actions/notification";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { NotificationCard } from "@/components/notification/notification-card";
+
+export default async function NotificationsPage() {
+	const notifications = await getNotifications();
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-3xl mx-auto px-4 py-6">
+				<h1 className="text-2xl font-bold text-gray-900 mb-6">通知</h1>
+
+				{!notifications || notifications.length === 0 ? (
+					<div className="text-center py-12 text-gray-500">
+						<p className="mb-2">通知はありません</p>
+						<p className="text-sm">
+							いいねやフォローなどの通知がここに表示されます
+						</p>
+					</div>
+				) : (
+					<div className="bg-white rounded-lg shadow overflow-hidden">
+						{notifications.map((notification) => (
+							<NotificationCard
+								key={notification.id}
+								id={notification.id}
+								type={notification.type}
+								title={notification.title}
+								message={notification.message}
+								linkUrl={notification.linkUrl}
+								isRead={notification.isRead}
+								createdAt={notification.createdAt}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</AuthenticatedLayout>
+	);
+}

--- a/src/components/notification/notification-card.tsx
+++ b/src/components/notification/notification-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { markNotificationAsRead } from "@/actions/notification";
+
+type NotificationCardProps = {
+	id: string;
+	type: string;
+	title: string;
+	message: string;
+	linkUrl: string | null;
+	isRead: boolean;
+	createdAt: Date;
+};
+
+function getNotificationIcon(type: string): string {
+	switch (type) {
+		case "post_liked":
+			return "❤️";
+		case "followed":
+			return "👤";
+		case "new_article":
+			return "📰";
+		default:
+			return "🔔";
+	}
+}
+
+function formatRelativeTime(date: Date): string {
+	const now = new Date();
+	const diff = now.getTime() - date.getTime();
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 0) {
+		return `${days}日前`;
+	}
+	if (hours > 0) {
+		return `${hours}時間前`;
+	}
+	if (minutes > 0) {
+		return `${minutes}分前`;
+	}
+	return "たった今";
+}
+
+export function NotificationCard({
+	id,
+	type,
+	title,
+	message,
+	linkUrl,
+	isRead,
+	createdAt,
+}: NotificationCardProps) {
+	const router = useRouter();
+
+	const handleClick = async () => {
+		if (!isRead) {
+			await markNotificationAsRead(id);
+		}
+		if (linkUrl) {
+			router.push(linkUrl);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			className={`w-full text-left p-4 border-b border-gray-200 hover:bg-gray-50 transition-colors ${
+				!isRead ? "bg-blue-50" : "bg-white"
+			}`}
+		>
+			<div className="flex items-start gap-3">
+				<div className="flex-shrink-0 text-2xl">
+					{getNotificationIcon(type)}
+				</div>
+				<div className="flex-1 min-w-0">
+					<p className="text-sm font-semibold text-gray-900">{title}</p>
+					<p className="text-sm text-gray-600 mt-1">{message}</p>
+					<p className="text-xs text-gray-400 mt-1">
+						{formatRelativeTime(createdAt)}
+					</p>
+				</div>
+				<div className="flex-shrink-0">
+					<svg
+						className="w-5 h-5 text-gray-400"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+					>
+						<title>詳細を見る</title>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth={2}
+							d="M9 5l7 7-7 7"
+						/>
+					</svg>
+				</div>
+			</div>
+		</button>
+	);
+}


### PR DESCRIPTION
## 概要

通知一覧ページ(`/notifications`)を実装しました。

## 実装内容

### 追加ファイル
- `src/actions/notification.ts` - 通知データ取得と既読更新のServer Action
- `src/components/notification/notification-card.tsx` - 通知カードコンポーネント
- `src/app/notifications/page.tsx` - 通知一覧ページ

### 主な機能
- 通知一覧の表示（新しい順）
- 通知種別ごとのアイコン表示（❤️ いいね、👤 フォロー、📰 記事など）
- 未読/既読の視覚的区別（未読: 青背景、既読: 白背景）
- クリック時の既読更新とlink_urlへの遷移
- 相対時刻表示（5分前、1時間前、1日前など）
- 通知0件時の空状態メッセージ表示
- 未ログイン時の `/login` へのリダイレクト

## 受入条件の確認

✅ AC1: ページへのアクセス
- ログイン済みユーザーが `/notifications` にアクセス可能
- ページタイトル「通知」が表示される
- 共通ヘッダー・フッターが表示される

✅ AC2: 通知一覧の表示
- 通知が一覧表示される
- 各通知にアイコン・タイトル・メッセージ・日時が表示される
- 新しい順（created_at降順）で表示される
- 未読通知は背景色が異なる（青背景）

✅ AC3: 通知クリックによる遷移
- 通知をクリックすると `link_url` に従って遷移する
- クリック時に該当通知が既読状態に更新される

✅ AC4: 通知が0件の場合
- 「通知はありません」メッセージが表示される

✅ AC5: 認証チェック
- 未ログインユーザーが `/notifications` にアクセスすると `/login` にリダイレクトされる

## 動作確認

Playwright MCPで全ての受入条件を検証済みです。

## 関連Issue

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)