### PR TITLE
店舗詳細ページのメニュータブに画像表示を追加

### DIFF
--- a/src/components/bar/tabs/menu-tab.tsx
+++ b/src/components/bar/tabs/menu-tab.tsx
@@ -29,6 +29,16 @@ interface MenuTabProps {
 	foodMenus: FoodMenu[];
 }
 
+const getBeerFallbackImage = (index: number) => {
+	const seed = index % 10;
+	return `https://images.unsplash.com/photo-1608270586620-248524c67de9?w=800&h=600&fit=crop&crop=center&auto=format&q=80&seed=${seed}`;
+};
+
+const getFoodFallbackImage = (index: number) => {
+	const seed = index % 10;
+	return `https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=800&h=600&fit=crop&crop=center&auto=format&q=80&seed=${seed}`;
+};
+
 export function MenuTab({ beerMenus, foodMenus }: MenuTabProps) {
 	return (
 		<div className="space-y-8">
@@ -40,21 +50,19 @@ export function MenuTab({ beerMenus, foodMenus }: MenuTabProps) {
 					</p>
 				) : (
 					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-						{beerMenus.map((menu) => (
+						{beerMenus.map((menu, index) => (
 							<div
 								key={menu.id}
 								className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
 							>
-								{menu.imageUrl && (
-									<div className="relative w-full h-48 mb-3 rounded-md overflow-hidden bg-gray-100">
-										<Image
-											src={menu.imageUrl}
-											alt={menu.beer.name}
-											fill
-											className="object-cover"
-										/>
-									</div>
-								)}
+								<div className="relative w-full h-48 mb-3 rounded-md overflow-hidden bg-gray-100">
+									<Image
+										src={menu.imageUrl || getBeerFallbackImage(index)}
+										alt={menu.beer.name}
+										fill
+										className="object-cover"
+									/>
+								</div>
 								<h3 className="font-bold text-lg text-gray-900 mb-1">
 									{menu.beer.name}
 								</h3>
@@ -97,21 +105,19 @@ export function MenuTab({ beerMenus, foodMenus }: MenuTabProps) {
 					</p>
 				) : (
 					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-						{foodMenus.map((menu) => (
+						{foodMenus.map((menu, index) => (
 							<div
 								key={menu.id}
 								className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
 							>
-								{menu.imageUrl && (
-									<div className="relative w-full h-48 mb-3 rounded-md overflow-hidden bg-gray-100">
-										<Image
-											src={menu.imageUrl}
-											alt={menu.name}
-											fill
-											className="object-cover"
-										/>
-									</div>
-								)}
+								<div className="relative w-full h-48 mb-3 rounded-md overflow-hidden bg-gray-100">
+									<Image
+										src={menu.imageUrl || getFoodFallbackImage(index)}
+										alt={menu.name}
+										fill
+										className="object-cover"
+									/>
+								</div>
 								<h3 className="font-bold text-lg text-gray-900 mb-1">
 									{menu.name}
 								</h3>


### PR DESCRIPTION
## 概要
店舗詳細ページのメニュータブにおいて、ビールメニュー・食事メニューの画像を常時表示するようにしました。

Closes #116

## 変更内容
- ビールメニューと食事メニューに画像を常時表示
- `imageUrl`が`null`の場合はUnsplashのフォールバック画像を使用
- ビールはクラフトビールの画像、食事は料理の画像をフォールバックとして表示

## 修正ファイル
- `src/components/bar/tabs/menu-tab.tsx`

## 受入条件の検証結果
以下の受入条件をPlaywright MCPで検証しました：

- ✅ 店舗詳細ページ（`/bars/[barId]`）のメニュータブにアクセスすると、Beersセクションにビールメニューカードが表示される
- ✅ 各ビールメニューカードに画像が表示される（image_urlがある場合はその画像、ない場合はUnsplashのサンプル画像）
- ✅ ビールメニューカードに、ビール名、説明文、醸造所、産地が表示される
- ✅ Mealsセクションに食事メニューカードが表示される
- ✅ 各食事メニューカードに画像が表示される（image_urlがある場合はその画像、ない場合はUnsplashのサンプル画像）
- ✅ 食事メニューカードに、料理名、説明文が表示される
- ✅ 画像が適切なサイズ・レイアウトで表示され、モバイル・PC両方で視認性が良い

## スクリーンショット
- PC表示: menu-tab-with-images.png
- モバイル表示: menu-tab-mobile.png, menu-tab-mobile-scrolled.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)