### PR TITLE
fix: 店舗一覧と詳細ページで表示される店舗を一致させる

### DIFF
--- a/src/actions/bar.ts
+++ b/src/actions/bar.ts
@@ -3,6 +3,33 @@
 import { prisma } from "@/lib/prisma";
 import { createClient } from "@/lib/supabase/server";
 
+export async function getBars() {
+	const bars = await prisma.bar.findMany({
+		where: {
+			isActive: true,
+		},
+		include: {
+			barImages: {
+				orderBy: {
+					sortOrder: "asc",
+				},
+				take: 1,
+			},
+		},
+		orderBy: {
+			id: "asc",
+		},
+	});
+
+	return bars.map((bar) => ({
+		id: bar.id.toString(),
+		name: bar.name,
+		prefecture: bar.prefecture,
+		city: bar.city,
+		imageUrl: bar.barImages[0]?.imageUrl,
+	}));
+}
+
 export async function getBarDetail(barId: string) {
 	const bar = await prisma.bar.findUnique({
 		where: {

--- a/src/components/bar/bar-list.tsx
+++ b/src/components/bar/bar-list.tsx
@@ -1,34 +1,9 @@
+import { getBars } from "@/actions/bar";
 import { BarCard } from "./bar-card";
 
-// ダミーデータ
-const DUMMY_BARS = [
-	{
-		id: "1",
-		name: "静岡クラフトビアバー",
-		prefecture: "静岡県",
-		city: "静岡市",
-	},
-	{
-		id: "2",
-		name: "Beer Garden Tokyo",
-		prefecture: "東京都",
-		city: "渋谷区",
-	},
-	{
-		id: "3",
-		name: "浜松ビール工房",
-		prefecture: "静岡県",
-		city: "浜松市",
-	},
-	{
-		id: "4",
-		name: "横浜クラフトビアハウス",
-		prefecture: "神奈川県",
-		city: "横浜市",
-	},
-];
+export async function BarList() {
+	const bars = await getBars();
 
-export function BarList() {
 	return (
 		<div className="animate-fade-in">
 			<h2 className="text-2xl font-bold text-foreground mb-8 tracking-tight">
@@ -36,12 +11,12 @@ export function BarList() {
 			</h2>
 
 			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-				{DUMMY_BARS.map((bar) => (
+				{bars.map((bar) => (
 					<BarCard key={bar.id} {...bar} />
 				))}
 			</div>
 
-			{DUMMY_BARS.length === 0 && (
+			{bars.length === 0 && (
 				<div className="text-center py-12 text-muted-foreground">
 					<p className="tracking-wide">店舗が見つかりませんでした</p>
 				</div>


### PR DESCRIPTION
## 概要

Issue #39 のバグ修正。
店舗一覧から選択した店舗と、店舗詳細ページで表示される店舗が一致するようになりました。

## 修正内容

### 原因
- BarList コンポーネントがハードコードされたダミーデータを使用していた
- ダミーデータのIDとデータベースの実際のIDが一致していなかった
- 例: ダミーデータの「静岡クラフトビアバー」のID="1" が、実際にはデータベースの「ビアバー サンプル」を指していた

### 対策
1. `src/actions/bar.ts` に `getBars()` 関数を追加
   - データベースから店舗一覧を取得
   - 店舗の基本情報（id, name, prefecture, city, imageUrl）を返す
2. `src/components/bar/bar-list.tsx` を修正
   - ダミーデータを削除
   - Server Component として `getBars()` を呼び出し
   - データベースから取得した実際のデータを表示

## 変更ファイル

- `src/actions/bar.ts`
- `src/components/bar/bar-list.tsx`

## 受入条件の検証

Playwright MCP で以下を検証済み：

1. ✅ 店舗一覧から店舗を選択したとき、正しい barId がURLに反映されること
   - 「ビアバー サンプル」をクリック → `/bars/1` に遷移
2. ✅ 店舗詳細ページで、URLの barId に対応する店舗情報が表示されること
   - `/bars/1` で「ビアバー サンプル」が表示される
3. ✅ 複数の店舗で同様に動作すること
   - 実装上、複数店舗に対応（現在DBには1件のみ）

## 関連Issue

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)