### PR TITLE
認証系Server Actionsのユニットテスト実装

### DIFF
--- a/src/app/login/actions.test.ts
+++ b/src/app/login/actions.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// next/navigationのモック
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+	redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+// Supabase clientのモック
+const mockSignInWithPassword = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			signInWithPassword: mockSignInWithPassword,
+		},
+	})),
+}));
+
+import { login } from "./actions";
+
+describe("login", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("正常系", () => {
+		it("有効な認証情報でログインが成功し、エラーが返らない", async () => {
+			// Supabase Auth成功をモック
+			mockSignInWithPassword.mockResolvedValue({
+				data: { user: { id: "test-user-id" }, session: {} },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "ValidPassword123!");
+
+			const result = await login(undefined, formData);
+
+			expect(mockSignInWithPassword).toHaveBeenCalledWith({
+				email: "test@example.com",
+				password: "ValidPassword123!",
+			});
+			expect(result).toBeUndefined();
+		});
+
+		it("成功時にredirect('/')が呼ばれる", async () => {
+			mockSignInWithPassword.mockResolvedValue({
+				data: { user: { id: "test-user-id" }, session: {} },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "valid@example.com");
+			formData.append("password", "SecurePass1!");
+
+			try {
+				await login(undefined, formData);
+			} catch (_error) {
+				// redirectは実際にはthrowするので、catchでモック呼び出しを確認
+			}
+
+			expect(mockRedirect).toHaveBeenCalledWith("/");
+		});
+	});
+
+	describe("異常系 - バリデーションエラー", () => {
+		it("メールアドレスが空の場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "");
+			formData.append("password", "Password123!");
+
+			const result = await login(undefined, formData);
+
+			expect(result).toEqual({
+				error: "メールアドレスを入力してください",
+			});
+			expect(mockSignInWithPassword).not.toHaveBeenCalled();
+		});
+
+		it("パスワードが空の場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "");
+
+			const result = await login(undefined, formData);
+
+			expect(result).toEqual({
+				error: "パスワードを入力してください",
+			});
+			expect(mockSignInWithPassword).not.toHaveBeenCalled();
+		});
+
+		it("メール形式が不正な場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "invalid-email");
+			formData.append("password", "Password123!");
+
+			const result = await login(undefined, formData);
+
+			expect(result).toEqual({
+				error: "有効なメールアドレスを入力してください",
+			});
+			expect(mockSignInWithPassword).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("異常系 - 認証失敗", () => {
+		it("Supabase Auth認証失敗時、エラーメッセージが返る", async () => {
+			mockSignInWithPassword.mockResolvedValue({
+				data: { user: null, session: null },
+				error: { message: "Invalid login credentials" },
+			});
+
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "WrongPassword!");
+
+			const result = await login(undefined, formData);
+
+			expect(result).toEqual({
+				error: "メールアドレスまたはパスワードが違います",
+			});
+			expect(mockRedirect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("エッジケース", () => {
+		it("FormDataにnullが含まれる場合、文字列として扱われる", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "null");
+
+			const _result = await login(undefined, formData);
+
+			// "null"という文字列はバリデーションを通過しないので、パスワード強度エラーになる可能性
+			// しかし、loginSchemaはパスワードの文字列チェックのみなので、通過する
+			// 実際の認証で失敗することを期待
+			expect(mockSignInWithPassword).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/app/signup/actions.test.ts
+++ b/src/app/signup/actions.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// next/navigationのモック
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+	redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+// Supabase clientのモック
+const mockSignUp = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			signUp: mockSignUp,
+		},
+	})),
+}));
+
+import { signUp } from "./actions";
+
+describe("signUp", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("正常系", () => {
+		it("有効なメール・パスワードで新規登録が成功し、エラーが返らない", async () => {
+			mockSignUp.mockResolvedValue({
+				data: {
+					user: { id: "new-user-id" },
+					session: null, // メール確認が必要な場合はsessionはnull
+				},
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "newuser@example.com");
+			formData.append("password", "SecurePass1!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(mockSignUp).toHaveBeenCalledWith({
+				email: "newuser@example.com",
+				password: "SecurePass1!",
+				options: {
+					emailRedirectTo: expect.stringMatching(
+						/^http:\/\/(localhost|127\.0\.0\.1):3000\/signup\/profile$/,
+					),
+				},
+			});
+			expect(result).toBeUndefined();
+		});
+
+		it("成功時にredirect('/signup?success=true')が呼ばれる", async () => {
+			mockSignUp.mockResolvedValue({
+				data: {
+					user: { id: "new-user-id" },
+					session: null,
+				},
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "ValidPass123!");
+
+			try {
+				await signUp(undefined, formData);
+			} catch (_error) {
+				// redirectは実際にはthrowするので、catchでモック呼び出しを確認
+			}
+
+			expect(mockRedirect).toHaveBeenCalledWith("/signup?success=true");
+		});
+	});
+
+	describe("異常系 - バリデーションエラー", () => {
+		it("メールアドレスが空の場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "");
+			formData.append("password", "SecurePass1!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result).toEqual({
+				error: "メールアドレスを入力してください",
+			});
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("メール形式が不正な場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "invalid-email");
+			formData.append("password", "SecurePass1!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result).toEqual({
+				error: "有効なメールアドレスを入力してください",
+			});
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("パスワードが8文字未満の場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "Short1!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result?.error).toContain("パスワードは8文字以上");
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("パスワードに小文字が含まれていない場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "PASSWORD123!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result?.error).toContain("小文字");
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("パスワードに大文字が含まれていない場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "password123!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result?.error).toContain("大文字");
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("パスワードに数字が含まれていない場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "PasswordPass!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result?.error).toContain("数字");
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+
+		it("パスワードに記号が含まれていない場合、バリデーションエラーが返る", async () => {
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "Password1234");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result?.error).toContain("記号");
+			expect(mockSignUp).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("異常系 - Supabase Authエラー", () => {
+		it("Supabase Authエラー時、エラーメッセージが返る", async () => {
+			mockSignUp.mockResolvedValue({
+				data: { user: null, session: null },
+				error: { message: "User already registered" },
+			});
+
+			const formData = new FormData();
+			formData.append("email", "existing@example.com");
+			formData.append("password", "ValidPass123!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result).toEqual({
+				error: "User already registered",
+			});
+			expect(mockRedirect).not.toHaveBeenCalled();
+		});
+
+		it("メールアドレスが既に登録済みの場合、エラーメッセージが返る", async () => {
+			mockSignUp.mockResolvedValue({
+				data: { user: null, session: null },
+				error: { message: "Email already exists" },
+			});
+
+			const formData = new FormData();
+			formData.append("email", "duplicate@example.com");
+			formData.append("password", "SecurePass1!");
+
+			const result = await signUp(undefined, formData);
+
+			expect(result).toEqual({
+				error: "Email already exists",
+			});
+		});
+	});
+
+	describe("エッジケース", () => {
+		it("セッションが発行された場合、console.errorで警告が出力される", async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+
+			mockSignUp.mockResolvedValue({
+				data: {
+					user: { id: "new-user-id" },
+					session: { access_token: "token" }, // セッションが発行される想定外のケース
+				},
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "test@example.com");
+			formData.append("password", "ValidPass123!");
+
+			try {
+				await signUp(undefined, formData);
+			} catch (_error) {
+				// redirectでthrow
+			}
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("セッションが発行されています"),
+			);
+
+			consoleErrorSpy.mockRestore();
+		});
+	});
+});

--- a/src/app/signup/confirm/actions.test.ts
+++ b/src/app/signup/confirm/actions.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// next/navigationのモック
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+	redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+// Supabase clientのモック
+const mockGetUser = vi.fn();
+const mockUpload = vi.fn();
+const mockGetPublicUrl = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+		storage: {
+			from: vi.fn(() => ({
+				upload: mockUpload,
+				getPublicUrl: mockGetPublicUrl,
+			})),
+		},
+	})),
+}));
+
+// Prismaのモック
+const mockPrismaCreate = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+	prisma: {
+		userProfile: {
+			create: vi.fn((...args: unknown[]) => mockPrismaCreate(...args)),
+		},
+	},
+}));
+
+import { confirmAndSaveProfile } from "./actions";
+
+describe("confirmAndSaveProfile", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("正常系", () => {
+		it("有効なプロフィールデータでDB保存が成功する", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			mockPrismaCreate.mockResolvedValue({
+				id: "profile-id",
+				userAuthId: "test-user-id",
+			});
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: "",
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			const result = await confirmAndSaveProfile(undefined, formData);
+
+			expect(mockPrismaCreate).toHaveBeenCalledWith({
+				data: {
+					userAuthId: "test-user-id",
+					lastName: "山田",
+					firstName: "太郎",
+					nickname: "やまちゃん",
+					birthday: new Date("1990-01-01"),
+					gender: "male",
+					prefecture: "東京都",
+					profileImageUrl: undefined,
+					bio: "",
+				},
+			});
+			expect(result).toBeUndefined();
+		});
+
+		it("成功時にredirect('/')が呼ばれる", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			mockPrismaCreate.mockResolvedValue({
+				id: "profile-id",
+			});
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: "",
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			try {
+				await confirmAndSaveProfile(undefined, formData);
+			} catch (_error) {
+				// redirectはthrowする
+			}
+
+			expect(mockRedirect).toHaveBeenCalledWith("/");
+		});
+
+		it("プロフィール画像がある場合、Supabase Storageへアップロードされる", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			// base64エンコードされた画像データ（簡易的なもの）
+			const base64Image =
+				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
+
+			mockUpload.mockResolvedValue({
+				data: { path: "test-user-id-123456.png" },
+				error: null,
+			});
+
+			mockGetPublicUrl.mockReturnValue({
+				data: {
+					publicUrl: "https://storage.example.com/test-user-id-123456.png",
+				},
+			});
+
+			mockPrismaCreate.mockResolvedValue({
+				id: "profile-id",
+			});
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: base64Image,
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			try {
+				await confirmAndSaveProfile(undefined, formData);
+			} catch (_error) {
+				// redirectはthrowする
+			}
+
+			expect(mockUpload).toHaveBeenCalled();
+			expect(mockPrismaCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						profileImageUrl:
+							"https://storage.example.com/test-user-id-123456.png",
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("異常系", () => {
+		it("未認証ユーザーの場合、エラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: null },
+				error: null,
+			});
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: "",
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			const result = await confirmAndSaveProfile(undefined, formData);
+
+			expect(result).toEqual({
+				error: "認証が必要です",
+			});
+			expect(mockPrismaCreate).not.toHaveBeenCalled();
+		});
+
+		it("DB保存失敗時、エラーメッセージが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			mockPrismaCreate.mockRejectedValue(new Error("Database error"));
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: "",
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			const result = await confirmAndSaveProfile(undefined, formData);
+
+			expect(result).toEqual({
+				error: "プロフィールの保存に失敗しました",
+			});
+		});
+
+		it("画像アップロード失敗時でも、処理が継続する", async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const base64Image =
+				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
+
+			mockUpload.mockResolvedValue({
+				data: null,
+				error: { message: "Upload failed" },
+			});
+
+			mockPrismaCreate.mockResolvedValue({
+				id: "profile-id",
+			});
+
+			const profileData = {
+				lastName: "山田",
+				firstName: "太郎",
+				nickname: "やまちゃん",
+				birthday: "1990-01-01",
+				gender: "male",
+				prefecture: "東京都",
+				profileImageUrl: base64Image,
+				bio: "",
+			};
+
+			const formData = new FormData();
+			formData.append("profileData", JSON.stringify(profileData));
+
+			try {
+				await confirmAndSaveProfile(undefined, formData);
+			} catch (_error) {
+				// redirectはthrowする
+			}
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("画像アップロードエラー"),
+				expect.anything(),
+			);
+			expect(mockPrismaCreate).toHaveBeenCalled(); // 処理は継続
+
+			consoleErrorSpy.mockRestore();
+		});
+	});
+});

