### PR TITLE
fix: 店舗詳細ページの営業時間表示のタイムゾーン変換を修正

### DIFF
--- a/src/components/bar/tabs/top-tab.tsx
+++ b/src/components/bar/tabs/top-tab.tsx
@@ -44,11 +44,10 @@ interface TopTabProps {
 
 function formatTime(date: Date | null): string {
 	if (!date) return "-";
-	return new Date(date).toLocaleTimeString("ja-JP", {
-		hour: "2-digit",
-		minute: "2-digit",
-		hour12: false,
-	});
+	const d = new Date(date);
+	const hours = d.getUTCHours();
+	const minutes = d.getUTCMinutes();
+	return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
 const DAY_NAMES = [


### PR DESCRIPTION
## 概要
店舗詳細ページに表示される営業時間が、管理画面で設定した時刻から9時間ずれて表示される問題を修正しました。

## 問題の詳細
- **症状**: 管理画面で「10:00」と設定した営業時間が、ユーザー画面では「19:00」と表示される
- **原因**: 
  - Prismaが PostgreSQL の`time`型を`Date`オブジェクト（UTC時刻）として返す
  - `formatTime`関数が`toLocaleTimeString()`を使用する際に、タイムゾーン変換（UTC→JST、+9時間）が発生
  - 結果として、営業時間が9時間ずれて表示される

## 修正内容
### 変更ファイル
- `src/components/bar/tabs/top-tab.tsx`

### 修正方法
`formatTime`関数で以下の変更を実施：
- **修正前**: `toLocaleTimeString()`を使用（タイムゾーン変換あり）
- **修正後**: `getUTCHours()`と`getUTCMinutes()`を使用してUTC時刻部分のみを抽出し、タイムゾーン変換を回避

```typescript
// 修正前
function formatTime(date: Date | null): string {
  if (!date) return "-";
  return new Date(date).toLocaleTimeString("ja-JP", {
    hour: "2-digit",
    minute: "2-digit",
    hour12: false,
  });
}

// 修正後
function formatTime(date: Date | null): string {
  if (!date) return "-";
  const d = new Date(date);
  const hours = d.getUTCHours();
  const minutes = d.getUTCMinutes();
  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
}
```

## 動作確認
- データベースに保存されている営業時間データ（例: 月曜日 10:00-15:00, 17:00-23:00）
- 修正後は管理画面で設定した時刻がそのまま表示されることを確認

## 影響範囲
- **ユーザー影響**: 店舗詳細ページの営業時間表示のみ
- **データ影響**: なし（DBには正しいデータが保存されている）
- **他機能への影響**: なし

## 関連Issue
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)