### PR TITLE
fix: 管理画面のTailwind CSSクラスが一部適用されない問題を修正

### DIFF
--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
## Summary
- 管理画面（apps/admin）の `globals.css` で Tailwind v3 形式の `@tailwind` ディレクティブを使用していたが、PostCSS プラグインは Tailwind v4（`@tailwindcss/postcss`）であったため、グリッドレイアウト・高さ指定等の一部 CSS クラスが生成されていなかった
- `@tailwind base/components/utilities` を `@import "tailwindcss"` に変更し、v4 形式に統一

Closes #190

## Test plan
- [x] イベント一覧ページでグリッドレイアウトが適用されていることを確認
- [x] 画像の `h-40` が効いて画像が正常に表示されることを確認
- [x] 店舗詳細ページの画像スライダーが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)