### PR TITLE
feat: プロフィール画像とプロフィール文機能を追加

### DIFF
--- a/prisma/migrations/20251224094124_add_profile_image_url_and_bio_to_user_profiles/migration.sql
+++ b/prisma/migrations/20251224094124_add_profile_image_url_and_bio_to_user_profiles/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "user_profiles" ADD COLUMN     "bio" TEXT,
+ADD COLUMN     "profile_image_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model UserProfile {
   birthday       DateTime             @db.Date
   gender         String
   prefecture     String
+  profileImageUrl String?             @map("profile_image_url")
+  bio            String?
   isActive       Boolean              @default(true) @map("is_active")
   createdAt      DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt      DateTime             @updatedAt @map("updated_at") @db.Timestamptz(6)

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -36,6 +36,8 @@ export async function getCurrentUser() {
 	return {
 		id: userProfile.id,
 		nickname: userProfile.nickname,
+		profileImageUrl: userProfile.profileImageUrl,
+		bio: userProfile.bio,
 		followingCount: userProfile._count.following,
 		followersCount: userProfile._count.followedBy,
 		postsCount: userProfile._count.posts,
@@ -196,6 +198,8 @@ export async function getUserById(userId: string) {
 		nickname: userProfile.nickname,
 		lastName: userProfile.lastName,
 		firstName: userProfile.firstName,
+		profileImageUrl: userProfile.profileImageUrl,
+		bio: userProfile.bio,
 		followingCount: userProfile._count.following,
 		followersCount: userProfile._count.followedBy,
 		postsCount: userProfile._count.posts,

--- a/src/app/mypage/edit/actions.ts
+++ b/src/app/mypage/edit/actions.ts
@@ -78,12 +78,16 @@ export async function updateProfile(
 			},
 			data: updateData,
 		});
-
-		redirect("/mypage");
 	} catch (error) {
 		console.error("プロフィール更新エラー:", error);
+		if (error instanceof Error) {
+			console.error("エラーメッセージ:", error.message);
+			console.error("エラースタック:", error.stack);
+		}
 		return {
 			error: "プロフィールの更新に失敗しました",
 		};
 	}
+
+	redirect("/mypage");
 }

--- a/src/app/mypage/edit/actions.ts
+++ b/src/app/mypage/edit/actions.ts
@@ -57,8 +57,6 @@ export async function updateProfile(
 				} = supabase.storage.from("profile-images").getPublicUrl(fileName);
 				imageUrl = publicUrl;
 			}
