### PR TITLE
feat: 店舗詳細ページにFacebookリンクを表示

### DIFF
--- a/database.md
+++ b/database.md
@@ -67,6 +67,8 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 | access          | text       | NULLABLE                         | 交通手段・最寄駅など                    |
 | website_url     | text       | NULLABLE                         | 店舗公式サイト URL                      |
 | instagram_url   | text       | NULLABLE                         | Instagram URL                           |
+| x_url           | text       | NULLABLE                         | X (Twitter) URL                         |
+| facebook_url    | text       | NULLABLE                         | Facebook URL                            |
 | description     | text       | NULLABLE                         | PR文                                    |
 | is_active       | boolean    | NOT NULL DEFAULT true            | 掲載中フラグ                            |
 | created_at      | timestamptz| NOT NULL DEFAULT now()           | 作成日時                                |

--- a/e2e/bar-detail-facebook-url.spec.ts
+++ b/e2e/bar-detail-facebook-url.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "@playwright/test";
+import { createAuthenticatedUser } from "./helpers/auth";
+import {
+	cleanup,
+	ensureBarWithFacebookUrl,
+	ensureBarWithoutFacebookUrl,
+} from "./helpers/database";
+
+let barIdWithFacebookUrl: bigint;
+let barIdWithoutFacebookUrl: bigint;
+
+test.describe("店舗詳細ページ - Facebook URL表示", () => {
+	test.beforeAll(async () => {
+		barIdWithFacebookUrl = await ensureBarWithFacebookUrl();
+		barIdWithoutFacebookUrl = await ensureBarWithoutFacebookUrl();
+	});
+
+	test.afterAll(async () => {
+		await cleanup();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await createAuthenticatedUser(page);
+	});
+
+	test("Facebook URL登録済み店舗ではアイコンとユーザー名が表示される", async ({
+		page,
+	}) => {
+		await page.goto(`/bars/${barIdWithFacebookUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const facebookSection = page.locator("text=/Facebook/i");
+		const facebookLink = page.locator('a[href*="facebook.com"]');
+
+		await expect(facebookSection.first()).toBeVisible();
+		await expect(facebookLink.first()).toBeVisible();
+
+		await expect(facebookLink.first()).toHaveAttribute(
+			"href",
+			"https://www.facebook.com/beersalon.test",
+		);
+		await expect(facebookLink.first()).toHaveAttribute("target", "_blank");
+		await expect(facebookLink.first()).toHaveAttribute(
+			"rel",
+			"nofollow noopener",
+		);
+		await expect(facebookLink.first()).toHaveAttribute(
+			"aria-label",
+			"Facebookで見る",
+		);
+
+		const facebookIcon = facebookLink.first().locator("svg").first();
+		await expect(facebookIcon).toBeVisible();
+
+		const usernameText = facebookLink.first().locator("span");
+		await expect(usernameText).toContainText("@beersalon.test");
+	});
+
+	test("Facebook URL未登録店舗では表示されない", async ({ page }) => {
+		await page.goto(`/bars/${barIdWithoutFacebookUrl}`);
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(500);
+
+		const facebookLink = page.locator('a[href*="facebook.com"]');
+		await expect(facebookLink).not.toBeVisible();
+
+		const facebookSection = page.locator("text=/Facebook/i");
+		await expect(facebookSection).not.toBeVisible();
+	});
+
+	test("Facebook URLリンクをクリックすると新規タブで開く", async ({
+		page,
+		context,
+	}) => {
+		await page.goto(`/bars/${barIdWithFacebookUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const facebookLink = page.locator('a[href*="facebook.com"]');
+
+		const [newPage] = await Promise.all([
+			context.waitForEvent("page"),
+			facebookLink.first().click(),
+		]);
+
+		expect(newPage.url()).toContain("facebook.com");
+
+		await newPage.close();
+	});
+
+	test("Facebook URLリンクにrel属性が正しく設定されている", async ({
+		page,
+	}) => {
+		await page.goto(`/bars/${barIdWithFacebookUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const facebookLink = page.locator('a[href*="facebook.com"]');
+
+		await expect(facebookLink.first()).toBeVisible();
+
+		const rel = await facebookLink.first().getAttribute("rel");
+		expect(rel).toBe("nofollow noopener");
+
+		const target = await facebookLink.first().getAttribute("target");
+		expect(target).toBe("_blank");
+	});
+
+	test("Facebook URLアイコンがhover時に青色に変化する", async ({ page }) => {
+		await page.goto(`/bars/${barIdWithFacebookUrl}`, {
+			waitUntil: "networkidle",
+		});
+
+		await page.reload({ waitUntil: "networkidle" });
+
+		const topTab = page.locator(
+			'[role="tab"]:has-text("基本情報"), button:has-text("基本情報"), [data-value="top"]',
+		);
+
+		if ((await topTab.count()) > 0) {
+			await topTab.first().click();
+		}
+
+		await page.waitForTimeout(1000);
+
+		const facebookLink = page.locator('a[href*="facebook.com"]');
+
+		await expect(facebookLink.first()).toBeVisible();
+
+		const classAttr = await facebookLink.first().getAttribute("class");
+		expect(classAttr).toContain("hover:text-blue-600");
+	});
+});

--- a/e2e/bar-detail-x-url.spec.ts
+++ b/e2e/bar-detail-x-url.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { createAuthenticatedUser } from "./helpers/auth";
-import { cleanup, ensureBarWithXUrl, ensureBarWithoutXUrl } from "./helpers/database";
+import {
+	cleanup,
+	ensureBarWithoutXUrl,
+	ensureBarWithXUrl,
+} from "./helpers/database";
 
 let barIdWithXUrl: bigint;
 let barIdWithoutXUrl: bigint;

--- a/e2e/helpers/database.ts
+++ b/e2e/helpers/database.ts
@@ -88,6 +88,50 @@ export async function ensureBarWithoutXUrl(): Promise<bigint> {
 	return barId;
 }
 
+export async function ensureBarWithFacebookUrl(): Promise<bigint> {
+	const bars = await prisma.bar.findMany({
+		select: { id: true, name: true, facebookUrl: true },
+		take: 5,
+	});
+
+	if (bars.length === 0) {
+		throw new Error("No bars found in database");
+	}
+
+	const barId = bars[0].id;
+
+	await prisma.bar.updateMany({
+		where: { id: barId },
+		data: { facebookUrl: "https://www.facebook.com/beersalon.test" },
+	});
+
+	return barId;
+}
+
+export async function ensureBarWithoutFacebookUrl(): Promise<bigint> {
+	const bars = await prisma.bar.findMany({
+		select: { id: true, name: true, facebookUrl: true },
+		skip: 1,
+		take: 1,
+	});
+
+	if (bars.length === 0) {
+		const firstBar = await prisma.bar.findFirst({
+			select: { id: true },
+		});
+		return firstBar?.id ?? 1n;
+	}
+
+	const barId = bars[0].id;
+
+	await prisma.bar.updateMany({
+		where: { id: barId },
+		data: { facebookUrl: null },
+	});
+
+	return barId;
+}
+
 export async function cleanup() {
 	await prisma.$disconnect();
 }

--- a/prisma/migrations/20260222000001_add_x_url_and_facebook_url_to_bars/migration.sql
+++ b/prisma/migrations/20260222000001_add_x_url_and_facebook_url_to_bars/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "bars" ADD COLUMN IF NOT EXISTS "x_url" TEXT;
+ALTER TABLE "bars" ADD COLUMN IF NOT EXISTS "facebook_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model Bar {
   websiteUrl        String?            @map("website_url")
   instagramUrl      String?            @map("instagram_url")
   xUrl              String?            @map("x_url")
+  facebookUrl       String?            @map("facebook_url")
   description       String?
   isActive          Boolean            @default(true) @map("is_active")
   createdAt         DateTime           @default(now()) @map("created_at") @db.Timestamptz(6)

--- a/src/components/bar/tabs/top-tab.tsx
+++ b/src/components/bar/tabs/top-tab.tsx
@@ -1,4 +1,5 @@
 import { Instagram } from "lucide-react";
+import { FacebookIcon } from "@/components/icons/facebook-icon";
 import { XIcon } from "@/components/icons/x-icon";
 
 interface PaymentMethod {
@@ -32,6 +33,7 @@ interface BarInfo {
 	websiteUrl: string | null;
 	instagramUrl: string | null;
 	xUrl: string | null;
+	facebookUrl: string | null;
 	paymentMethods: PaymentMethod[];
 	openingHours: OpeningHour[];
 }
@@ -233,6 +235,26 @@ export function TopTab({ bar }: TopTabProps) {
 							<XIcon className="w-6 h-6" />
 							<span className="text-sm">
 								@{bar.xUrl.split("/").filter(Boolean).pop()}
+							</span>
+						</a>
+					</div>
+				)}
+
+				{bar.facebookUrl && (
+					<div>
+						<h3 className="text-sm font-semibold text-gray-700 mb-1">
+							Facebook
+						</h3>
+						<a
+							href={bar.facebookUrl}
+							target="_blank"
+							rel="nofollow noopener"
+							className="inline-flex items-center gap-2 text-gray-700 hover:text-blue-600 transition-colors"
+							aria-label="Facebookで見る"
+						>
+							<FacebookIcon className="w-6 h-6" />
+							<span className="text-sm">
+								@{bar.facebookUrl.split("/").filter(Boolean).pop()}
 							</span>
 						</a>
 					</div>

--- a/src/components/icons/facebook-icon.tsx
+++ b/src/components/icons/facebook-icon.tsx
@@ -1,0 +1,16 @@
+interface FacebookIconProps {
+	className?: string;
+}
+
+export function FacebookIcon({ className }: FacebookIconProps) {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			className={className}
+			fill="currentColor"
+		>
+			<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+		</svg>
+	);
+}

--- a/supabase/migrations/20260222000001_add_x_url_and_facebook_url_to_bars.sql
+++ b/supabase/migrations/20260222000001_add_x_url_and_facebook_url_to_bars.sql
@@ -1,0 +1,3 @@
+-- Add x_url and facebook_url columns to bars table
+ALTER TABLE bars ADD COLUMN IF NOT EXISTS x_url TEXT;
+ALTER TABLE bars ADD COLUMN IF NOT EXISTS facebook_url TEXT;


### PR DESCRIPTION
## 概要
店舗詳細ページの基本情報タブに Facebook リンクを表示する機能を追加しました。

## 変更内容
- `bars` テーブルに `facebook_url` カラムを追加（Prisma & Supabase マイグレーション）
- Facebook アイコンコンポーネント (`FacebookIcon`) を作成
- `TopTab` コンポーネントに Facebook リンク表示機能を追加
  - Facebook URL が登録されている場合のみ表示
  - アイコン + ユーザー名形式で表示
  - hover 時に青色に変化
  - `rel="nofollow noopener"` と `target="_blank"` を設定
- E2E テストを追加（5 テスト）
  - Facebook URL 登録済み店舗でのアイコンとユーザー名の表示確認
  - Facebook URL 未登録店舗での非表示確認
  - リンククリック時の新規タブでの開く動作確認
  - rel 属性と target 属性の検証
  - hover 時のスタイル変化確認
- `database.md` を更新して `facebook_url` カラムを反映
- データベースヘルパー関数を追加
  - `ensureBarWithFacebookUrl`: Facebook URL 付きバーを準備
  - `ensureBarWithoutFacebookUrl`: Facebook URL なしバーを準備

## テスト結果
- E2E テスト: ✅ 5/5 passed
- lint: ✅ No errors
- format: ✅ Applied

## スクリーンショット
（必要に応じて後で追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)