### PR TITLE
feat: add article_likes schema for top page (#93)

### DIFF
--- a/database.md
+++ b/database.md
@@ -316,6 +316,26 @@ UNIQUE制約: `country_id + name`
 
 ---
 
+### 3-4. article_likes
+
+記事への「いいね」。
+
+- **Table name:** `article_likes`
+- **Description:** 記事に対するいいね
+
+#### Columns
+
+| Column       | Type        | Constraints                         | Description       |
+|--------------|------------|--------------------------------------|-------------------|
+| id           | bigserial  | PK                                   | ID                |
+| article_id   | bigint     | NOT NULL, FK → articles(id)          | 記事ID            |
+| user_id      | uuid       | NOT NULL, FK → user_profiles(id)     | いいねしたユーザー |
+| created_at   | timestamptz| NOT NULL DEFAULT now()               | いいね日時         |
+
+`article_id + user_id` に UNIQUE 制約を張る想定。
+
+---
+
 ## 4. 投稿・タイムライン・お気に入り
 
 ### 4-1. posts

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model UserProfile {
   isActive       Boolean              @default(true) @map("is_active")
   createdAt      DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt      DateTime             @updatedAt @map("updated_at") @db.Timestamptz(6)
+  articleLikes   ArticleLike[]
   favoriteBars   FavoriteBar[]
   loginHistories LoginHistory[]
   notifications  Notification[]
@@ -225,18 +226,32 @@ model UserCoupon {
 
 /// 店舗記事
 model Article {
-  id          BigInt    @id @default(autoincrement())
-  barId       BigInt    @map("bar_id")
-  title       String
-  body        String
-  imageUrl    String?   @map("image_url")
-  publishedAt DateTime? @map("published_at") @db.Timestamptz(6)
-  isPublished Boolean   @default(false) @map("is_published")
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  bar         Bar       @relation(fields: [barId], references: [id], onDelete: Cascade)
+  id           BigInt        @id @default(autoincrement())
+  barId        BigInt        @map("bar_id")
+  title        String
+  body         String
+  imageUrl     String?       @map("image_url")
+  publishedAt  DateTime?     @map("published_at") @db.Timestamptz(6)
+  isPublished  Boolean       @default(false) @map("is_published")
+  createdAt    DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime      @updatedAt @map("updated_at") @db.Timestamptz(6)
+  articleLikes ArticleLike[]
+  bar          Bar           @relation(fields: [barId], references: [id], onDelete: Cascade)
 
   @@map("articles")
+}
+
+/// 記事いいね
+model ArticleLike {
+  id        BigInt      @id @default(autoincrement())
+  articleId BigInt      @map("article_id")
+  userId    String      @map("user_id") @db.Uuid
+  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  article   Article     @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  user      UserProfile @relation(fields: [userId], references: [id])
+
+  @@unique([articleId, userId])
+  @@map("article_likes")
 }
 
 /// ユーザー投稿


### PR DESCRIPTION
## 概要

Issue #93のトップページレイアウト更新に必要なデータベーススキーマ変更を実装しました。

## 変更内容

### データベーススキーマ

- `article_likes` テーブルの定義を `database.md` に追加
- `ArticleLike` モデルをPrisma schemaに追加
  - `article_id + user_id` のUNIQUE制約を設定
  - `Article` と `UserProfile` モデルにリレーションを追加

### 実装した機能

- 記事へのいいね機能の基盤となるスキーマ

## 実装していない機能（次のPRで実装予定）

Issue #93の完全な実装には、以下の未確定事項の解決が必要です：

### 未確定事項

1. **「クラフトビールについて知る」の遷移先URL**
   - 解説記事の実装方法・ルーティングが未定

2. **利用規約・プライバシーポリシーのルーティング**
   - `/terms`, `/privacy` などのパスが既存設計に存在しない

3. **先月いいね集計の実装方法**
   - バッチ処理の実行環境・タイミングが未定
   - クエリ時集計とするか、事前集計とするか

4. **人気な○○の集計結果の保存方法**
   - キャッシュを使うか、専用テーブルを作るか

5. **導線カードの背景画像リソース**
   - どこから取得するか（Supabase Storage？）
   - どのように管理するか

6. **人気なお店で探すカードの遷移先**
   - 店舗詳細 `/bars/[barId]` か
   - 検索結果 `/?bar=[barId]` か

7. **ビールカテゴリ・産地の集計時の重複カウントの扱い**
   - 店舗×カテゴリの組み合わせでユニークにするか
   - 単純に全ビールをカウントするか

### 次のステップ

上記の未確定事項について方針を決定後、以下を実装します：

- バッチ処理の実装
- トップページUIコンポーネントの実装
- 利用規約ページの実装

## テスト

- `pnpm prisma db push` でスキーマを適用済み
- `pnpm prisma generate` でPrisma Client生成済み
- lint/formatエラーなし

## 関連Issue

Closes #93 (部分実装：スキーマ変更のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)