### PR TITLE
add: イベント登録の画像アップロード機能を実装

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -19,7 +19,7 @@ agent: frontend-engineer
 #### 1-1. ブランチ作成
 
 - developベースで feature ブランチを作成する
-- `gh issue develop $ARGUMENTS --checkout` を使用する
+- `gh issue develop $ARGUMENTS --base develop --checkout` を使用する
 
 #### 1-2. プロダクトコード実装
 

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,16 @@
+name: Protect main branch
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::mainへのマージはdevelopブランチからのみ許可されています。現在のソースブランチ: ${{ github.head_ref }}"
+            exit 1
+          fi

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -7,14 +7,13 @@ const nextConfig: NextConfig = {
 				protocol: "http",
 				hostname: "127.0.0.1",
 				port: "54421",
-				pathname: "/storage/v1/object/public/**",
 			},
 			{
 				protocol: "https",
-				hostname: "*.supabase.co",
-				pathname: "/storage/v1/object/public/**",
+				hostname: "**.supabase.co",
 			},
 		],
+		unoptimized: process.env.NODE_ENV === "development",
 	},
 };
 

--- a/apps/admin/src/app/api/bars/[barId]/events/upload/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/events/upload/route.ts
@@ -1,0 +1,86 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { canAccessBar, getCurrentUser } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const BUCKET_NAME = "bar-media";
+
+export async function POST(
+	request: NextRequest,
+	{ params }: { params: Promise<{ barId: string }> },
+) {
+	try {
+		const user = await getCurrentUser();
+		if (!user) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		if (user.role !== "bar_owner") {
+			return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+		}
+
+		const { barId } = await params;
+
+		if (!canAccessBar(user, barId)) {
+			return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+		}
+
+		const formData = await request.formData();
+		const file = formData.get("file") as File;
+
+		if (!file) {
+			return NextResponse.json(
+				{ error: "ファイルが選択されていません" },
+				{ status: 400 },
+			);
+		}
+
+		if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+			return NextResponse.json(
+				{ error: "画像形式はJPEG、PNG、WebPのみ対応しています" },
+				{ status: 400 },
+			);
+		}
+
+		if (file.size > MAX_IMAGE_SIZE) {
+			return NextResponse.json(
+				{ error: "ファイルサイズは5MB以下にしてください" },
+				{ status: 400 },
+			);
+		}
+
+		const timestamp = Date.now();
+		const uuid = crypto.randomUUID();
+		const extension = file.name.split(".").pop();
+		const fileName = `bars/${barId}/events/${timestamp}-${uuid}.${extension}`;
+
+		const arrayBuffer = await file.arrayBuffer();
+		const buffer = Buffer.from(arrayBuffer);
+
+		const { data: uploadData, error: uploadError } = await supabaseAdmin.storage
+			.from(BUCKET_NAME)
+			.upload(fileName, buffer, {
+				contentType: file.type,
+				upsert: false,
+			});
+
+		if (uploadError) {
+			return NextResponse.json(
+				{ error: "画像のアップロードに失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		const { data: publicUrlData } = supabaseAdmin.storage
+			.from(BUCKET_NAME)
+			.getPublicUrl(uploadData.path);
+
+		return NextResponse.json({ url: publicUrlData.publicUrl });
+	} catch (_error) {
+		return NextResponse.json(
+			{ error: "画像のアップロードに失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/admin/src/app/api/bars/[barId]/media/reorder/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/media/reorder/route.ts
@@ -36,7 +36,12 @@ export async function PUT(
 			);
 		}
 
-		if (mediaIds.length === 0 || !mediaIds.every((id) => typeof id === "number" && Number.isInteger(id) && id > 0)) {
+		if (
+			mediaIds.length === 0 ||
+			!mediaIds.every(
+				(id) => typeof id === "number" && Number.isInteger(id) && id > 0,
+			)
+		) {
 			return NextResponse.json(
 				{ error: "mediaIdsは正の整数の配列である必要があります" },
 				{ status: 400 },

--- a/apps/admin/src/app/api/bars/[barId]/media/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/media/route.ts
@@ -164,9 +164,12 @@ export async function POST(
 
 		const mediaUrl = publicUrlData.publicUrl;
 
-		const nextSortOrder = existingMedia && existingMedia.length > 0
-			? Math.max(...existingMedia.map((m: { sort_order: number }) => m.sort_order)) + 1
-			: 0;
+		const nextSortOrder =
+			existingMedia && existingMedia.length > 0
+				? Math.max(
+						...existingMedia.map((m: { sort_order: number }) => m.sort_order),
+					) + 1
+				: 0;
 
 		const { data: newMedia, error: insertError } = await supabaseAdmin
 			.from("bar_images")

--- a/apps/admin/src/app/bars/[barId]/BarDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/BarDetail.tsx
@@ -234,7 +234,9 @@ export default function BarDetail({ barId, userRole }: BarDetailProps) {
 									<button
 										type="button"
 										onClick={() => scrollToSlide("next")}
-										disabled={currentSlide === (bar.bar_images?.length ?? 1) - 1}
+										disabled={
+											currentSlide === (bar.bar_images?.length ?? 1) - 1
+										}
 										className={`absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full flex items-center justify-center ${
 											currentSlide === (bar.bar_images?.length ?? 1) - 1
 												? "bg-black/20 text-white/50 cursor-not-allowed"

--- a/apps/admin/src/components/EventForm.tsx
+++ b/apps/admin/src/components/EventForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { BarEvent } from "@/types/database";
 
 interface EventFormProps {
@@ -9,53 +10,90 @@ interface EventFormProps {
 	eventId?: string;
 }
 
+interface ImageState {
+	file: File | null;
+	preview: string;
+}
+
 export default function EventForm({ barId, eventId }: EventFormProps) {
 	const router = useRouter();
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
+	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const [formData, setFormData] = useState({
 		title: "",
 		description: "",
 		start_date: "",
 		end_date: "",
-		image_url: "",
 		is_active: true,
 	});
 
+	const [image, setImage] = useState<ImageState | null>(null);
+	const [existingImageUrl, setExistingImageUrl] = useState("");
+
 	useEffect(() => {
-		if (eventId) {
-			fetchEvent();
-		}
-	}, [eventId]);
+		const loadEvent = async () => {
+			try {
+				const response = await fetch(`/api/bars/${barId}/events/${eventId}`);
 
-	const fetchEvent = async () => {
-		try {
-			const response = await fetch(`/api/bars/${barId}/events/${eventId}`);
+				if (!response.ok) {
+					setError("イベントの取得に失敗しました");
+					return;
+				}
 
-			if (!response.ok) {
+				const data = await response.json();
+				const event: BarEvent = data.event;
+
+				setFormData({
+					title: event.title,
+					description: event.description || "",
+					start_date: event.start_date
+						? new Date(event.start_date).toISOString().slice(0, 16)
+						: "",
+					end_date: event.end_date
+						? new Date(event.end_date).toISOString().slice(0, 16)
+						: "",
+					is_active: event.is_active,
+				});
+
+				if (event.image_url) {
+					setExistingImageUrl(event.image_url);
+				}
+			} catch (_error) {
 				setError("イベントの取得に失敗しました");
-				return;
 			}
+		};
 
-			const data = await response.json();
-			const event: BarEvent = data.event;
-
-			setFormData({
-				title: event.title,
-				description: event.description || "",
-				start_date: event.start_date
-					? new Date(event.start_date).toISOString().slice(0, 16)
-					: "",
-				end_date: event.end_date
-					? new Date(event.end_date).toISOString().slice(0, 16)
-					: "",
-				image_url: event.image_url || "",
-				is_active: event.is_active,
-			});
-		} catch (error) {
-			setError("イベントの取得に失敗しました");
+		if (eventId) {
+			loadEvent();
 		}
+	}, [eventId, barId]);
+
+	useEffect(() => {
+		return () => {
+			if (image?.file) {
+				URL.revokeObjectURL(image.preview);
+			}
+		};
+	}, [image]);
+
+	const uploadImage = async (file: File): Promise<string> => {
+		const uploadFormData = new FormData();
+		uploadFormData.append("file", file);
+
+		const res = await fetch(`/api/bars/${barId}/events/upload`, {
+			method: "POST",
+			body: uploadFormData,
+		});
+
+		if (!res.ok) {
+			const data = await res.json();
+			throw new Error(data.error || "画像のアップロードに失敗しました");
+		}
+
+		const data = await res.json();
+		return data.url;
 	};
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -64,6 +102,12 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 		setError("");
 
 		try {
+			let imageUrl: string | null = existingImageUrl || null;
+
+			if (image?.file) {
+				imageUrl = await uploadImage(image.file);
+			}
+
 			const url = eventId
 				? `/api/bars/${barId}/events/${eventId}`
 				: `/api/bars/${barId}/events`;
@@ -84,7 +128,7 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 					end_date: formData.end_date
 						? new Date(formData.end_date).toISOString()
 						: null,
-					image_url: formData.image_url || null,
+					image_url: imageUrl,
 					is_active: formData.is_active,
 				}),
 			});
@@ -96,7 +140,7 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 			}
 
 			router.push(`/bars/${barId}/events`);
-		} catch (error) {
+		} catch (_error) {
 			setError("保存に失敗しました");
 		} finally {
 			setLoading(false);
@@ -115,6 +159,44 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 			setFormData((prev) => ({ ...prev, [name]: value }));
 		}
 	};
+
+	const handleImageAdd = useCallback(() => {
+		fileInputRef.current?.click();
+	}, []);
+
+	const handleFileChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const files = e.target.files;
+			if (!files || files.length === 0) return;
+
+			const file = files[0];
+
+			if (image?.file) {
+				URL.revokeObjectURL(image.preview);
+			}
+
+			setImage({
+				file,
+				preview: URL.createObjectURL(file),
+			});
+			setExistingImageUrl("");
+
+			if (fileInputRef.current) {
+				fileInputRef.current.value = "";
+			}
+		},
+		[image],
+	);
+
+	const handleImageRemove = useCallback(() => {
+		if (image?.file) {
+			URL.revokeObjectURL(image.preview);
+		}
+		setImage(null);
+		setExistingImageUrl("");
+	}, [image]);
+
+	const currentPreview = image?.preview || existingImageUrl;
 
 	return (
 		<form onSubmit={handleSubmit} className="space-y-6">
@@ -200,20 +282,52 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 
 			<div>
 				<label
-					htmlFor="image_url"
-					className="block text-sm font-medium text-gray-700"
+					htmlFor="event_image"
+					className="block text-sm font-medium text-gray-700 mb-2"
 				>
-					画像URL
+					画像
 				</label>
 				<input
-					type="url"
-					id="image_url"
-					name="image_url"
-					value={formData.image_url}
-					onChange={handleChange}
-					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-					placeholder="https://example.com/image.jpg"
+					ref={fileInputRef}
+					id="event_image"
+					type="file"
+					accept="image/jpeg,image/png,image/webp"
+					onChange={handleFileChange}
+					className="hidden"
 				/>
+
+				<div className="flex flex-wrap gap-4">
+					{currentPreview && (
+						<div className="relative w-32 h-32">
+							<Image
+								src={currentPreview}
+								alt="イベント画像"
+								fill
+								className="object-cover rounded-md border border-gray-200"
+							/>
+							<button
+								type="button"
+								onClick={handleImageRemove}
+								className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full text-xs flex items-center justify-center hover:bg-red-600"
+							>
+								x
+							</button>
+						</div>
+					)}
+
+					{!currentPreview && (
+						<button
+							type="button"
+							onClick={handleImageAdd}
+							className="w-32 h-32 border-2 border-dashed border-gray-300 rounded-md flex items-center justify-center text-gray-400 hover:border-gray-400 hover:text-gray-500 transition-colors"
+						>
+							<span className="text-2xl">+</span>
+						</button>
+					)}
+				</div>
+				<p className="mt-1 text-xs text-gray-500">
+					JPEG、PNG、WebP形式（最大5MB）
+				</p>
 			</div>
 
 			<div className="flex items-center">

--- a/supabase/migrations/20260603000000_create_bar_events.sql
+++ b/supabase/migrations/20260603000000_create_bar_events.sql
@@ -1,0 +1,19 @@
+-- ============================================================
+-- bar_events テーブル作成
+-- Issue #179: イベント管理機能のテーブルが未作成だったため追加
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS bar_events (
+  id bigserial PRIMARY KEY,
+  bar_id bigint NOT NULL REFERENCES bars(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  start_date timestamptz NOT NULL,
+  end_date timestamptz,
+  image_url text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bar_events_bar_id ON bar_events(bar_id);


### PR DESCRIPTION
## Summary
- イベント登録フォームの画像入力をURL直接入力方式からファイルアップロード方式に変更
- Supabase Storage連携の画像アップロードAPIを新規作成
- 編集時の既存画像プレビュー表示・差し替え・削除に対応

Closes #179

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `apps/admin/src/app/api/bars/[barId]/events/upload/route.ts` | 新規: 画像アップロードAPI（JPEG/PNG/WebP、5MB上限） |
| `apps/admin/src/components/EventForm.tsx` | 改修: URL入力→ファイル選択UI+プレビュー+アップロード処理 |
| `supabase/migrations/20260603000000_create_bar_events.sql` | 新規: bar_eventsテーブルのマイグレーション |
| その他3ファイル | pnpm formatによる自動整形 |

## Test plan
- [x] イベント新規作成で画像アップロード→プレビュー表示を確認
- [x] 作成後、一覧ページにサムネイル付きで表示されることを確認
- [x] 詳細ページでアップロード画像が表示されることを確認
- [x] 編集ページで既存画像のプレビュー表示を確認
- [x] 「x」ボタンで画像削除→「+」ボタンに戻ることを確認
- [x] pnpm format / pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)