### PR TITLE
feat: 店舗詳細ページにX（Twitter）リンクを表示

### DIFF
--- a/e2e/bar-detail-x-url.spec.ts
+++ b/e2e/bar-detail-x-url.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import { createAuthenticatedUser } from "./helpers/auth";
+import { cleanup, ensureBarWithXUrl, ensureBarWithoutXUrl } from "./helpers/database";
+
+let barIdWithXUrl: bigint;
+let barIdWithoutXUrl: bigint;
+
+test.describe("店舗詳細ページ - X（Twitter）URL", () => {
+	test.beforeAll(async () => {
+		barIdWithXUrl = await ensureBarWithXUrl();
+		barIdWithoutXUrl = await ensureBarWithoutXUrl();
+	});
+
+	test.afterAll(async () => {
+		await cleanup();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await createAuthenticatedUser(page);
+	});
+
+	test("X URL登録済み店舗ではXリンクが表示される", async ({ page }) => {
+		await page.goto(`/bars/${barIdWithXUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const xSection = page.locator("text=/X（Twitter）/i");
+		const xLink = page.locator('a[href*="x.com"], a[href*="twitter.com"]');
+
+		await expect(xSection.first()).toBeVisible();
+		await expect(xLink.first()).toBeVisible();
+
+		const rel = await xLink.first().getAttribute("rel");
+		expect(rel).toBe("nofollow noopener");
+
+		const target = await xLink.first().getAttribute("target");
+		expect(target).toBe("_blank");
+	});
+
+	test("X URL未登録店舗ではXリンクが表示されない", async ({ page }) => {
+		await page.goto(`/bars/${barIdWithoutXUrl}`);
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(500);
+
+		const xLink = page.locator('a[href*="x.com"], a[href*="twitter.com"]');
+		await expect(xLink).not.toBeVisible();
+
+		const xSection = page.locator("text=/X（Twitter）/i");
+		await expect(xSection).not.toBeVisible();
+	});
+
+	test("Xリンクには正しいrel属性とtarget属性が設定されている", async ({
+		page,
+	}) => {
+		await page.goto(`/bars/${barIdWithXUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const xLink = page.locator('a[href*="x.com"], a[href*="twitter.com"]');
+
+		await expect(xLink.first()).toBeVisible();
+
+		const rel = await xLink.first().getAttribute("rel");
+		expect(rel).toBe("nofollow noopener");
+
+		const target = await xLink.first().getAttribute("target");
+		expect(target).toBe("_blank");
+	});
+});

--- a/e2e/helpers/database.ts
+++ b/e2e/helpers/database.ts
@@ -44,6 +44,50 @@ export async function ensureBarWithoutInstagram(): Promise<bigint> {
 	return barId;
 }
 
+export async function ensureBarWithXUrl(): Promise<bigint> {
+	const bars = await prisma.bar.findMany({
+		select: { id: true, name: true, xUrl: true },
+		take: 5,
+	});
+
+	if (bars.length === 0) {
+		throw new Error("No bars found in database");
+	}
+
+	const barId = bars[0].id;
+
+	await prisma.bar.updateMany({
+		where: { id: barId },
+		data: { xUrl: "https://x.com/beersalon_test" },
+	});
+
+	return barId;
+}
+
+export async function ensureBarWithoutXUrl(): Promise<bigint> {
+	const bars = await prisma.bar.findMany({
+		select: { id: true, name: true, xUrl: true },
+		skip: 1,
+		take: 1,
+	});
+
+	if (bars.length === 0) {
+		const firstBar = await prisma.bar.findFirst({
+			select: { id: true },
+		});
+		return firstBar?.id ?? 1n;
+	}
+
+	const barId = bars[0].id;
+
+	await prisma.bar.updateMany({
+		where: { id: barId },
+		data: { xUrl: null },
+	});
+
+	return barId;
+}
+
 export async function cleanup() {
 	await prisma.$disconnect();
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Bar {
   access            String?
   websiteUrl        String?            @map("website_url")
   instagramUrl      String?            @map("instagram_url")
+  xUrl              String?            @map("x_url")
   description       String?
   isActive          Boolean            @default(true) @map("is_active")
   createdAt         DateTime           @default(now()) @map("created_at") @db.Timestamptz(6)

--- a/src/components/bar/tabs/top-tab.tsx
+++ b/src/components/bar/tabs/top-tab.tsx
@@ -1,4 +1,5 @@
 import { Instagram } from "lucide-react";
+import { XIcon } from "@/components/icons/x-icon";
 
 interface PaymentMethod {
 	id: string;
@@ -30,6 +31,7 @@ interface BarInfo {
 	addressLine2: string | null;
 	websiteUrl: string | null;
 	instagramUrl: string | null;
+	xUrl: string | null;
 	paymentMethods: PaymentMethod[];
 	openingHours: OpeningHour[];
 }
@@ -211,6 +213,26 @@ export function TopTab({ bar }: TopTabProps) {
 							<Instagram className="w-6 h-6" />
 							<span className="text-sm">
 								@{bar.instagramUrl.split("/").filter(Boolean).pop()}
+							</span>
+						</a>
+					</div>
+				)}
+
+				{bar.xUrl && (
+					<div>
+						<h3 className="text-sm font-semibold text-gray-700 mb-1">
+							X（Twitter）
+						</h3>
+						<a
+							href={bar.xUrl}
+							target="_blank"
+							rel="nofollow noopener"
+							className="inline-flex items-center gap-2 text-gray-700 hover:text-black transition-colors"
+							aria-label="Xで見る"
+						>
+							<XIcon className="w-6 h-6" />
+							<span className="text-sm">
+								@{bar.xUrl.split("/").filter(Boolean).pop()}
 							</span>
 						</a>
 					</div>

--- a/src/components/icons/x-icon.tsx
+++ b/src/components/icons/x-icon.tsx
@@ -1,0 +1,16 @@
+interface XIconProps {
+	className?: string;
+}
+
+export function XIcon({ className }: XIconProps) {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			className={className}
+			fill="currentColor"
+		>
+			<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+		</svg>
+	);
+}


### PR DESCRIPTION
## 概要
店舗詳細ページにX（Twitter）のリンクを表示する機能を追加しました。

Closes #131

## 変更内容
- Prismaスキーマにx_urlカラムを追加
- TopTabコンポーネントにX URLリンク表示機能を追加（Instagram URLの直後に配置）
- XIconコンポーネントを作成（SVGアイコン）
- E2Eテストを追加（X URL登録済み店舗での表示、未登録店舗での非表示、rel/target属性の検証）
- database helpersにensureBarWithXUrlとensureBarWithoutXUrl関数を追加

## 受入条件の確認
- [x] X URLが登録されている店舗では、店舗詳細ページ「基本情報」タブにXリンクがアイコンベースで表示される
- [x] Xリンクは「Instagram」の直後に表示される
- [x] X URLが未登録の店舗では、Xリンクは表示されない
- [x] Xリンクは新しいタブで開かれる（target="_blank"）
- [x] rel="nofollow noopener"が設定されている
- [x] E2Eテストで動作確認済み（3つのテストケース全て合格）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>