--- a/src/app/signup/profile/actions.test.ts
+++ b/src/app/signup/profile/actions.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// next/navigationのモック
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+	redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+// Supabase clientのモック
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	})),
+}));
+
+import { saveProfileToSession } from "./actions";
+
+describe("saveProfileToSession", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("正常系", () => {
+		it("有効なプロフィールデータでセッション保存が成功し、エラーが返らない", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+			formData.append("profileImageUrl", "");
+			formData.append("bio", "");
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toBeUndefined();
+		});
+
+		it("成功時に/signup/confirm?data={encodedData}へリダイレクトされる", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+			formData.append("profileImageUrl", "");
+			formData.append("bio", "");
+
+			try {
+				await saveProfileToSession(undefined, formData);
+			} catch (_error) {
+				// redirectはthrowする
+			}
+
+			expect(mockRedirect).toHaveBeenCalled();
+			const callArgs = mockRedirect.mock.calls[0][0] as string;
+			expect(callArgs).toMatch(/^\/signup\/confirm\?data=/);
+		});
+
+		it("エンコードされたデータが正しくURLに含まれる", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "佐藤");
+			formData.append("firstName", "花子");
+			formData.append("nickname", "はなちゃん");
+			formData.append("birthday", "1995-05-15");
+			formData.append("gender", "female");
+			formData.append("prefecture", "大阪府");
+			formData.append("profileImageUrl", "");
+			formData.append("bio", "クラフトビール好きです");
+
+			try {
+				await saveProfileToSession(undefined, formData);
+			} catch (_error) {
+				// redirectはthrowする
+			}
+
+			const callArgs = mockRedirect.mock.calls[0][0] as string;
+			const encodedData = callArgs.split("data=")[1];
+			const decodedData = JSON.parse(decodeURIComponent(encodedData));
+
+			expect(decodedData).toEqual({
+				lastName: "佐藤",
+				firstName: "花子",
+				nickname: "はなちゃん",
+				birthday: "1995-05-15",
+				gender: "female",
+				prefecture: "大阪府",
+				profileImageUrl: "",
+				bio: "クラフトビール好きです",
+			});
+		});
+	});
+
+	describe("異常系 - バリデーションエラー", () => {
+		it("姓が空の場合、バリデーションエラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toEqual({
+				error: "姓を入力してください",
+			});
+			expect(mockRedirect).not.toHaveBeenCalled();
+		});
+
+		it("名が空の場合、バリデーションエラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toEqual({
+				error: "名を入力してください",
+			});
+		});
+
+		it("ニックネームが空の場合、バリデーションエラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toEqual({
+				error: "ニックネームを入力してください",
+			});
+		});
+
+		it("プロフィール文が500文字を超える場合、バリデーションエラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+
+			const longBio = "あ".repeat(501);
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+			formData.append("profileImageUrl", "");
+			formData.append("bio", longBio);
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toEqual({
+				error: "プロフィール文は500文字以内で入力してください",
+			});
+		});
+	});
+
+	describe("異常系 - 認証エラー", () => {
+		it("未認証ユーザーの場合、エラーが返る", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: null },
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+			formData.append("profileImageUrl", "");
+			formData.append("bio", "");
+
+			const result = await saveProfileToSession(undefined, formData);
+
+			expect(result).toEqual({
+				error: "認証が必要です",
+			});
+			expect(mockRedirect).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## 概要

Issue #74 の実装として、認証系Server Actionsのユニットテストを追加しました。

## 実装内容

以下の4つのServer Actionに対するテストを実装:

### 1. login() (7 tests)
- src/app/login/actions.test.ts
- 正常系: ログイン成功、リダイレクト検証
- 異常系: バリデーションエラー(空メール/パスワード、不正メール形式)、認証失敗

### 2. signUp() (12 tests)
- src/app/signup/actions.test.ts  
- 正常系: 新規登録成功、リダイレクト検証
- 異常系: バリデーションエラー(メール形式、パスワード強度)、Supabase Authエラー
- エッジケース: セッション発行時の警告

### 3. saveProfileToSession() (8 tests)
- src/app/signup/profile/actions.test.ts
- 正常系: セッション保存成功、URLエンコーディング検証
- 異常系: バリデーションエラー(必須項目、文字数制限)、未認証ユーザー

### 4. confirmAndSaveProfile() (6 tests)
- src/app/signup/confirm/actions.test.ts
- 正常系: DB保存成功、画像アップロード、リダイレクト検証
- 異常系: 未認証ユーザー、DB保存失敗、画像アップロード失敗時の継続処理

## テスト結果

- 追加テスト数: 33 tests
- 全体テスト数: 85 tests (すべてパス)
- lint/format: クリーン

## 技術的なポイント

### Vitestモックパターン
- vi.mock()のホイスティング動作を考慮した実装
- Supabase Auth/Storage, Prisma, next/navigationの適切なモック化

### FormDataハンドリング
- オプショナルフィールドは空文字列を明示的に追加
- null値によるZodバリデーションエラーを回避

### 環境変数の柔軟な検証
- localhost/127.0.0.1の両方に対応する正規表現マッチャー使用

## 関連Issue

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)