### PR TITLE
fix: 支払い方法管理のハードコードURLをStripe Portal Session APIに置換（#201）

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -13,6 +13,8 @@ JWT_SECRET=your_jwt_secret_key
 # App
 # アプリケーションのベースURL
 NEXT_PUBLIC_APP_URL=http://localhost:3001
+# サーバーサイド専用のベースURL（Stripe Portal戻りURL等で使用）
+ADMIN_BASE_URL=http://localhost:3001
 
 # Stripe
 # Stripeのシークレットキー（サーバーサイドで使用、機密情報）

--- a/apps/admin/src/__tests__/portal-api.test.ts
+++ b/apps/admin/src/__tests__/portal-api.test.ts
@@ -44,6 +44,7 @@ function mockSupabaseChain(result: { data: unknown; error: unknown }) {
 		select: vi.fn().mockReturnThis(),
 		eq: vi.fn().mockReturnThis(),
 		in: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
 		limit: vi.fn().mockReturnThis(),
 		single: vi.fn().mockResolvedValue(result),
 	};
@@ -129,7 +130,8 @@ describe("POST /api/bars/[barId]/portal", () => {
 		});
 	});
 
-	it("Stripe APIエラー時は500を返す", async () => {
+	it("Stripe APIエラー時は500を返し、エラーをログ出力する", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		mockGetCurrentUser.mockResolvedValue({
 			id: "user-1",
 			role: "bar_owner",
@@ -140,13 +142,19 @@ describe("POST /api/bars/[barId]/portal", () => {
 			data: { stripe_customer_id: "cus_test123" },
 			error: null,
 		});
-		mockPortalSessionsCreate.mockRejectedValue(new Error("Stripe API Error"));
+		const stripeError = new Error("Stripe API Error");
+		mockPortalSessionsCreate.mockRejectedValue(stripeError);
 
 		const response = await POST(createMockRequest(), createMockParams("1"));
 		const body = await response.json();
 
 		expect(response.status).toBe(500);
 		expect(body.error).toBe("Stripe Customer Portalの作成に失敗しました");
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"Stripe Portal Session作成エラー:",
+			stripeError,
+		);
+		consoleSpy.mockRestore();
 	});
 
 	it("admin権限でもアクセスできる", async () => {

--- a/apps/admin/src/__tests__/portal-api.test.ts
+++ b/apps/admin/src/__tests__/portal-api.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+const mockCanAccessBar = vi.fn();
+vi.mock("@/lib/auth", () => ({
+	getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+	canAccessBar: (...args: unknown[]) => mockCanAccessBar(...args),
+}));
+
+const mockSupabaseFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+	},
+}));
+
+const mockPortalSessionsCreate = vi.fn();
+vi.mock("@/lib/stripe", () => ({
+	stripe: {
+		billingPortal: {
+			sessions: {
+				create: (...args: unknown[]) => mockPortalSessionsCreate(...args),
+			},
+		},
+	},
+}));
+
+import { POST } from "@/app/api/bars/[barId]/portal/route";
+
+function createMockRequest(): Parameters<typeof POST>[0] {
+	return {
+		method: "POST",
+	} as Parameters<typeof POST>[0];
+}
+
+function createMockParams(barId: string): Parameters<typeof POST>[1] {
+	return {
+		params: Promise.resolve({ barId }),
+	};
+}
+
+function mockSupabaseChain(result: { data: unknown; error: unknown }) {
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		in: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockReturnThis(),
+		single: vi.fn().mockResolvedValue(result),
+	};
+	mockSupabaseFrom.mockReturnValue(chain);
+	return chain;
+}
+
+describe("POST /api/bars/[barId]/portal", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3001";
+	});
+
+	it("未認証の場合は401を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(body.error).toBe("Unauthorized");
+	});
+
+	it("アクセス権限がない場合は403を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 2,
+		});
+		mockCanAccessBar.mockReturnValue(false);
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(body.error).toBe("Forbidden");
+	});
+
+	it("サブスクリプションが存在しない場合は404を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: null,
+			error: { code: "PGRST116", message: "Not found" },
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(404);
+		expect(body.error).toBe("サブスクリプションが設定されていません");
+	});
+
+	it("正常系: Portal URLが返却される", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockResolvedValue({
+			url: "https://billing.stripe.com/session/test_session_url",
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.url).toBe(
+			"https://billing.stripe.com/session/test_session_url",
+		);
+		expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+			customer: "cus_test123",
+			return_url: "http://localhost:3001/bars/1",
+		});
+	});
+
+	it("Stripe APIエラー時は500を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockRejectedValue(new Error("Stripe API Error"));
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("Stripe Customer Portalの作成に失敗しました");
+	});
+
+	it("admin権限でもアクセスできる", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "admin-1",
+			role: "admin",
+			barId: null,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test456" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockResolvedValue({
+			url: "https://billing.stripe.com/session/admin_session",
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("5"));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.url).toBe("https://billing.stripe.com/session/admin_session");
+	});
+});

