### PR TITLE
fix: E2Eテストのcreate-next-app雛形残骸（example.spec.ts）を削除

### DIFF
--- a/apps/web/e2e/example.spec.ts
+++ b/apps/web/e2e/example.spec.ts
@@ -1,6 +1,0 @@
-import { expect, test } from "@playwright/test";
-
-test("homepage should load", async ({ page }) => {
-	await page.goto("/");
-	await expect(page).toHaveTitle(/Next.js/i);
-});


### PR DESCRIPTION
## Summary

- `apps/web/e2e/example.spec.ts` は `create-next-app` 生成時の雛形が残置されたもので、Beer Salon の実装と無関係なタイトル `/Next.js/i` を期待していたため `pnpm e2e:web` 実行時に必ず失敗するテスト負債だった
- 当該テストは `@smoke` タグを持たないため CI スモークは緑だったが、`pnpm e2e:web`（全件実行）では確実に失敗するため削除する
- `/` の挙動は既存の `auth-redirect.spec.ts`（未認証→ `/login` リダイレクト）と `bar-search.spec.ts`（認証済みの検索ページ表示）でカバー済みのため、代替テストの追加は不要

## 影響範囲

- 削除: `apps/web/e2e/example.spec.ts`（1ファイル / 6行）
- 他のE2Eテスト / `playwright.config.ts` / `package.json` のスクリプト / 設計ドキュメントへの影響なし

## Test plan

- [x] `pnpm exec playwright test --list` に `homepage should load` が含まれないことを確認
- [x] `grep -r "homepage should load" apps/web/e2e/` が0件であることを確認
- [x] `pnpm e2e:smoke` がスモーク7本（web 5本 + admin 2本）green
- [x] `pnpm format` で差分なし
- [x] `pnpm lint` でエラーなし

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)