### PR TITLE
fix: 新規登録系UT 3ファイル/11テスト失敗を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           node-version: 22
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec prisma generate --schema=prisma/schema.prisma
       - run: pnpm test
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec prisma generate --schema=prisma/schema.prisma
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
       - run: pnpm test
 
   build:

--- a/apps/web/src/app/signup/actions.test.ts
+++ b/apps/web/src/app/signup/actions.test.ts
@@ -44,7 +44,7 @@ describe("signUp", () => {
 				password: "SecurePass1!",
 				options: {
 					emailRedirectTo: expect.stringMatching(
-						/^http:\/\/(localhost|127\.0\.0\.1):3000\/signup\/profile$/,
+						/^http:\/\/(localhost|127\.0\.0\.1):3000\/auth\/callback\?next=\/signup\/profile$/,
 					),
 				},
 			});

--- a/apps/web/src/app/signup/confirm/actions.test.ts
+++ b/apps/web/src/app/signup/confirm/actions.test.ts
@@ -11,9 +11,20 @@ vi.mock("next/navigation", () => ({
 	},
 }));
 
+// next/headersのモック
+const mockCookieStore = {
+	get: vi.fn(),
+	delete: vi.fn(),
+};
+vi.mock("next/headers", () => ({
+	cookies: vi.fn(() => mockCookieStore),
+}));
+
 // Supabase clientのモック
 const mockGetUser = vi.fn();
 const mockUpload = vi.fn();
