### PR TITLE
【タイムライン】自分の投稿が表示されないバグ修正

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -361,9 +361,10 @@ export async function getTimelinePosts() {
 		},
 	});
 
-	const followingUserIds = followingRelations.map(
-		(relation) => relation.followeeId,
-	);
+	const followingUserIds = [
+		userProfile.id,
+		...followingRelations.map((relation) => relation.followeeId),
+	];
 
 	const posts = await prisma.post.findMany({
 		where: {


### PR DESCRIPTION
## 関連Issue

Closes #43

## 変更内容

タイムラインページ (`/timeline`) に自分自身の投稿も表示されるように修正しました。

### 修正前
- タイムラインには、フォローしているユーザーの投稿のみが表示されていた
- 自分自身の投稿は表示されなかった

### 修正後
- タイムラインには、フォローしているユーザーの投稿 + **自分自身の投稿**も時系列で表示される
- 一般的なSNSと同様の動作になる

## 技術的な変更

### 修正箇所
- `src/actions/user.ts` の `getTimelinePosts` 関数

### 変更内容
```typescript
// 修正前
const followingUserIds = followingRelations.map(
  (relation) => relation.followeeId,
);

// 修正後
const followingUserIds = [
  userProfile.id,  // 自分自身のIDを追加
  ...followingRelations.map((relation) => relation.followeeId),
];
```

これにより、投稿取得クエリの `userId: { in: followingUserIds }` に自分自身のIDが含まれるようになり、自分の投稿も取得されます。

## 受入条件

以下の手順で動作確認をお願いします：

1. **事前準備**
   - テストユーザーでログイン
   - 既存の投稿を確認（あれば）

2. **投稿作成**
   - `/posts/new` に遷移
   - 店舗を選択
   - 投稿本文を入力（例: "テスト投稿 - 自分の投稿表示確認"）
   - 投稿ボタンをクリック

3. **タイムライン確認**
   - `/timeline` に遷移
   - ページ内に自分が作成した投稿本文が表示されていることを確認
   - 投稿者が自分のニックネームであることを確認

4. **期待される結果**
   - ✅ タイムライン上に自分の投稿が表示される
   - ✅ 投稿内容が正しく表示される
   - ✅ 投稿者情報が正しく表示される
   - ✅ フォローしているユーザーの投稿と一緒に時系列でソートされている

## 注意事項

Playwright MCP サーバーが別プロセスで実行中のため、自動テストは実施できませんでした。
上記の受入条件を手動で確認してください。

## チェックリスト

- [x] コードをフォーマットした (`pnpm format`)
- [x] lintエラーを修正した (`pnpm lint`)
- [x] 修正内容をコミットした
- [ ] 受入条件を手動で確認した（レビュアー確認事項）

🍺 Generated with [Claude Code](https://claude.com/claude-code)