### PR TITLE
fix: 閲覧履歴の重複表示を修正

### DIFF
--- a/prisma/migrations/20251219171254_add_unique_constraint_to_view_histories/migration.sql
+++ b/prisma/migrations/20251219171254_add_unique_constraint_to_view_histories/migration.sql
@@ -1,0 +1,10 @@
+-- まず、重複する閲覧履歴を削除（各user_id, bar_idの組み合わせで最新のviewed_atのみ残す）
+DELETE FROM view_histories
+WHERE id NOT IN (
+  SELECT DISTINCT ON (user_id, bar_id) id
+  FROM view_histories
+  ORDER BY user_id, bar_id, viewed_at DESC
+);
+
+-- 次に、UNIQUE制約を追加
+CREATE UNIQUE INDEX "view_histories_user_id_bar_id_key" ON "view_histories"("user_id", "bar_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -285,6 +285,7 @@ model ViewHistory {
   bar      Bar         @relation(fields: [barId], references: [id], onDelete: Cascade)
   user     UserProfile @relation(fields: [userId], references: [id])
 
+  @@unique([userId, barId])
   @@map("view_histories")
 }
 

--- a/src/actions/bar.ts
+++ b/src/actions/bar.ts
@@ -331,8 +331,17 @@ export async function recordViewHistory(barId: string) {
 		return;
 	}
 
-	await prisma.viewHistory.create({
-		data: {
+	await prisma.viewHistory.upsert({
+		where: {
+			userId_barId: {
+				userId: userProfile.id,
+				barId: BigInt(barId),
+			},
+		},
+		update: {
+			viewedAt: new Date(),
+		},
+		create: {
 			userId: userProfile.id,
 			barId: BigInt(barId),
 		},


### PR DESCRIPTION
## 概要
閲覧履歴ページで同じ店舗が重複して表示される問題を修正しました。

Closes #41

## 変更内容
### データベース
- `view_histories`テーブルに`UNIQUE`制約を追加（`user_id`, `bar_id`の組み合わせ）
- 既存の重複データを削除するマイグレーションを追加

### アプリケーション
- `recordViewHistory`関数を`create`から`upsert`に変更
- 同じ店舗に再アクセスした場合、新規レコードを作成せず`viewed_at`を更新

## 修正した問題
店舗詳細ページにアクセスするたびに、閲覧履歴に同じ店舗が重複して表示されていました。

### 期待される動作
- 各店舗は閲覧履歴に1件のみ表示
- 再アクセス時は`viewed_at`を更新し、並び順のみ変更

## テスト結果
受入条件の検証を実施し、全てPASSしました：

✅ 1. 店舗Aにアクセス時、閲覧履歴に店舗Aが1件のみ表示される
✅ 2. 店舗Bにアクセス時、閲覧履歴に店舗B→店舗Aの順で2件表示される
✅ 3. 再度店舗Aにアクセス時、閲覧履歴で店舗A→店舗Bの順に並び替えられる
✅ 4. 全過程で同じ店舗の重複エントリーが存在しない

## 変更ファイル
- `prisma/schema.prisma`: `ViewHistory`モデルに`@@unique([userId, barId])`制約を追加
- `src/actions/bar.ts`: `recordViewHistory`関数を`upsert`パターンに変更
- `prisma/migrations/20251219171254_add_unique_constraint_to_view_histories/migration.sql`: マイグレーションファイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)