-		} else if (profileImageUrl) {
-			imageUrl = profileImageUrl;
 		}
 
 		const updateData: {
@@ -68,7 +66,7 @@ export async function updateProfile(
 			bio: bio || null,
 		};
 
-		if (imageUrl !== null) {
+		if (profileImageUrl?.startsWith("data:image") && imageUrl) {
 			updateData.profileImageUrl = imageUrl;
 		}
 

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,0 +1,69 @@
+import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/actions/user";
+import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { ProfileEditForm } from "./profile-edit-form";
+import { GENDERS } from "@/lib/constants/prefectures";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function ProfileEditPage() {
+	const user = await getCurrentUser();
+
+	if (!user) {
+		redirect("/login");
+	}
+
+	const supabase = await createClient();
+	const {
+		data: { user: authUser },
+	} = await supabase.auth.getUser();
+
+	if (!authUser) {
+		redirect("/login");
+	}
+
+	const userProfile = await prisma.userProfile.findUnique({
+		where: {
+			userAuthId: authUser.id,
+		},
+	});
+
+	if (!userProfile) {
+		redirect("/login");
+	}
+
+	const genderLabel =
+		GENDERS.find((g) => g.value === userProfile.gender)?.label || "不明";
+
+	return (
+		<AuthenticatedLayout>
+			<div className="max-w-3xl mx-auto px-4 py-6">
+				<div className="glass-card rounded-2xl modern-shadow overflow-hidden animate-fade-in">
+					<div className="p-6">
+						<h1 className="text-2xl font-bold text-card-foreground mb-6 tracking-tight">
+							プロフィール編集
+						</h1>
+
+						<ProfileEditForm
+							currentProfile={{
+								profileImageUrl: userProfile.profileImageUrl || undefined,
+								bio: userProfile.bio || undefined,
+								nickname: userProfile.nickname,
+								lastName: userProfile.lastName,
+								firstName: userProfile.firstName,
+								email: authUser.email || "",
+								birthday: userProfile.birthday.toLocaleDateString("ja-JP", {
+									year: "numeric",
+									month: "long",
+									day: "numeric",
+								}),
+								gender: genderLabel,
+								prefecture: userProfile.prefecture,
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+		</AuthenticatedLayout>
+	);
+}

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,10 +1,10 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/actions/user";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
-import { ProfileEditForm } from "./profile-edit-form";
 import { GENDERS } from "@/lib/constants/prefectures";
 import { prisma } from "@/lib/prisma";
 import { createClient } from "@/lib/supabase/server";
+import { ProfileEditForm } from "./profile-edit-form";
 
 export default async function ProfileEditPage() {
 	const user = await getCurrentUser();

--- a/src/app/mypage/edit/profile-edit-form.tsx
+++ b/src/app/mypage/edit/profile-edit-form.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { updateProfile } from "./actions";
+
+interface ProfileEditFormProps {
+	currentProfile: {
+		profileImageUrl?: string;
+		bio?: string;
+		nickname: string;
+		lastName: string;
+		firstName: string;
+		email: string;
+		birthday: string;
+		gender: string;
+		prefecture: string;
+	};
+}
+
+export function ProfileEditForm({ currentProfile }: ProfileEditFormProps) {
+	const router = useRouter();
+	const [state, formAction, isPending] = useActionState(
+		updateProfile,
+		undefined,
+	);
+	const [imagePreview, setImagePreview] = useState<string | null>(
+		currentProfile.profileImageUrl || null,
+	);
+	const [bioLength, setBioLength] = useState(currentProfile.bio?.length || 0);
+
+	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) {
+			if (file.size > 5 * 1024 * 1024) {
+				alert("画像サイズは5MB以下にしてください");
+				e.target.value = "";
+				return;
+			}
+
+			const reader = new FileReader();
+			reader.onloadend = () => {
+				setImagePreview(reader.result as string);
+			};
+			reader.readAsDataURL(file);
+		}
+	};
+
+	return (
+		<form action={formAction} className="flex flex-col gap-6 w-full">
+			<div className="flex flex-col gap-2">
+				<label
+					htmlFor="profileImage"
+					className="text-sm font-medium text-card-foreground tracking-wide"
+				>
+					プロフィール画像
+				</label>
+				<div className="flex flex-col items-center gap-4">
+					{imagePreview ? (
+						<div className="w-32 h-32 rounded-full overflow-hidden border-2 border-primary relative">
+							<Image
+								src={imagePreview}
+								alt="プロフィール画像プレビュー"
+								fill
+								className="object-cover"
+							/>
+						</div>
+					) : (
+						<div className="w-32 h-32 rounded-full border-2 border-muted bg-muted flex items-center justify-center text-4xl text-muted-foreground">
+							{currentProfile.nickname.charAt(0)}
+						</div>
+					)}
+					<input
+						type="file"
+						id="profileImage"
+						name="profileImage"
+						accept="image/*"
+						onChange={handleImageChange}
+						className="glass-input px-4 py-3 rounded-xl text-card-foreground file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 focus:outline-none transition-all duration-300"
+					/>
+					<input
+						type="hidden"
+						name="profileImageUrl"
+						value={imagePreview || ""}
+					/>
+					<p className="text-xs text-muted-foreground">
+						推奨: 正方形の画像、最大5MB
+					</p>
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					htmlFor="bio"
+					className="text-sm font-medium text-card-foreground tracking-wide"
+				>
+					プロフィール文
+				</label>
+				<textarea
+					id="bio"
+					name="bio"
+					placeholder="自己紹介やビールの好みを入力してください"
+					maxLength={500}
+					rows={4}
+					defaultValue={currentProfile.bio}
+					onChange={(e) => setBioLength(e.target.value.length)}
+					className="glass-input px-4 py-3 rounded-xl text-card-foreground placeholder:text-muted-foreground focus:outline-none transition-all duration-300 resize-none"
+				/>
+				<p className="text-xs text-muted-foreground text-right">
+					{bioLength}/500文字
+				</p>
+			</div>
+
+			<div className="border-t border-border/50 pt-6">
+				<h2 className="text-lg font-bold text-card-foreground mb-4 tracking-tight">
+					基本情報（編集不可）
+				</h2>
+
+				<div className="space-y-4">
+					<div>
+						<p className="text-sm text-muted-foreground mb-1">ニックネーム</p>
+						<p className="text-base text-card-foreground font-medium">
+							{currentProfile.nickname}
+						</p>
+					</div>
+
+					<div className="grid grid-cols-2 gap-4">
+						<div>
+							<p className="text-sm text-muted-foreground mb-1">姓</p>
+							<p className="text-base text-card-foreground font-medium">
+								{currentProfile.lastName}
+							</p>
+						</div>
+						<div>
+							<p className="text-sm text-muted-foreground mb-1">名</p>
+							<p className="text-base text-card-foreground font-medium">
+								{currentProfile.firstName}
+							</p>
+						</div>
+					</div>
+
+					<div>
+						<p className="text-sm text-muted-foreground mb-1">メールアドレス</p>
+						<p className="text-base text-card-foreground font-medium">
+							{currentProfile.email}
+						</p>
+					</div>
+
+					<div>
+						<p className="text-sm text-muted-foreground mb-1">生年月日</p>
+						<p className="text-base text-card-foreground font-medium">
+							{currentProfile.birthday}
+						</p>
+					</div>
+
+					<div>
+						<p className="text-sm text-muted-foreground mb-1">性別</p>
+						<p className="text-base text-card-foreground font-medium">
+							{currentProfile.gender}
+						</p>
+					</div>
+
+					<div>
+						<p className="text-sm text-muted-foreground mb-1">都道府県</p>
+						<p className="text-base text-card-foreground font-medium">
+							{currentProfile.prefecture}
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{state?.error && (
+				<div className="p-3 text-sm text-destructive bg-destructive/10 rounded-xl border border-destructive/20">
+					{state.error}
+				</div>
+			)}
+
+			<div className="flex gap-4">
+				<button
+					type="button"
+					onClick={() => router.push("/mypage")}
+					className="flex-1 px-4 py-3 text-card-foreground bg-muted rounded-xl font-medium hover:bg-muted/80 transition-all duration-300 shadow-md"
+				>
+					キャンセル
+				</button>
+				<button
+					type="submit"
+					disabled={isPending}
+					className="flex-1 px-4 py-3 text-primary-foreground gradient-primary rounded-xl font-medium hover:shadow-lg hover:scale-105 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed transition-all duration-300 shadow-md"
+				>
+					{isPending ? "保存中..." : "保存"}
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/src/app/mypage/edit/profile-edit-form.tsx
+++ b/src/app/mypage/edit/profile-edit-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useActionState, useState } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useActionState, useState } from "react";
 import { updateProfile } from "./actions";
 
 interface ProfileEditFormProps {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -19,15 +19,44 @@ export default async function MyPage() {
 			<div className="max-w-7xl mx-auto px-4 py-6">
 				<div className="glass-card rounded-2xl modern-shadow overflow-hidden animate-fade-in">
 					<div className="p-6 border-b border-border/50">
-						<div className="flex items-center justify-between mb-4">
-							<div>
+						<div className="flex items-center gap-4 mb-4">
+							<div className="w-24 h-24 rounded-full overflow-hidden border-2 border-primary flex-shrink-0">
+								{user.profileImageUrl ? (
+									<Image
+										src={user.profileImageUrl}
+										alt={`${user.nickname}のプロフィール画像`}
+										width={96}
+										height={96}
+										className="w-full h-full object-cover"
+									/>
+								) : (
+									<div className="w-full h-full bg-muted flex items-center justify-center text-4xl text-muted-foreground">
+										{user.nickname.charAt(0)}
+									</div>
+								)}
+							</div>
+							<div className="flex-1">
 								<h1 className="text-2xl font-bold text-card-foreground mb-2 tracking-tight">
 									{user.nickname}
 								</h1>
+								{user.bio && (
+									<p className="text-sm text-muted-foreground whitespace-pre-wrap">
+										{user.bio}
+									</p>
+								)}
 							</div>
+						</div>
+
+						<div className="flex gap-2 mb-4">
+							<Link
+								href="/mypage/edit"
+								className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors duration-300 font-medium tracking-wide"
+							>
+								プロフィールを編集
+							</Link>
 							<Link
 								href="/mypage/coupons"
-								className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors duration-300 font-medium tracking-wide"
+								className="px-4 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/90 transition-colors duration-300 font-medium tracking-wide"
 							>
 								持っているクーポン
 							</Link>

--- a/src/app/signup/confirm/confirm-form.tsx
+++ b/src/app/signup/confirm/confirm-form.tsx
@@ -10,6 +10,8 @@ interface ProfileData {
 	birthday: string;
 	gender: string;
 	prefecture: string;
+	profileImageUrl?: string;
+	bio?: string;
 }
 
 interface ConfirmFormProps {

--- a/src/app/signup/confirm/page.tsx
+++ b/src/app/signup/confirm/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
 import Image from "next/image";
+import { redirect } from "next/navigation";
 import { GENDERS } from "@/lib/constants/prefectures";
 import { createClient } from "@/lib/supabase/server";
 import { ConfirmForm } from "./confirm-form";

--- a/src/app/signup/confirm/page.tsx
+++ b/src/app/signup/confirm/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import Image from "next/image";
 import { GENDERS } from "@/lib/constants/prefectures";
 import { createClient } from "@/lib/supabase/server";
 import { ConfirmForm } from "./confirm-form";
@@ -41,6 +42,20 @@ export default async function ConfirmPage({
 
 				<div className="bg-white p-8 rounded-lg shadow-md">
 					<div className="space-y-4 mb-6">
+						{profileData.profileImageUrl && (
+							<div className="border-b pb-3 flex flex-col items-center">
+								<p className="text-sm text-gray-500 mb-2">プロフィール画像</p>
+								<div className="w-32 h-32 rounded-full overflow-hidden border-2 border-primary relative">
+									<Image
+										src={profileData.profileImageUrl}
+										alt="プロフィール画像"
+										fill
+										className="object-cover"
+									/>
+								</div>
+							</div>
+						)}
+
 						<div className="border-b pb-3">
 							<p className="text-sm text-gray-500 mb-1">姓</p>
 							<p className="text-lg font-medium">{profileData.lastName}</p>
@@ -76,6 +91,15 @@ export default async function ConfirmPage({
 							<p className="text-sm text-gray-500 mb-1">お住まいの都道府県</p>
 							<p className="text-lg font-medium">{profileData.prefecture}</p>
 						</div>
+
+						{profileData.bio && (
+							<div className="border-b pb-3">
+								<p className="text-sm text-gray-500 mb-1">プロフィール文</p>
+								<p className="text-base whitespace-pre-wrap">
+									{profileData.bio}
+								</p>
+							</div>
+						)}
 					</div>
 
 					<ConfirmForm

--- a/src/app/signup/profile/actions.ts
+++ b/src/app/signup/profile/actions.ts
@@ -19,6 +19,8 @@ export async function saveProfileToSession(
 		birthday: formData.get("birthday") as string,
 		gender: formData.get("gender") as string,
 		prefecture: formData.get("prefecture") as string,
+		profileImageUrl: formData.get("profileImageUrl") as string | undefined,
+		bio: formData.get("bio") as string | undefined,
 	};
 
 	const result = profileSchema.safeParse(data);

--- a/src/app/signup/profile/profile-form.tsx
+++ b/src/app/signup/profile/profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
+import Image from "next/image";
 import { GENDERS, PREFECTURES } from "@/lib/constants/prefectures";
 import { saveProfileToSession } from "./actions";
 
@@ -9,6 +10,8 @@ export function ProfileForm() {
 		saveProfileToSession,
 		undefined,
 	);
+	const [imagePreview, setImagePreview] = useState<string | null>(null);
+	const [bioLength, setBioLength] = useState(0);
 
 	const currentYear = new Date().getFullYear();
 	const years = Array.from({ length: 100 }, (_, i) => currentYear - i);
@@ -16,6 +19,23 @@ export function ProfileForm() {
 	const months = Array.from({ length: 12 }, (_, i) => i + 1);
 
 	const days = Array.from({ length: 31 }, (_, i) => i + 1);
+
+	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) {
+			if (file.size > 5 * 1024 * 1024) {
+				alert("画像サイズは5MB以下にしてください");
+				e.target.value = "";
+				return;
+			}
+
+			const reader = new FileReader();
+			reader.onloadend = () => {
+				setImagePreview(reader.result as string);
+			};
+			reader.readAsDataURL(file);
+		}
+	};
 
 	return (
 		<form action={formAction} className="flex flex-col gap-4 w-full">
@@ -162,6 +182,64 @@ export function ProfileForm() {
 						</option>
 					))}
 				</select>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					htmlFor="profileImage"
+					className="text-sm font-medium text-card-foreground tracking-wide"
+				>
+					プロフィール画像（任意）
+				</label>
+				<div className="flex flex-col items-center gap-4">
+					{imagePreview && (
+						<div className="w-32 h-32 rounded-full overflow-hidden border-2 border-primary relative">
+							<Image
+								src={imagePreview}
+								alt="プロフィール画像プレビュー"
+								fill
+								className="object-cover"
+							/>
+						</div>
+					)}
+					<input
+						type="file"
+						id="profileImage"
+						name="profileImage"
+						accept="image/*"
+						onChange={handleImageChange}
+						className="glass-input px-4 py-3 rounded-xl text-card-foreground file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 focus:outline-none transition-all duration-300"
+					/>
+					<input
+						type="hidden"
+						name="profileImageUrl"
+						value={imagePreview || ""}
+					/>
+					<p className="text-xs text-muted-foreground">
+						推奨: 正方形の画像、最大5MB
+					</p>
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					htmlFor="bio"
+					className="text-sm font-medium text-card-foreground tracking-wide"
+				>
+					プロフィール文（任意）
+				</label>
+				<textarea
+					id="bio"
+					name="bio"
+					placeholder="自己紹介やビールの好みを入力してください"
+					maxLength={500}
+					rows={4}
+					onChange={(e) => setBioLength(e.target.value.length)}
+					className="glass-input px-4 py-3 rounded-xl text-card-foreground placeholder:text-muted-foreground focus:outline-none transition-all duration-300 resize-none"
+				/>
+				<p className="text-xs text-muted-foreground text-right">
+					{bioLength}/500文字
+				</p>
 			</div>
 
 			{state?.error && (

--- a/src/app/signup/profile/profile-form.tsx
+++ b/src/app/signup/profile/profile-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useActionState, useState } from "react";
 import Image from "next/image";
+import { useActionState, useState } from "react";
 import { GENDERS, PREFECTURES } from "@/lib/constants/prefectures";
 import { saveProfileToSession } from "./actions";
 

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -45,14 +45,34 @@ export default async function UserDetailPage({ params }: UserDetailPageProps) {
 			<div className="max-w-7xl mx-auto px-4 py-6">
 				<div className="glass-card rounded-2xl modern-shadow overflow-hidden animate-fade-in">
 					<div className="p-6 border-b border-border/50">
-						<div className="flex items-center justify-between mb-4">
-							<div>
+						<div className="flex items-center gap-4 mb-4">
+							<div className="w-24 h-24 rounded-full overflow-hidden border-2 border-primary flex-shrink-0">
+								{user.profileImageUrl ? (
+									<Image
+										src={user.profileImageUrl}
+										alt={`${user.nickname}のプロフィール画像`}
+										width={96}
+										height={96}
+										className="w-full h-full object-cover"
+									/>
+								) : (
+									<div className="w-full h-full bg-muted flex items-center justify-center text-4xl text-muted-foreground">
+										{user.nickname.charAt(0)}
+									</div>
+								)}
+							</div>
+							<div className="flex-1">
 								<h1 className="text-2xl font-bold text-card-foreground mb-2 tracking-tight">
 									{user.nickname}
 								</h1>
-								<p className="text-muted-foreground tracking-wide">
+								<p className="text-muted-foreground tracking-wide mb-2">
 									{user.lastName} {user.firstName}
 								</p>
+								{user.bio && (
+									<p className="text-sm text-muted-foreground whitespace-pre-wrap">
+										{user.bio}
+									</p>
+								)}
 							</div>
 							<FollowButton userId={userId} initialIsFollowing={followStatus} />
 						</div>

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -39,6 +39,11 @@ export const profileSchema = z.object({
 	birthday: z.string().min(1, { message: "生年月日を選択してください" }),
 	gender: z.string().min(1, { message: "性別を選択してください" }),
 	prefecture: z.string().min(1, { message: "都道府県を選択してください" }),
+	profileImageUrl: z.string().optional(),
+	bio: z
+		.string()
+		.max(500, { message: "プロフィール文は500文字以内で入力してください" })
+		.optional(),
 });
 
 export type ProfileFormData = z.infer<typeof profileSchema>;

--- a/supabase/migrations/20250101000000_create_profile_images_bucket.sql
+++ b/supabase/migrations/20250101000000_create_profile_images_bucket.sql
@@ -1,0 +1,30 @@
+-- Create storage bucket for profile images
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('profile-images', 'profile-images', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Set up storage policies for profile images
+CREATE POLICY "Allow public read access to profile images"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'profile-images');
+
+CREATE POLICY "Allow authenticated users to upload profile images"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'profile-images'
+  AND auth.role() = 'authenticated'
+);
+
+CREATE POLICY "Allow users to update their own profile images"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'profile-images'
+  AND auth.role() = 'authenticated'
+);
+
+CREATE POLICY "Allow users to delete their own profile images"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'profile-images'
+  AND auth.role() = 'authenticated'
+);

--- a/よく使うコマンド.md
+++ b/よく使うコマンド.md
@@ -1,0 +1,5 @@
+## PRの最新を取得
+```
+// たとえばPRの#61の最新を取得するなら
+gh api /repos/RikuShimoida/BeerSalon/issues/61/comments
+```


### PR DESCRIPTION
## 概要
マイページと他人のアカウント詳細ページにプロフィール画像とプロフィール文を追加しました。

Closes #60

## 主な変更内容

### データベース
- `user_profiles`テーブルに`profile_image_url`と`bio`カラムを追加
- Prismaマイグレーションを実行

### 機能追加
- **新規登録時**: `/signup/profile`でプロフィール画像とプロフィール文を入力可能に
- **プロフィール編集**: `/mypage/edit`ページを新規作成し、プロフィール画像・文の編集が可能に
- **プロフィール表示**: `/mypage`と`/users/[userId]`でプロフィール画像・文を表示
- **画像アップロード**: Supabase Storageへの画像アップロード機能を実装
- **デフォルト画像**: プロフィール画像未設定時はニックネームの頭文字を表示

### 技術的改善
- Next.js Imageコンポーネントを使用してパフォーマンスを最適化
- 画像サイズ制限（5MB）を実装
- プロフィール文の文字数制限（500文字）を実装
- リアルタイム文字数カウンター機能

### UI/UX
- 円形のプロフィール画像表示
- 編集不可フィールド（ニックネーム、氏名、メール等）を読み取り専用で表示
- 画像プレビュー機能
- エラーハンドリングとユーザーフィードバック

## 変更ファイル
- `prisma/schema.prisma`: スキーマ更新
- `src/actions/user.ts`: プロフィール画像・文を返すように更新
- `src/app/signup/profile/*`: プロフィール入力フォームに画像・文を追加
- `src/app/signup/confirm/*`: 確認画面に画像・文を表示
- `src/app/mypage/page.tsx`: プロフィール画像・文を表示、編集ボタン追加
- `src/app/mypage/edit/*`: 新規作成（プロフィール編集ページ）
- `src/app/users/[userId]/page.tsx`: プロフィール画像・文を表示
- `src/lib/validations/auth.ts`: バリデーションスキーマ更新

## テスト状況
Playwright MCPで以下を検証済み:
- ✅ マイページにプロフィール画像・文が表示される
- ✅ 「プロフィールを編集」ボタンが表示され、`/mypage/edit`へ遷移する
- ✅ `/mypage/edit`でプロフィール画像とプロフィール文が編集可能
- ✅ 編集不可項目（ニックネーム、氏名等）が読み取り専用で表示される
- ✅ キャンセルボタンで`/mypage`へ戻る
- ✅ デフォルトプロフィール画像が表示される
- ✅ 文字数カウンターが正常に動作する

## 補足
- 編集不可フィールドは将来的にも編集不可とする方針で実装済み
- プロフィール画像の推奨サイズは正方形（1:1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)