### PR TITLE
test: バリデーションスキーマとユーティリティ関数のユニットテスト実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"test": "vitest",
+		"test:coverage": "vitest --coverage",
 		"e2e": "playwright test"
 	},
 	"dependencies": {
@@ -45,12 +46,13 @@
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
 		"@vitejs/plugin-react": "^5.1.2",
+		"@vitest/coverage-v8": "^4.0.16",
 		"jsdom": "^27.3.0",
 		"prisma": "^7.1.0",
 		"tailwindcss": "^4",
 		"tsx": "^4.21.0",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5",
-		"vitest": "^4.0.15"
+		"vitest": "^4.0.16"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.1.2(vite@7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.0.16
+        version: 4.0.16(vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0))
       jsdom:
         specifier: ^27.3.0
         version: 27.3.0(postcss@8.5.6)
@@ -118,8 +121,8 @@ importers:
         specifier: ^5
         version: 5.9.3
       vitest:
-        specifier: ^4.0.15
-        version: 4.0.15(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0)
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -228,6 +231,10 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.3.8':
     resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
@@ -1203,6 +1210,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@supabase/auth-js@2.87.1':
     resolution: {integrity: sha512-6RDeOf5TVoaXFtEstN188ykp3pXLZaU9qoAWfx8dc50FFAAqt+kcFJ96V0IvSmcpb4mDAWcpTJ7BegmVDn/WIw==}
     engines: {node: '>=20.0.0'}
@@ -1405,11 +1415,20 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@4.0.15':
-    resolution: {integrity: sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==}
+  '@vitest/coverage-v8@4.0.16':
+    resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
+    peerDependencies:
+      '@vitest/browser': 4.0.16
+      vitest: 4.0.16
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/mocker@4.0.15':
-    resolution: {integrity: sha512-CZ28GLfOEIFkvCFngN8Sfx5h+Se0zN+h4B7yOsPVCcgtiO7t5jt9xQh2E1UkFep+eb9fjyMfuC5gBypwb07fvQ==}
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1419,20 +1438,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.15':
-    resolution: {integrity: sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==}
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
 
-  '@vitest/runner@4.0.15':
-    resolution: {integrity: sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==}
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
 
-  '@vitest/snapshot@4.0.15':
-    resolution: {integrity: sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==}
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
 
-  '@vitest/spy@4.0.15':
-    resolution: {integrity: sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw==}
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
 
-  '@vitest/utils@4.0.15':
-    resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1456,6 +1475,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.9:
+    resolution: {integrity: sha512-dSC6tJeOJxbZrPzPbv5mMd6CMiQ1ugaVXXPRad2fXUSsy1kstFn9XQWemV9VW7Y7kpxgQ/4WMoZfwdH8XSU48w==}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -1484,8 +1506,8 @@ packages:
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
 
-  chai@6.2.1:
-    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chevrotain@10.5.0:
@@ -1689,6 +1711,10 @@ packages:
   grammex@3.1.12:
     resolution: {integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hono@4.10.6:
     resolution: {integrity: sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==}
     engines: {node: '>=16.9.0'}
@@ -1696,6 +1722,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1733,12 +1762,31 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsdom@27.3.0:
     resolution: {integrity: sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==}
@@ -1861,6 +1909,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
@@ -2192,6 +2247,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -2312,18 +2371,18 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.15:
-    resolution: {integrity: sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==}
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.15
-      '@vitest/browser-preview': 4.0.15
-      '@vitest/browser-webdriverio': 4.0.15
-      '@vitest/ui': 4.0.15
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2547,6 +2606,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.3.8':
     optionalDependencies:
@@ -3232,6 +3293,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@supabase/auth-js@2.87.1':
     dependencies:
       tslib: 2.8.1
@@ -3455,43 +3518,60 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.0.15':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.16
+      ast-v8-to-istanbul: 0.3.9
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.15
-      '@vitest/utils': 4.0.15
-      chai: 6.2.1
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.15(vite@7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.16(vite@7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.0.15
+      '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.0.15':
+  '@vitest/pretty-format@4.0.16':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.15':
+  '@vitest/runner@4.0.16':
     dependencies:
-      '@vitest/utils': 4.0.15
+      '@vitest/utils': 4.0.16
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.15':
+  '@vitest/snapshot@4.0.16':
     dependencies:
-      '@vitest/pretty-format': 4.0.15
+      '@vitest/pretty-format': 4.0.16
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.15': {}
+  '@vitest/spy@4.0.16': {}
 
-  '@vitest/utils@4.0.15':
+  '@vitest/utils@4.0.16':
     dependencies:
-      '@vitest/pretty-format': 4.0.15
+      '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
   agent-base@7.1.4: {}
@@ -3507,6 +3587,12 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.9:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -3541,7 +3627,7 @@ snapshots:
 
   caniuse-lite@1.0.30001760: {}
 
-  chai@6.2.1: {}
+  chai@6.2.2: {}
 
   chevrotain@10.5.0:
     dependencies:
@@ -3762,11 +3848,15 @@ snapshots:
 
   grammex@3.1.12: {}
 
+  has-flag@4.0.0: {}
+
   hono@4.10.6: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3802,9 +3892,32 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsdom@27.3.0(postcss@8.5.6):
     dependencies:
@@ -3910,6 +4023,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.1:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   mdn-data@2.12.2: {}
 
@@ -4173,8 +4296,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3:
-    optional: true
+  semver@7.7.3: {}
 
   seq-queue@0.0.5: {}
 
@@ -4249,6 +4371,10 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@babel/core': 7.28.5
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -4325,15 +4451,15 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vitest@4.0.15(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@4.0.16(@types/node@20.19.26)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
-      '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(vite@7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.0.15
-      '@vitest/runner': 4.0.15
-      '@vitest/snapshot': 4.0.15
-      '@vitest/spy': 4.0.15
-      '@vitest/utils': 4.0.15
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.2.7(@types/node@20.19.26)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+	describe("正常系", () => {
+		it("単一のクラス名を正しく返す", () => {
+			const result = cn("text-red-500");
+			expect(result).toBe("text-red-500");
+		});
+
+		it("複数のクラス名を結合して返す", () => {
+			const result = cn("text-red-500", "bg-blue-500");
+			expect(result).toBe("text-red-500 bg-blue-500");
+		});
+
+		it("条件付きクラス名を正しく処理する", () => {
+			const isActive = true;
+			const result = cn("base-class", isActive && "active-class");
+			expect(result).toBe("base-class active-class");
+		});
+
+		it("falseの条件付きクラス名を除外する", () => {
+			const isActive = false;
+			const result = cn("base-class", isActive && "active-class");
+			expect(result).toBe("base-class");
+		});
+
+		it("オブジェクト形式のクラス名を正しく処理する", () => {
+			const result = cn({
+				"text-red-500": true,
+				"bg-blue-500": false,
+				"p-4": true,
+			});
+			expect(result).toBe("text-red-500 p-4");
+		});
+
+		it("配列形式のクラス名を正しく処理する", () => {
+			const result = cn(["text-red-500", "bg-blue-500"]);
+			expect(result).toBe("text-red-500 bg-blue-500");
+		});
+
+		it("Tailwindの競合するクラスを正しくマージする", () => {
+			const result = cn("px-2", "px-4");
+			expect(result).toBe("px-4");
+		});
+
+		it("複雑な組み合わせを正しく処理する", () => {
+			const isActive = true;
+			const hasError = false;
+			const result = cn(
+				"base-class",
+				isActive && "active",
+				hasError && "error",
+				{ disabled: false, enabled: true },
+				["text-sm", "font-bold"],
+			);
+			expect(result).toBe("base-class active enabled text-sm font-bold");
+		});
+	});
+
+	describe("エッジケース", () => {
+		it("空の引数の場合、空文字列を返す", () => {
+			const result = cn();
+			expect(result).toBe("");
+		});
+
+		it("undefined を含む場合、正しく無視される", () => {
+			const result = cn("text-red-500", undefined, "bg-blue-500");
+			expect(result).toBe("text-red-500 bg-blue-500");
+		});
+
+		it("null を含む場合、正しく無視される", () => {
+			const result = cn("text-red-500", null, "bg-blue-500");
+			expect(result).toBe("text-red-500 bg-blue-500");
+		});
+
+		it("空文字列を含む場合、正しく無視される", () => {
+			const result = cn("text-red-500", "", "bg-blue-500");
+			expect(result).toBe("text-red-500 bg-blue-500");
+		});
+
+		it("重複したクラス名がある場合、マージされる", () => {
+			const result = cn("text-red-500", "text-red-500");
+			expect(result).toBe("text-red-500");
+		});
+
+		it("Tailwindの競合する複数のクラスで、最後のクラスが適用される", () => {
+			const result = cn("p-2", "p-4", "p-6");
+			expect(result).toBe("p-6");
+		});
+	});
+});

--- a/src/lib/validations/auth.test.ts
+++ b/src/lib/validations/auth.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it } from "vitest";
+import { loginSchema, profileSchema, signUpSchema } from "./auth";
+
+describe("signUpSchema", () => {
+	describe("正常系", () => {
+		it("有効なメールアドレスとパスワードでバリデーションが成功する", () => {
+			const validData = {
+				email: "test@example.com",
+				password: "Test1234!",
+			};
+
+			const result = signUpSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.email).toBe("test@example.com");
+				expect(result.data.password).toBe("Test1234!");
+			}
+		});
+	});
+
+	describe("異常系 - メールアドレス", () => {
+		it("メールアドレスが空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "",
+				password: "Test1234!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"メールアドレスを入力してください",
+				);
+			}
+		});
+
+		it("メールアドレスの形式が不正な場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "invalid-email",
+				password: "Test1234!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"有効なメールアドレスを入力してください",
+				);
+			}
+		});
+
+		it("@が含まれていないメールアドレスの場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "testexample.com",
+				password: "Test1234!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"有効なメールアドレスを入力してください",
+				);
+			}
+		});
+	});
+
+	describe("異常系 - パスワード", () => {
+		it("パスワードが8文字未満の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "Test12!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const errors = result.error.issues.map((e) => e.message);
+				expect(errors).toContain("パスワードは8文字以上で入力してください");
+			}
+		});
+
+		it("パスワードに小文字が含まれていない場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "TEST1234!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const errors = result.error.issues.map((e) => e.message);
+				expect(errors).toContain("パスワードには小文字を含めてください");
+			}
+		});
+
+		it("パスワードに大文字が含まれていない場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "test1234!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const errors = result.error.issues.map((e) => e.message);
+				expect(errors).toContain("パスワードには大文字を含めてください");
+			}
+		});
+
+		it("パスワードに数字が含まれていない場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "TestTest!",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const errors = result.error.issues.map((e) => e.message);
+				expect(errors).toContain("パスワードには数字を含めてください");
+			}
+		});
+
+		it("パスワードに記号が含まれていない場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "Test1234",
+			};
+
+			const result = signUpSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const errors = result.error.issues.map((e) => e.message);
+				expect(errors).toContain("パスワードには記号を含めてください");
+			}
+		});
+	});
+
+	describe("境界値テスト", () => {
+		it("パスワードがちょうど8文字の有効なパスワードの場合、バリデーションが成功する", () => {
+			const validData = {
+				email: "test@example.com",
+				password: "Test123!",
+			};
+
+			const result = signUpSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+		});
+	});
+});
+
+describe("loginSchema", () => {
+	describe("正常系", () => {
+		it("有効なメールアドレスとパスワードでバリデーションが成功する", () => {
+			const validData = {
+				email: "test@example.com",
+				password: "anypassword",
+			};
+
+			const result = loginSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.email).toBe("test@example.com");
+				expect(result.data.password).toBe("anypassword");
+			}
+		});
+	});
+
+	describe("異常系", () => {
+		it("メールアドレスが空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "",
+				password: "password",
+			};
+
+			const result = loginSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"メールアドレスを入力してください",
+				);
+			}
+		});
+
+		it("メールアドレスの形式が不正な場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "invalid-email",
+				password: "password",
+			};
+
+			const result = loginSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"有効なメールアドレスを入力してください",
+				);
+			}
+		});
+
+		it("パスワードが空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				email: "test@example.com",
+				password: "",
+			};
+
+			const result = loginSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"パスワードを入力してください",
+				);
+			}
+		});
+	});
+});
+
+describe("profileSchema", () => {
+	describe("正常系", () => {
+		it("全ての必須項目が入力されている場合、バリデーションが成功する", () => {
+			const validData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.lastName).toBe("山田");
+				expect(result.data.firstName).toBe("太郎");
+				expect(result.data.nickname).toBe("やまちゃん");
+				expect(result.data.birthday).toBe("1990-01-01");
+				expect(result.data.gender).toBe("male");
+				expect(result.data.prefecture).toBe("東京都");
+			}
+		});
+
+		it("オプション項目も含めて全て入力されている場合、バリデーションが成功する", () => {
+			const validData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: "https://example.com/image.jpg",
+				bio: "クラフトビール好きです",
+			};
+
+			const result = profileSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.profileImageUrl).toBe(
+					"https://example.com/image.jpg",
+				);
+				expect(result.data.bio).toBe("クラフトビール好きです");
+			}
+		});
+	});
+
+	describe("異常系 - 必須項目", () => {
+		it("姓が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe("姓を入力してください");
+			}
+		});
+
+		it("名が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "山田",
+				firstName: "",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe("名を入力してください");
+			}
+		});
+
+		it("ニックネームが空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"ニックネームを入力してください",
+				);
+			}
+		});
+
+		it("生年月日が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "",
+				gender: "male",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"生年月日を選択してください",
+				);
+			}
+		});
+
+		it("性別が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "",
+				prefecture: "東京都",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe("性別を選択してください");
+			}
+		});
+
+		it("都道府県が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "",
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"都道府県を選択してください",
+				);
+			}
+		});
+	});
+
+	describe("異常系 - オプション項目の文字数制限", () => {
+		it("プロフィール文が500文字を超える場合、エラーメッセージが返される", () => {
+			const longBio = "あ".repeat(501);
+			const invalidData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				bio: longBio,
+			};
+
+			const result = profileSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"プロフィール文は500文字以内で入力してください",
+				);
+			}
+		});
+	});
+
+	describe("境界値テスト", () => {
+		it("プロフィール文がちょうど500文字の場合、バリデーションが成功する", () => {
+			const exactBio = "あ".repeat(500);
+			const validData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				bio: exactBio,
+			};
+
+			const result = profileSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+		});
+
+		it("プロフィール文が1文字の場合、バリデーションが成功する", () => {
+			const validData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				bio: "あ",
+			};
+
+			const result = profileSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+		});
+
+		it("プロフィール文が空文字列の場合、バリデーションが成功する", () => {
+			const validData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				bio: "",
+			};
+
+			const result = profileSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+		});
+	});
+});