+const mockDownload = vi.fn();
+const mockRemove = vi.fn();
 const mockGetPublicUrl = vi.fn();
 vi.mock("@/lib/supabase/server", () => ({
 	createClient: vi.fn(() => ({
@@ -23,6 +34,8 @@ vi.mock("@/lib/supabase/server", () => ({
 		storage: {
 			from: vi.fn(() => ({
 				upload: mockUpload,
+				download: mockDownload,
+				remove: mockRemove,
 				getPublicUrl: mockGetPublicUrl,
 			})),
 		},
@@ -43,6 +56,31 @@ vi.mock("@/lib/prisma", () => ({
 
 import { confirmAndSaveProfile } from "./actions";
 
+const validProfileData = {
+	lastName: "山田",
+	firstName: "太郎",
+	nickname: "やまちゃん",
+	birthday: "1990-01-01",
+	gender: "male",
+	prefecture: "東京都",
+	bio: "",
+};
+
+function setupCookies(
+	profileData: Record<string, string> | null,
+	imagePath: string | null = null,
+) {
+	mockCookieStore.get.mockImplementation((name: string) => {
+		if (name === "profile_data" && profileData) {
+			return { value: JSON.stringify(profileData) };
+		}
+		if (name === "profile_image_path" && imagePath) {
+			return { value: imagePath };
+		}
+		return undefined;
+	});
+}
+
 describe("confirmAndSaveProfile", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -50,34 +88,19 @@ describe("confirmAndSaveProfile", () => {
 
 	describe("正常系", () => {
 		it("有効なプロフィールデータでDB保存が成功する", async () => {
+			setupCookies(validProfileData);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
-
 			mockPrismaCreate.mockResolvedValue({
 				id: "profile-id",
 				userAuthId: "test-user-id",
 			});
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
 			try {
-				await confirmAndSaveProfile(undefined, formData);
+				await confirmAndSaveProfile(undefined, new FormData());
 			} catch (_error) {
 				// redirectはthrowする
 			}
@@ -98,33 +121,16 @@ describe("confirmAndSaveProfile", () => {
 		});
 
 		it("成功時にredirect('/')が呼ばれる", async () => {
+			setupCookies(validProfileData);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
-
-			mockPrismaCreate.mockResolvedValue({
-				id: "profile-id",
-			});
-
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
+			mockPrismaCreate.mockResolvedValue({ id: "profile-id" });
 
 			try {
-				await confirmAndSaveProfile(undefined, formData);
+				await confirmAndSaveProfile(undefined, new FormData());
 			} catch (_error) {
 				// redirectはthrowする
 			}
@@ -133,58 +139,47 @@ describe("confirmAndSaveProfile", () => {
 		});
 
 		it("プロフィール画像がある場合、Supabase Storageへアップロードされる", async () => {
+			const tempPath = "temp/test-user-id-123456.png";
+			setupCookies(validProfileData, tempPath);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
 
-			// base64エンコードされた画像データ（簡易的なもの）
-			const base64Image =
-				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
-
-			mockUpload.mockResolvedValue({
-				data: { path: "test-user-id-123456.png" },
+			const mockFileBlob = new Blob(["fake-image-data"], {
+				type: "image/png",
+			});
+			mockDownload.mockResolvedValue({
+				data: mockFileBlob,
 				error: null,
 			});
-
+			mockUpload.mockResolvedValue({
+				data: { path: "profiles/test-user-id/avatar.png" },
+				error: null,
+			});
+			mockRemove.mockResolvedValue({ data: [], error: null });
 			mockGetPublicUrl.mockReturnValue({
 				data: {
-					publicUrl: "https://storage.example.com/test-user-id-123456.png",
+					publicUrl:
+						"https://storage.example.com/profiles/test-user-id/avatar.png",
 				},
 			});
-
-			mockPrismaCreate.mockResolvedValue({
-				id: "profile-id",
-			});
-
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: base64Image,
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
+			mockPrismaCreate.mockResolvedValue({ id: "profile-id" });
 
 			try {
-				await confirmAndSaveProfile(undefined, formData);
+				await confirmAndSaveProfile(undefined, new FormData());
 			} catch (_error) {
 				// redirectはthrowする
 			}
 
+			expect(mockDownload).toHaveBeenCalledWith(tempPath);
 			expect(mockUpload).toHaveBeenCalled();
 			expect(mockPrismaCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: expect.objectContaining({
 						profileImageUrl:
-							"https://storage.example.com/test-user-id-123456.png",
+							"https://storage.example.com/profiles/test-user-id/avatar.png",
 					}),
 				}),
 			);
@@ -193,26 +188,13 @@ describe("confirmAndSaveProfile", () => {
 
 	describe("異常系", () => {
 		it("未認証ユーザーの場合、エラーが返る", async () => {
+			setupCookies(validProfileData);
 			mockGetUser.mockResolvedValue({
 				data: { user: null },
 				error: null,
 			});
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
-			const result = await confirmAndSaveProfile(undefined, formData);
+			const result = await confirmAndSaveProfile(undefined, new FormData());
 
 			expect(result).toEqual({
 				error: "認証が必要です",
@@ -221,30 +203,15 @@ describe("confirmAndSaveProfile", () => {
 		});
 
 		it("DB保存失敗時、詳細なエラーメッセージが返る", async () => {
+			setupCookies(validProfileData);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
-
 			mockPrismaCreate.mockRejectedValue(new Error("Database error"));
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
-			const result = await confirmAndSaveProfile(undefined, formData);
+			const result = await confirmAndSaveProfile(undefined, new FormData());
 
 			expect(result).toEqual({
 				error: "プロフィールの保存に失敗しました: Database error",
@@ -252,33 +219,19 @@ describe("confirmAndSaveProfile", () => {
 		});
 
 		it("プロフィールが既に存在する場合、redirect('/')が呼ばれる", async () => {
+			setupCookies(validProfileData);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue({
 				id: "existing-profile-id",
 				userAuthId: "test-user-id",
 				nickname: "既存ユーザー",
 			});
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
 			try {
-				await confirmAndSaveProfile(undefined, formData);
+				await confirmAndSaveProfile(undefined, new FormData());
 			} catch (_error) {
 				// redirectはthrowする
 			}
@@ -288,28 +241,14 @@ describe("confirmAndSaveProfile", () => {
 		});
 
 		it("生年月日の形式が不正な場合、エラーが返る", async () => {
+			setupCookies({ ...validProfileData, birthday: "invalid-date" });
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "invalid-date",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: "",
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
-			const result = await confirmAndSaveProfile(undefined, formData);
+			const result = await confirmAndSaveProfile(undefined, new FormData());
 
 			expect(result).toEqual({
 				error: "生年月日の形式が不正です",
@@ -322,43 +261,34 @@ describe("confirmAndSaveProfile", () => {
 				.spyOn(console, "error")
 				.mockImplementation(() => {});
 
+			const tempPath = "temp/test-user-id-123456.png";
+			setupCookies(validProfileData, tempPath);
 			mockGetUser.mockResolvedValue({
 				data: { user: { id: "test-user-id" } },
 				error: null,
 			});
-
 			mockPrismaFindUnique.mockResolvedValue(null);
 
-			const base64Image =
-				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
-
+			const mockFileBlob = new Blob(["fake-image-data"], {
+				type: "image/png",
+			});
+			mockDownload.mockResolvedValue({
+				data: mockFileBlob,
+				error: null,
+			});
 			mockUpload.mockResolvedValue({
 				data: null,
 				error: { message: "Upload failed" },
 			});
 
-			const profileData = {
-				lastName: "山田",
-				firstName: "太郎",
-				nickname: "やまちゃん",
-				birthday: "1990-01-01",
-				gender: "male",
-				prefecture: "東京都",
-				profileImageUrl: base64Image,
-				bio: "",
-			};
-
-			const formData = new FormData();
-			formData.append("profileData", JSON.stringify(profileData));
-
-			const result = await confirmAndSaveProfile(undefined, formData);
+			const result = await confirmAndSaveProfile(undefined, new FormData());
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				expect.stringContaining("画像アップロードエラー"),
+				expect.stringContaining("アップロードエラー"),
 				expect.anything(),
 			);
 			expect(result).toEqual({
-				error: "画像のアップロードに失敗しました: Upload failed",
+				error: "画像の保存に失敗しました",
 			});
 			expect(mockPrismaCreate).not.toHaveBeenCalled();
 

--- a/apps/web/src/app/signup/profile/profile-form.test.tsx
+++ b/apps/web/src/app/signup/profile/profile-form.test.tsx
@@ -162,14 +162,17 @@ describe("ProfileForm", () => {
 
 			const imageInput = screen.getByLabelText("プロフィール画像（任意）");
 			expect(imageInput).toHaveAttribute("type", "file");
-			expect(imageInput).toHaveAttribute("accept", "image/*");
+			expect(imageInput).toHaveAttribute(
+				"accept",
+				"image/jpeg,image/png,image/webp",
+			);
 		});
 
 		it("画像サイズのヒントが表示される", () => {
 			render(<ProfileForm />);
 
 			expect(
-				screen.getByText("推奨: 正方形の画像、最大5MB"),
+				screen.getByText("推奨: 正方形の画像、最大5MB、JPEG/PNG/WebP形式"),
 			).toBeInTheDocument();
 		});
 	});


### PR DESCRIPTION
## Summary
- `apps/web` の新規登録系UT（Vitest）3ファイル/11テストの失敗を修正
- テストコードが古い仕様を期待していた箇所を、現在の実装に合わせて更新

Closes #208

## 変更内容

### `actions.test.ts`（1テスト修正）
- `emailRedirectTo` の正規表現を `/auth/callback?next=/signup/profile` 経由のURLパターンに修正

### `profile-form.test.tsx`（2テスト修正）
- `accept` 属性の期待値を `"image/jpeg,image/png,image/webp"` に変更
- ヒントテキストの期待値を `"推奨: 正方形の画像、最大5MB、JPEG/PNG/WebP形式"` に変更

### `confirm/actions.test.ts`（8テスト全面修正）
- Cookieベースのデータ取得（`profile_data`, `profile_image_path`）に合わせてモック構造を変更
- Storage の download → upload → remove → getPublicUrl フローに対応
- FormData 経由の profileData 送信を Cookie 設定に置き換え

## Test plan
- [x] `pnpm --filter web test -- --run` で 18ファイル/219テスト全件パス
- [x] `pnpm format` / `pnpm lint` クリア
- [ ] CIのtestジョブが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)