--- a/apps/admin/src/app/api/bars/[barId]/portal/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/portal/route.ts
@@ -1,0 +1,49 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getCurrentUser, canAccessBar } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { stripe } from "@/lib/stripe";
+
+export async function POST(
+	request: NextRequest,
+	{ params }: { params: Promise<{ barId: string }> },
+) {
+	const user = await getCurrentUser();
+	if (!user) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const { barId } = await params;
+
+	if (!canAccessBar(user, barId)) {
+		return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+	}
+
+	const { data: subscription, error } = await supabaseAdmin
+		.from("bar_subscriptions")
+		.select("stripe_customer_id")
+		.eq("bar_id", barId)
+		.in("status", ["active", "trialing", "past_due"])
+		.limit(1)
+		.single();
+
+	if (error || !subscription?.stripe_customer_id) {
+		return NextResponse.json(
+			{ error: "サブスクリプションが設定されていません" },
+			{ status: 404 },
+		);
+	}
+
+	try {
+		const portalSession = await stripe.billingPortal.sessions.create({
+			customer: subscription.stripe_customer_id,
+			return_url: `${process.env.NEXT_PUBLIC_APP_URL}/bars/${barId}`,
+		});
+
+		return NextResponse.json({ url: portalSession.url });
+	} catch (_e) {
+		return NextResponse.json(
+			{ error: "Stripe Customer Portalの作成に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/admin/src/app/api/bars/[barId]/portal/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/portal/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { getCurrentUser, canAccessBar } from "@/lib/auth";
-import { supabaseAdmin } from "@/lib/supabase";
+import { canAccessBar, getCurrentUser } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export async function POST(
-	request: NextRequest,
+	_request: NextRequest,
 	{ params }: { params: Promise<{ barId: string }> },
 ) {
 	const user = await getCurrentUser();
@@ -23,6 +23,7 @@ export async function POST(
 		.select("stripe_customer_id")
 		.eq("bar_id", barId)
 		.in("status", ["active", "trialing", "past_due"])
+		.order("created_at", { ascending: false })
 		.limit(1)
 		.single();
 
@@ -36,11 +37,12 @@ export async function POST(
 	try {
 		const portalSession = await stripe.billingPortal.sessions.create({
 			customer: subscription.stripe_customer_id,
-			return_url: `${process.env.NEXT_PUBLIC_APP_URL}/bars/${barId}`,
+			return_url: `${process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL}/bars/${barId}`,
 		});
 
 		return NextResponse.json({ url: portalSession.url });
-	} catch (_e) {
+	} catch (e) {
+		console.error("Stripe Portal Session作成エラー:", e);
 		return NextResponse.json(
 			{ error: "Stripe Customer Portalの作成に失敗しました" },
 			{ status: 500 },

--- a/apps/admin/src/app/bars/[barId]/BarDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/BarDetail.tsx
@@ -5,6 +5,54 @@ import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Bar, BarImage, BarOpeningHour } from "@/types/database";
 
+function PaymentManagementCard({ barId }: { barId: string }) {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState("");
+
+	const handleClick = async () => {
+		setLoading(true);
+		setError("");
+
+		try {
+			const response = await fetch(`/api/bars/${barId}/portal`, {
+				method: "POST",
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				setError(data.error || "エラーが発生しました");
+				return;
+			}
+
+			window.location.href = data.url;
+		} catch (_e) {
+			setError("通信エラーが発生しました");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<div className="border border-gray-200 rounded-lg p-4">
+			<button
+				type="button"
+				onClick={handleClick}
+				disabled={loading}
+				className="w-full text-left hover:opacity-80 transition-opacity disabled:opacity-50"
+			>
+				<h3 className="font-medium text-gray-900">支払い方法管理</h3>
+				<p className="text-sm text-gray-500 mt-1">
+					{loading
+						? "Stripe Customer Portalを開いています..."
+						: "Stripe Customer Portal（外部サイト）"}
+				</p>
+			</button>
+			{error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+		</div>
+	);
+}
+
 interface BarDetailProps {
 	barId: string;
 	userRole: "bar_owner" | "admin";
@@ -414,17 +462,7 @@ export default function BarDetail({ barId, userRole }: BarDetailProps) {
 							)}
 						</Link>
 					))}
-					<a
-						href="https://billing.stripe.com/p/login/test"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="block border border-gray-200 rounded-lg p-4 hover:border-gray-400 transition-colors"
-					>
-						<h3 className="font-medium text-gray-900">支払い方法管理</h3>
-						<p className="text-sm text-gray-500 mt-1">
-							Stripe Customer Portal（外部サイト）
-						</p>
-					</a>
+					<PaymentManagementCard barId={barId} />
 				</div>
 			</section>
 		</div>


### PR DESCRIPTION
## Summary
- 支払い方法管理リンクのハードコードURL (`https://billing.stripe.com/p/login/test`) を、Stripe Billing Portal Session APIによる動的URL生成に置換
- サブスクリプション未設定時のエラーハンドリングを追加
- Portal Session生成APIエンドポイント (`/api/bars/[barId]/portal`) を新規作成

Closes #201

## Test plan
- [x] Portal APIのUT（6テスト: 未認証/権限なし/サブスク未設定/正常系/Stripeエラー/admin権限）
- [x] Playwright MCPによるE2E確認（管理メニュー表示・クリック動作・エラーメッセージ表示）
- [x] 既存テスト（admin 24テスト全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)