### PR TITLE
タグ付けされた投稿にいいねボタンとタグを追加

### DIFF
--- a/src/app/bars/[barId]/page.tsx
+++ b/src/app/bars/[barId]/page.tsx
@@ -53,7 +53,9 @@ export default async function BarDetailPage({
 							menu: (
 								<MenuTab beerMenus={bar.beerMenus} foodMenus={bar.foodMenus} />
 							),
-							posts: <PostsTab posts={bar.posts} />,
+							posts: (
+								<PostsTab posts={bar.posts} barId={barId} barName={bar.name} />
+							),
 							articles: <ArticlesTab articles={bar.articles} />,
 							coupons: <CouponsTab coupons={bar.coupons} />,
 						}}

--- a/src/components/bar/tabs/posts-tab.tsx
+++ b/src/components/bar/tabs/posts-tab.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
+import { LikeButton } from "@/components/post/like-button";
 
 interface Post {
 	id: string;
 	body: string;
 	createdAt: Date;
+	likeCount: number;
+	isLikedByCurrentUser: boolean;
 	user: {
 		id: string;
 		nickname: string;
@@ -17,9 +22,11 @@ interface Post {
 
 interface PostsTabProps {
 	posts: Post[];
+	barId: string;
+	barName: string;
 }
 
-export function PostsTab({ posts }: PostsTabProps) {
+export function PostsTab({ posts, barId, barName }: PostsTabProps) {
 	if (posts.length === 0) {
 		return (
 			<div className="text-center py-8">
@@ -69,7 +76,21 @@ export function PostsTab({ posts }: PostsTabProps) {
 						</div>
 					)}
 
-					<p className="text-gray-800 whitespace-pre-wrap">{post.body}</p>
+					<p className="text-gray-800 whitespace-pre-wrap mb-3">{post.body}</p>
+
+					<div className="flex items-center justify-between">
+						<Link
+							href={`/bars/${barId}`}
+							className="inline-flex items-center px-3 py-1 bg-primary/10 text-primary rounded-full text-sm hover:bg-primary/20 transition-colors"
+						>
+							{barName}
+						</Link>
+						<LikeButton
+							postId={BigInt(post.id)}
+							initialLikeCount={post.likeCount}
+							initialIsLiked={post.isLikedByCurrentUser}
+						/>
+					</div>
 				</div>
 			))}
 		</div>


### PR DESCRIPTION
## 概要
店舗詳細ページの「タグ付けされた投稿」タブにいいねボタンとタグ（店舗名）を追加しました。

## 変更内容
### 修正ファイル
- `src/actions/bar.ts`: `getBarDetail` でいいね情報（likeCount, isLikedByCurrentUser）を取得するように修正
- `src/components/bar/tabs/posts-tab.tsx`: いいねボタンとタグを追加、Client Componentに変更
- `src/app/bars/[barId]/page.tsx`: PostsTabに店舗情報（barId, barName）を渡すように修正

### 主な実装内容
- タイムラインや他人の投稿一覧と同様のUIでいいねボタンを実装
- 店舗名をタグとして表示し、クリックで店舗詳細に遷移可能に
- いいね数の表示といいね/いいね解除の切り替えを実装

## テスト
Playwright MCPで以下の受入条件を検証済み：
- ✅ 店舗詳細ページにアクセスし、「タグ付けされた投稿」タブをクリックできる
- ✅ 投稿一覧が表示され、各投稿カードにいいねボタンとタグが表示される
- ✅ いいねボタンをクリックするといいねが付与される（いいね数が増加、ボタン表示が変化）
- ✅ 既にいいね済みの投稿では、いいね解除ボタンが表示される
- ✅ タグをクリックすると店舗詳細に遷移する
- ✅ タイムラインや他人の投稿一覧と同様のいいねボタンUIが表示される

## 関連Issue
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)