### PR TITLE
管理画面にビールメニュー導線の追加

### DIFF
--- a/apps/admin/src/app/bars/BarList.tsx
+++ b/apps/admin/src/app/bars/BarList.tsx
@@ -127,6 +127,14 @@ export default function BarList() {
 								</div>
 								<div className="flex items-start space-x-2 ml-4">
 									<button
+										onClick={() =>
+											router.push(`/bars/${bar.id}/menus/beers`)
+										}
+										className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+									>
+										メニュー管理
+									</button>
+									<button
 										onClick={() => router.push(`/bars/${bar.id}/edit`)}
 										className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
 									>

--- a/apps/admin/src/app/menus/MenuHub.tsx
+++ b/apps/admin/src/app/menus/MenuHub.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import type { Bar } from "@/types/database";
+
+interface MenuHubProps {
+	userRole: string;
+}
+
+export default function MenuHub({ userRole }: MenuHubProps) {
+	const [bars, setBars] = useState<Bar[]>([]);
+	const [loading, setLoading] = useState(true);
+	const router = useRouter();
+
+	useEffect(() => {
+		const fetchBars = async () => {
+			try {
+				const response = await fetch("/api/bars");
+				if (response.ok) {
+					const data = await response.json();
+					setBars(data);
+				}
+			} catch (_error) {
+			} finally {
+				setLoading(false);
+			}
+		};
+		fetchBars();
+	}, []);
+
+	useEffect(() => {
+		if (loading) return;
+		if (userRole === "bar_owner" && bars.length === 1) {
+			router.push(`/bars/${bars[0].id}/menus/beers`);
+		}
+	}, [loading, bars, userRole, router]);
+
+	if (loading) {
+		return (
+			<div className="p-6">
+				<div className="animate-pulse space-y-4">
+					<div className="h-8 bg-gray-200 rounded w-1/4" />
+					<div className="h-32 bg-gray-200 rounded" />
+					<div className="h-32 bg-gray-200 rounded" />
+				</div>
+			</div>
+		);
+	}
+
+	if (bars.length === 0) {
+		return (
+			<div className="p-6">
+				<h1 className="text-2xl font-bold text-gray-900 mb-6">
+					メニュー管理
+				</h1>
+				<div className="bg-white shadow rounded-lg p-12 text-center">
+					<p className="text-gray-500">バーが登録されていません</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (userRole === "bar_owner" && bars.length === 1) {
+		return (
+			<div className="p-6">
+				<div className="animate-pulse space-y-4">
+					<div className="h-8 bg-gray-200 rounded w-1/4" />
+					<div className="h-32 bg-gray-200 rounded" />
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="p-6">
+			<h1 className="text-2xl font-bold text-gray-900 mb-6">
+				メニュー管理
+			</h1>
+			<p className="text-gray-600 mb-6">
+				メニューを管理するバーを選択してください
+			</p>
+			<div className="space-y-4">
+				{bars.map((bar) => (
+					<div
+						key={bar.id}
+						className="bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow"
+					>
+						<div className="flex items-start justify-between">
+							<div className="flex items-center space-x-4">
+								{bar.preview_image_url ? (
+									<img
+										src={bar.preview_image_url}
+										alt={bar.name}
+										className="w-24 h-24 object-cover rounded-lg"
+									/>
+								) : (
+									<div className="w-24 h-24 bg-gray-200 rounded-lg flex items-center justify-center">
+										<span className="text-4xl">🏪</span>
+									</div>
+								)}
+								<div>
+									<h2 className="text-xl font-semibold text-gray-900 mb-2">
+										{bar.name}
+									</h2>
+									{(bar.prefecture || bar.city) && (
+										<p className="text-sm text-gray-600">
+											📍 {bar.prefecture} {bar.city}
+										</p>
+									)}
+								</div>
+							</div>
+							<div className="flex items-start space-x-2 ml-4">
+								<button
+									onClick={() =>
+										router.push(`/bars/${bar.id}/menus/beers`)
+									}
+									className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+								>
+									ビールメニュー管理
+								</button>
+								<button
+									onClick={() =>
+										router.push(`/bars/${bar.id}/menus/foods`)
+									}
+									className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+								>
+									フードメニュー管理
+								</button>
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/admin/src/app/menus/page.tsx
+++ b/apps/admin/src/app/menus/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import { getCurrentUser } from "@/lib/auth";
+import MenuHub from "./MenuHub";
 
 export default async function MenusPage() {
 	const user = await getCurrentUser();
@@ -11,10 +12,7 @@ export default async function MenusPage() {
 
 	return (
 		<DashboardLayout userName={user.name} userRole={user.role}>
-			<div className="p-6">
-				<h1 className="text-2xl font-bold text-gray-900 mb-4">メニュー管理</h1>
-				<p className="text-gray-600">メニュー管理機能は実装予定です</p>
-			</div>
+			<MenuHub userRole={user.role} />
 		</DashboardLayout>
 	);
 }

--- a/apps/admin/tests/menu-navigation.spec.ts
+++ b/apps/admin/tests/menu-navigation.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "./helpers/fixtures";
+
+test.describe("Menu Navigation", () => {
+	test("should navigate to beer menu page from sidebar menu link", async ({
+		barOwnerPage,
+	}) => {
+		await barOwnerPage.goto("/menus");
+
+		// bar_ownerで1件のバーがある場合、ビールメニュー管理ページにリダイレクトされる
+		await barOwnerPage.waitForURL(/\/bars\/\d+\/menus\/beers/);
+		await expect(
+			barOwnerPage.getByRole("heading", { name: "ビールメニュー管理" }),
+		).toBeVisible();
+	});
+
+	test("should display menu management button on bar list", async ({
+		barOwnerPage,
+	}) => {
+		await barOwnerPage.goto("/bars");
+
+		// メニュー管理ボタンが表示されることを確認
+		const menuButton = barOwnerPage
+			.getByRole("button", { name: "メニュー管理" })
+			.first();
+		await expect(menuButton).toBeVisible();
+	});
+
+	test("should navigate from bar list menu button to beer menu page", async ({
+		barOwnerPage,
+	}) => {
+		await barOwnerPage.goto("/bars");
+
+		// メニュー管理ボタンをクリック
+		const menuButton = barOwnerPage
+			.getByRole("button", { name: "メニュー管理" })
+			.first();
+		await menuButton.click();
+
+		// ビールメニュー管理ページに遷移することを確認
+		await barOwnerPage.waitForURL(/\/bars\/\d+\/menus\/beers/);
+		await expect(
+			barOwnerPage.getByRole("heading", { name: "ビールメニュー管理" }),
+		).toBeVisible();
+	});
+
+	test("should display bar selection when admin accesses menu page", async ({
+		adminPage,
+	}) => {
+		await adminPage.goto("/menus");
+
+		// メニュー管理の見出しが表示されることを確認
+		await expect(
+			adminPage.getByRole("heading", { name: "メニュー管理" }),
+		).toBeVisible();
+
+		// バー選択UIが表示されることを確認
+		await expect(
+			adminPage.getByText("メニューを管理するバーを選択してください"),
+		).toBeVisible();
+
+		// ビールメニュー管理ボタンが表示されることを確認
+		await expect(
+			adminPage
+				.getByRole("button", { name: "ビールメニュー管理" })
+				.first(),
+		).toBeVisible();
+	});
+
+	test("should navigate from menu hub to beer menu for specific bar (admin)", async ({
+		adminPage,
+	}) => {
+		await adminPage.goto("/menus");
+
+		// ビールメニュー管理ボタンをクリック
+		await adminPage
+			.getByRole("button", { name: "ビールメニュー管理" })
+			.first()
+			.click();
+
+		// ビールメニュー管理ページに遷移することを確認
+		await adminPage.waitForURL(/\/bars\/\d+\/menus\/beers/);
+		await expect(
+			adminPage.getByRole("heading", { name: "ビールメニュー管理" }),
+		).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary
- サイドバーの「メニュー」リンクからバー別ビールメニュー管理ページへの導線を追加
- バー一覧ページの各バーカードに「メニュー管理」ボタンを追加
- `/menus` ページをプレースホルダーからMenuHubコンポーネントに置き換え（バー選択UI）

## 変更内容
- `BarList.tsx`: 各バーカードに「メニュー管理」ボタンを追加（`/bars/[barId]/menus/beers` へ遷移）
- `MenuHub.tsx`: 新規作成。バー選択→メニュー管理への導線ハブ。`bar_owner` で1バーのみの場合は自動リダイレクト
- `menus/page.tsx`: プレースホルダーをMenuHubコンポーネントに置き換え
- `menu-navigation.spec.ts`: メニュー導線のE2Eテスト追加（5ケース）

## 関連Issue
Closes #156

## Test plan
- [ ] bar_ownerでログイン後、サイドバー「メニュー」から自バーのビールメニュー管理ページに自動遷移される
- [ ] bar_ownerでバー一覧の「メニュー管理」ボタンからビールメニュー管理ページに遷移できる
- [ ] adminでログイン後、サイドバー「メニュー」からバー選択画面が表示される
- [ ] adminでバー選択画面から任意のバーのビールメニュー管理ページに遷移できる
- [ ] Playwrightテスト（`menu-navigation.spec.ts`）が全件パスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)