### PR TITLE
マイページのレイアウトを他人のアカウント詳細ページと統一

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,7 +1,9 @@
+import Image from "next/image";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { getCurrentUser } from "@/actions/user";
+import { getCurrentUser, getUserPosts } from "@/actions/user";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { LikeButton } from "@/components/post/like-button";
 
 export default async function MyPage() {
 	const user = await getCurrentUser();
@@ -10,72 +12,112 @@ export default async function MyPage() {
 		redirect("/login");
 	}
 
-	const menuItems = [
-		{
-			label: "フォロー",
-			href: "/mypage/following",
-			count: user.followingCount,
-		},
-		{
-			label: "フォロワー",
-			href: "/mypage/followers",
-			count: user.followersCount,
-		},
-		{
-			label: "投稿",
-			href: "/mypage/posts",
-			count: user.postsCount,
-		},
-		{
-			label: "持っているクーポン",
-			href: "/mypage/coupons",
-			count: user.couponsCount,
-		},
-	];
+	const posts = await getUserPosts(user.id);
 
 	return (
 		<AuthenticatedLayout>
 			<div className="max-w-7xl mx-auto px-4 py-6">
 				<div className="glass-card rounded-2xl modern-shadow overflow-hidden animate-fade-in">
 					<div className="p-6 border-b border-border/50">
-						<h1 className="text-2xl font-bold text-card-foreground mb-2 tracking-tight">
-							マイページ
-						</h1>
-						<p className="text-lg text-muted-foreground tracking-wide">
-							{user.nickname}
-						</p>
+						<div className="flex items-center justify-between mb-4">
+							<div>
+								<h1 className="text-2xl font-bold text-card-foreground mb-2 tracking-tight">
+									{user.nickname}
+								</h1>
+							</div>
+							<Link
+								href="/mypage/coupons"
+								className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors duration-300 font-medium tracking-wide"
+							>
+								持っているクーポン
+							</Link>
+						</div>
+
+						<div className="flex gap-6 mt-4">
+							<Link
+								href="/mypage/following"
+								className="hover:text-primary transition-colors duration-300"
+							>
+								<span className="font-semibold text-card-foreground">
+									{user.followingCount}
+								</span>
+								<span className="text-muted-foreground ml-1 tracking-wide">
+									フォロー
+								</span>
+							</Link>
+							<Link
+								href="/mypage/followers"
+								className="hover:text-primary transition-colors duration-300"
+							>
+								<span className="font-semibold text-card-foreground">
+									{user.followersCount}
+								</span>
+								<span className="text-muted-foreground ml-1 tracking-wide">
+									フォロワー
+								</span>
+							</Link>
+						</div>
 					</div>
 
-					<div className="divide-y divide-border/50">
-						{menuItems.map((item) => (
-							<Link
-								key={item.href}
-								href={item.href}
-								className="flex items-center justify-between p-4 hover:bg-primary/10 transition-all duration-300"
-							>
-								<span className="text-card-foreground font-medium tracking-wide">
-									{item.label}
-								</span>
-								<div className="flex items-center gap-2">
-									<span className="text-muted-foreground">{item.count}</span>
-									<svg
-										className="w-5 h-5 text-muted-foreground"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24"
-										role="img"
-										aria-label="次へ"
+					<div className="p-6">
+						<h2 className="text-xl font-bold text-card-foreground mb-4 tracking-tight">
+							投稿
+						</h2>
+						{posts.length === 0 ? (
+							<div className="p-8 text-center">
+								<p className="text-muted-foreground tracking-wide">
+									投稿はありません
+								</p>
+							</div>
+						) : (
+							<div className="space-y-6">
+								{posts.map((post) => (
+									<div
+										key={post.id}
+										className="glass-card border-border/30 rounded-xl p-4 hover-lift"
 									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M9 5l7 7-7 7"
-										/>
-									</svg>
-								</div>
-							</Link>
-						))}
+										{post.images.length > 0 && (
+											<div className="grid grid-cols-2 gap-2 mb-4">
+												{post.images.map((image) => (
+													<div
+														key={image.id}
+														className="aspect-square relative overflow-hidden rounded-lg"
+													>
+														<Image
+															src={image.url}
+															alt=""
+															fill
+															className="object-cover"
+														/>
+													</div>
+												))}
+											</div>
+										)}
+										<p className="text-card-foreground mb-2 tracking-wide">
+											{post.body}
+										</p>
+										<div className="flex items-center justify-between text-sm mb-2">
+											<Link
+												href={`/bars/${post.bar.id}`}
+												className="text-primary hover:text-primary/80 transition-colors duration-300 tracking-wide"
+											>
+												{post.bar.name}
+											</Link>
+											<span className="text-muted-foreground tracking-wide">
+												{new Date(post.createdAt).toLocaleDateString("ja-JP")}
+											</span>
+										</div>
+										<div className="flex justify-end">
+											<LikeButton
+												postId={post.id}
+												initialLikeCount={post.likeCount}
+												initialIsLiked={post.isLikedByCurrentUser}
+											/>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## 概要

マイページのレイアウトを他人のアカウント詳細ページと統一し、一貫性のあるUI/UXを提供します。

Closes #58

## 変更内容

### マイページ (`/mypage`) のレイアウト変更

- **ヘッダー部分**
  - ニックネームを大きく表示（以前は「マイページ」というタイトル+小さいニックネーム）
  - 右側に「持っているクーポン」ボタンを配置（他人ページのフォローボタンと同じ位置）
  - フォロー数/フォロワー数を横並びで表示（クリック可能なリンク）

- **投稿セクション**
  - ヘッダー部分の下に投稿一覧を表示
  - 投稿がない場合は「投稿はありません」と表示
  - 投稿がある場合は投稿カードのリストを表示（画像、本文、店舗名、日付、いいねボタン）

### 統一されたレイアウト

他人のアカウント詳細ページ (`/users/[userId]`) と視覚的に統一されたレイアウトになりました：

- ヘッダー部分の構造が同じ
- 投稿一覧の表示形式が同じ
- スタイリング（余白、フォントサイズなど）が統一

## 受入条件の確認

- [x] マイページ (`/mypage`) にアクセスすると、ヘッダー部分にニックネームが大きく表示される
- [x] 「持っているクーポン」へのリンクボタンが右側に配置される
- [x] フォロー数とフォロワー数がヘッダー部分に横並びで表示される
- [x] フォロー数をクリックすると `/mypage/following` に遷移する
- [x] フォロワー数をクリックすると `/mypage/followers` に遷移する
- [x] 投稿一覧がヘッダー部分の下に表示される
- [x] 投稿がない場合は「投稿はありません」と表示される
- [x] レイアウトが `/users/[userId]` ページと視覚的に統一されている

## スクリーンショット

### 変更前（縦並びメニュー形式）
従来のマイページは、フォロー/フォロワー/投稿/クーポンが等価なメニュー項目として縦並びで表示されていました。

### 変更後（他人ページと統一）
他人のアカウント詳細ページと同じレイアウトになり、ヘッダー部分にユーザー情報、下部に投稿一覧が表示されます。

## テスト

Playwright MCP を使用して以下を検証しました：

- マイページのレイアウトが仕様通りに表示されること
- 他人のアカウント詳細ページとレイアウトが統一されていること
- すべてのリンクが正しく機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)