### PR TITLE
fix: ビールメニュー詳細に「国」フィールドを追加 (#182)

### DIFF
--- a/apps/admin/src/app/api/bars/[barId]/menus/beers/[menuId]/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/menus/beers/[menuId]/route.ts
@@ -27,7 +27,10 @@ export async function GET(
 					*,
 					category:beer_categories (*),
 					brewery:breweries (*),
-					region:regions (*)
+					region:regions (
+						*,
+						country:countries (*)
+					)
 				),
 				sizes:bar_beer_menu_sizes (*)
 			`)

--- a/apps/admin/src/app/bars/[barId]/menus/beers/[menuId]/BeerMenuDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/menus/beers/[menuId]/BeerMenuDetail.tsx
@@ -84,6 +84,7 @@ export default function BeerMenuDetail({
 
 	if (!menu) return null;
 
+	const countryName = menu.beer?.region?.country?.name;
 	const regionName = menu.beer?.region?.name;
 	const breweryName = menu.beer?.brewery?.name;
 
@@ -116,6 +117,13 @@ export default function BeerMenuDetail({
 			</h1>
 
 			<dl className="space-y-4">
+				{countryName && (
+					<div>
+						<dt className="text-sm font-medium text-gray-500">国</dt>
+						<dd className="mt-1 text-sm text-gray-900">{countryName}</dd>
+					</div>
+				)}
+
 				{regionName && (
 					<div>
 						<dt className="text-sm font-medium text-gray-500">産地</dt>

--- a/apps/admin/src/types/database.ts
+++ b/apps/admin/src/types/database.ts
@@ -145,7 +145,7 @@ export interface BarBeerMenuDetail extends BarBeerMenu {
 	beer: Beer & {
 		category: BeerCategory;
 		brewery: Brewery | null;
-		region: Region | null;
+		region: (Region & { country: Country | null }) | null;
 	};
 	sizes: BarBeerMenuSize[];
 }


### PR DESCRIPTION
## Summary
- ビールメニュー詳細ページに「国」フィールドの表示を追加
- APIのSupabase selectで`region → country`のネスト取得を追加
- `BarBeerMenuDetail`型にcountryプロパティを追加

Closes #182

## 変更ファイル
- `apps/admin/src/app/api/bars/[barId]/menus/beers/[menuId]/route.ts` — regionのselectにcountryネストを追加
- `apps/admin/src/app/bars/[barId]/menus/beers/[menuId]/BeerMenuDetail.tsx` — 国フィールドの表示を追加（国→産地→醸造所の順）
- `apps/admin/src/types/database.ts` — BarBeerMenuDetailのregion型にcountryを追加

## Test plan
- [x] E2E: ビールメニュー詳細ページで「国: アメリカ」が表示されることを確認
- [x] E2E: 表示順序が国→産地→醸造所→サイズ/価格であることを確認
- [x] format/lint: パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)