### PR TITLE
feat: タイムラインと他人の投稿一覧にいいねボタンを追加

### DIFF
--- a/src/actions/post.ts
+++ b/src/actions/post.ts
@@ -1,0 +1,114 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+export async function togglePostLike(postId: bigint) {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		throw new Error("Not authenticated");
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: {
+			userAuthId: user.id,
+		},
+	});
+
+	if (!userProfile) {
+		throw new Error("User profile not found");
+	}
+
+	const existingLike = await prisma.postLike.findUnique({
+		where: {
+			postId_userId: {
+				postId,
+				userId: userProfile.id,
+			},
+		},
+	});
+
+	if (existingLike) {
+		await prisma.$transaction([
+			prisma.postLike.delete({
+				where: {
+					postId_userId: {
+						postId,
+						userId: userProfile.id,
+					},
+				},
+			}),
+			prisma.post.update({
+				where: {
+					id: postId,
+				},
+				data: {
+					likeCount: {
+						decrement: 1,
+					},
+				},
+			}),
+		]);
+	} else {
+		await prisma.$transaction([
+			prisma.postLike.create({
+				data: {
+					postId,
+					userId: userProfile.id,
+				},
+			}),
+			prisma.post.update({
+				where: {
+					id: postId,
+				},
+				data: {
+					likeCount: {
+						increment: 1,
+					},
+				},
+			}),
+		]);
+	}
+
+	revalidatePath("/timeline");
+	revalidatePath("/users/[userId]", "page");
+
+	return !existingLike;
+}
+
+export async function checkIfUserLikedPost(postId: bigint) {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return false;
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: {
+			userAuthId: user.id,
+		},
+	});
+
+	if (!userProfile) {
+		return false;
+	}
+
+	const like = await prisma.postLike.findUnique({
+		where: {
+			postId_userId: {
+				postId,
+				userId: userProfile.id,
+			},
+		},
+	});
+
+	return like !== null;
+}

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTimelinePosts } from "@/actions/user";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { LikeButton } from "@/components/post/like-button";
 
 export default async function TimelinePage() {
 	const posts = await getTimelinePosts();
@@ -77,13 +78,18 @@ export default async function TimelinePage() {
 										{post.body}
 									</p>
 
-									<div className="flex items-center gap-2">
+									<div className="flex items-center justify-between">
 										<Link
 											href={`/bars/${post.bar.id}`}
 											className="inline-flex items-center px-3 py-1 bg-primary/10 text-primary rounded-full text-sm hover:bg-primary/20 transition-colors"
 										>
 											{post.bar.name}
 										</Link>
+										<LikeButton
+											postId={post.id}
+											initialLikeCount={post.likeCount}
+											initialIsLiked={post.isLikedByCurrentUser}
+										/>
 									</div>
 								</div>
 							))}

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -8,6 +8,7 @@ import {
 	isFollowing,
 } from "@/actions/user";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { LikeButton } from "@/components/post/like-button";
 import { FollowButton } from "./_components/follow-button";
 
 type UserDetailPageProps = {
@@ -119,7 +120,7 @@ export default async function UserDetailPage({ params }: UserDetailPageProps) {
 										<p className="text-card-foreground mb-2 tracking-wide">
 											{post.body}
 										</p>
-										<div className="flex items-center justify-between text-sm">
+										<div className="flex items-center justify-between text-sm mb-2">
 											<Link
 												href={`/bars/${post.bar.id}`}
 												className="text-primary hover:text-primary/80 transition-colors duration-300 tracking-wide"
@@ -129,6 +130,13 @@ export default async function UserDetailPage({ params }: UserDetailPageProps) {
 											<span className="text-muted-foreground tracking-wide">
 												{new Date(post.createdAt).toLocaleDateString("ja-JP")}
 											</span>
+										</div>
+										<div className="flex justify-end">
+											<LikeButton
+												postId={post.id}
+												initialLikeCount={post.likeCount}
+												initialIsLiked={post.isLikedByCurrentUser}
+											/>
 										</div>
 									</div>
 								))}

--- a/src/components/post/like-button.tsx
+++ b/src/components/post/like-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { togglePostLike } from "@/actions/post";
+
+type LikeButtonProps = {
+	postId: bigint;
+	initialLikeCount: number;
+	initialIsLiked: boolean;
+};
+
+export function LikeButton({
+	postId,
+	initialLikeCount,
+	initialIsLiked,
+}: LikeButtonProps) {
+	const [isLiked, setIsLiked] = useState(initialIsLiked);
+	const [likeCount, setLikeCount] = useState(initialLikeCount);
+	const [isPending, startTransition] = useTransition();
+
+	const handleLike = () => {
+		setIsLiked(!isLiked);
+		setLikeCount((prev) => (isLiked ? prev - 1 : prev + 1));
+
+		startTransition(async () => {
+			try {
+				await togglePostLike(postId);
+			} catch (error) {
+				setIsLiked(isLiked);
+				setLikeCount(isLiked ? likeCount + 1 : likeCount - 1);
+				console.error("Failed to toggle like:", error);
+			}
+		});
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleLike}
+			disabled={isPending}
+			className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors disabled:opacity-50"
+			aria-label={isLiked ? "いいねを取り消す" : "いいね"}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill={isLiked ? "currentColor" : "none"}
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className={`w-5 h-5 ${isLiked ? "text-primary" : ""}`}
+				aria-hidden="true"
+			>
+				<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+			</svg>
+			<span className="text-sm">{likeCount}</span>
+		</button>
+	);
+}


### PR DESCRIPTION
## Summary
タイムラインページと他人の投稿一覧ページにいいねボタンを実装しました。

### 主な変更内容
- いいね機能の Server Actions を実装 (`togglePostLike`, `checkIfUserLikedPost`)
- いいねボタンコンポーネントを作成（楽観的更新によるスムーズなUX）
- タイムラインページにいいねボタンを追加
- 他人の投稿一覧ページにいいねボタンを追加
- `getUserPosts` と `getTimelinePosts` にいいね情報を追加

### いいねボタンの仕様
- ハートアイコンでいいね/いいね解除が可能
- いいね数がリアルタイムで表示される
- いいね済みの投稿は、ハートアイコンが塗りつぶされ、色が変わる
- 楽観的更新により、クリック後すぐにUIが更新される

## Closes
Closes #50

## Test plan
- [x] タイムラインページにアクセスし、投稿カードにいいねボタンが表示されることを確認
- [x] いいねボタンをクリックし、いいねが追加されることを確認
- [x] いいね数が増加することを確認
- [x] もう一度いいねボタンをクリックし、いいねが削除されることを確認
- [x] いいね数が減少することを確認
- [x] いいね済みの投稿は、いいねボタンの見た目が変わることを確認
- [x] 他人のアカウント詳細ページにアクセスし、投稿カードにいいねボタンが表示されることを確認
- [x] 他人の投稿一覧でも、いいねボタンのクリックでいいねの追加/削除ができることを確認
- [x] 既存機能（投稿表示、ユーザー情報表示、タグ、店舗リンク等）に影響が出ていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)