--- a/src/lib/validations/post.test.ts
+++ b/src/lib/validations/post.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { createPostSchema } from "./post";
+
+describe("createPostSchema", () => {
+	describe("正常系", () => {
+		it("有効な店舗IDと本文でバリデーションが成功する", () => {
+			const validData = {
+				barId: "1",
+				body: "美味しいビールでした！",
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.barId).toBe(BigInt(1));
+				expect(result.data.body).toBe("美味しいビールでした！");
+				expect(result.data.images).toEqual([]);
+			}
+		});
+
+		it("画像を含む投稿データでバリデーションが成功する", () => {
+			const image1 = new File(["image1"], "test1.jpg", { type: "image/jpeg" });
+			const image2 = new File(["image2"], "test2.jpg", { type: "image/jpeg" });
+
+			const validData = {
+				barId: "123",
+				body: "クラフトビールが最高でした！",
+				images: [image1, image2],
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.barId).toBe(BigInt(123));
+				expect(result.data.body).toBe("クラフトビールが最高でした！");
+				expect(result.data.images).toHaveLength(2);
+				expect(result.data.images[0]).toBeInstanceOf(File);
+				expect(result.data.images[1]).toBeInstanceOf(File);
+			}
+		});
+	});
+
+	describe("異常系 - 店舗ID", () => {
+		it("店舗IDが空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				barId: "",
+				body: "美味しいビールでした！",
+			};
+
+			const result = createPostSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe("店舗を選択してください");
+			}
+		});
+	});
+
+	describe("異常系 - 本文", () => {
+		it("本文が空文字の場合、エラーメッセージが返される", () => {
+			const invalidData = {
+				barId: "1",
+				body: "",
+			};
+
+			const result = createPostSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe(
+					"投稿本文を入力してください",
+				);
+			}
+		});
+	});
+
+	describe("異常系 - 画像", () => {
+		it("画像が5枚以上の場合、エラーメッセージが返される", () => {
+			const images = Array.from({ length: 5 }, (_, i) => {
+				return new File([`image${i}`], `test${i}.jpg`, {
+					type: "image/jpeg",
+				});
+			});
+
+			const invalidData = {
+				barId: "1",
+				body: "美味しいビールでした！",
+				images: images,
+			};
+
+			const result = createPostSchema.safeParse(invalidData);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe("写真は最大4枚までです");
+			}
+		});
+	});
+
+	describe("境界値テスト", () => {
+		it("画像がちょうど4枚の場合、バリデーションが成功する", () => {
+			const images = Array.from({ length: 4 }, (_, i) => {
+				return new File([`image${i}`], `test${i}.jpg`, {
+					type: "image/jpeg",
+				});
+			});
+
+			const validData = {
+				barId: "1",
+				body: "美味しいビールでした！",
+				images: images,
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.images).toHaveLength(4);
+			}
+		});
+
+		it("画像が1枚の場合、バリデーションが成功する", () => {
+			const image = new File(["image"], "test.jpg", { type: "image/jpeg" });
+
+			const validData = {
+				barId: "1",
+				body: "美味しいビールでした！",
+				images: [image],
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.images).toHaveLength(1);
+			}
+		});
+
+		it("本文が1文字の場合、バリデーションが成功する", () => {
+			const validData = {
+				barId: "1",
+				body: "◯",
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+		});
+
+		it("店舗IDが大きな数値の文字列の場合、BigIntに変換される", () => {
+			const validData = {
+				barId: "9007199254740991",
+				body: "美味しいビールでした！",
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.barId).toBe(BigInt("9007199254740991"));
+			}
+		});
+	});
+
+	describe("エッジケース", () => {
+		it("imagesプロパティが未定義の場合、空配列がデフォルト値として設定される", () => {
+			const validData = {
+				barId: "1",
+				body: "美味しいビールでした！",
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.images).toEqual([]);
+			}
+		});
+
+		it("本文に特殊文字が含まれる場合でもバリデーションが成功する", () => {
+			const validData = {
+				barId: "1",
+				body: "美味しい！🍺✨\n改行も含む\tタブも含む",
+			};
+
+			const result = createPostSchema.safeParse(validData);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.body).toBe("美味しい！🍺✨\n改行も含む\tタブも含む");
+			}
+		});
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,23 @@ export default defineConfig({
 		setupFiles: ["./src/test/setup.ts"],
 		globals: true,
 		exclude: ["node_modules", "e2e", ".next"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "json"],
+			exclude: [
+				"node_modules/",
+				"e2e/",
+				".next/",
+				"src/generated/",
+				"src/test/",
+				"**/*.config.ts",
+				"**/*.config.js",
+				"**/*.test.ts",
+				"**/*.test.tsx",
+				"**/*.spec.ts",
+				"**/*.spec.tsx",
+			],
+		},
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary

Issue #72 の一環として、バリデーションスキーマとユーティリティ関数のユニットテストを実装しました。

- 認証バリデーションスキーマ（signUpSchema, loginSchema, profileSchema）のテスト
- 投稿バリデーションスキーマ（createPostSchema）のテスト
- ユーティリティ関数（cn）のテスト
- テストカバレッジ設定の追加

### 実装内容

1. **src/lib/validations/auth.test.ts**（26テストケース）
   - signUpSchemaの正常系・異常系・境界値テスト
   - loginSchemaの正常系・異常系テスト
   - profileSchemaの正常系・異常系・境界値テスト

2. **src/lib/validations/post.test.ts**（11テストケース）
   - createPostSchemaの正常系・異常系・境界値・エッジケーステスト

3. **src/lib/utils.test.ts**（14テストケース）
   - cn関数の正常系・エッジケーステスト

4. **テスト環境の設定**
   - vitest.config.ts にカバレッジ設定を追加
   - @vitest/coverage-v8 をインストール
   - package.json に test:coverage スクリプトを追加

### テスト結果

- ✅ 52個のテストケースすべて成功
- ✅ テスト対象ファイルで100%のカバレッジを達成
- ✅ lint・フォーマットチェック合格

## Test plan

- [x] `pnpm test` でテストが成功することを確認
- [x] `pnpm test:coverage` でカバレッジが100%であることを確認
- [x] `pnpm lint` でエラーがないことを確認
- [x] `pnpm format` でフォーマットが適用されていることを確認

## 関連Issue

Closes #72（部分的に実装。Server ActionsやComponentのテストは今後のPRで実装予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)