### PR TITLE
fix: E2Eテストの不正なPlaywrightセレクタ構文を修正する (#216)

### DIFF
--- a/apps/web/e2e/favorite-bars.spec.ts
+++ b/apps/web/e2e/favorite-bars.spec.ts
@@ -71,7 +71,8 @@ test.describe("お気に入りバー一覧", () => {
 		if ((await barCard.count()) > 0) {
 			const hasLocation =
 				(await barCard
-					.locator('[data-testid="location"], .location, text=/都|県|市|町|村/')
+					.locator('[data-testid="location"], .location')
+					.or(barCard.getByText(/都|県|市|町|村/))
 					.count()) > 0;
 
 			expect(hasLocation || true).toBe(true);

--- a/apps/web/e2e/history.spec.ts
+++ b/apps/web/e2e/history.spec.ts
@@ -76,7 +76,8 @@ test.describe("閲覧履歴", () => {
 		if ((await barCard.count()) > 0) {
 			const hasLocation =
 				(await barCard
-					.locator('[data-testid="location"], .location, text=/都|県|市|町|村/')
+					.locator('[data-testid="location"], .location')
+					.or(barCard.getByText(/都|県|市|町|村/))
 					.count()) > 0;
 
 			expect(hasLocation || true).toBe(true);

--- a/apps/web/e2e/notifications.spec.ts
+++ b/apps/web/e2e/notifications.spec.ts
@@ -90,9 +90,8 @@ test.describe("通知一覧", () => {
 		if ((await notification.count()) > 0) {
 			const hasDate =
 				(await notification
-					.locator(
-						'time, [data-testid="notification-date"], text=/分前|時間前|日前/',
-					)
+					.locator('time, [data-testid="notification-date"]')
+					.or(notification.getByText(/分前|時間前|日前/))
 					.count()) > 0;
 
 			expect(hasDate || true).toBe(true);

--- a/apps/web/e2e/post-like.spec.ts
+++ b/apps/web/e2e/post-like.spec.ts
@@ -122,9 +122,9 @@ test.describe("いいね機能", () => {
 			.first();
 
 		if ((await postCard.count()) > 0) {
-			const likeCount = postCard.locator(
-				'[data-testid="like-count"], .like-count, text=/\\d+.*いいね/',
-			);
+			const likeCount = postCard
+				.locator('[data-testid="like-count"], .like-count')
+				.or(postCard.getByText(/\d+.*いいね/));
 
 			const hasLikeCount = (await likeCount.count()) > 0;
 			expect(hasLikeCount || true).toBe(true);

--- a/apps/web/e2e/user-mypage.spec.ts
+++ b/apps/web/e2e/user-mypage.spec.ts
@@ -23,12 +23,12 @@ test.describe("マイページ", () => {
 	test("フォロー数とフォロワー数が表示される", async ({ page }) => {
 		await page.goto("/mypage");
 
-		const followingCount = page.locator(
-			'[data-testid="following-count"], a[href*="following"], text=/フォロー|Following/',
-		);
-		const followersCount = page.locator(
-			'[data-testid="followers-count"], a[href*="followers"], text=/フォロワー|Followers/',
-		);
+		const followingCount = page
+			.locator('[data-testid="following-count"], a[href*="following"]')
+			.or(page.getByText(/フォロー|Following/));
+		const followersCount = page
+			.locator('[data-testid="followers-count"], a[href*="followers"]')
+			.or(page.getByText(/フォロワー|Followers/));
 
 		const hasFollowingCount = (await followingCount.count()) > 0;
 		const hasFollowersCount = (await followersCount.count()) > 0;

--- a/apps/web/e2e/user-profile.spec.ts
+++ b/apps/web/e2e/user-profile.spec.ts
@@ -24,12 +24,12 @@ test.describe("他ユーザープロフィール", () => {
 	test("フォロー数とフォロワー数が表示される", async ({ page }) => {
 		await page.goto("/users/test-user-id");
 
-		const followingCount = page.locator(
-			'[data-testid="following-count"], a[href*="following"], text=/フォロー|Following/',
-		);
-		const followersCount = page.locator(
-			'[data-testid="followers-count"], a[href*="followers"], text=/フォロワー|Followers/',
-		);
+		const followingCount = page
+			.locator('[data-testid="following-count"], a[href*="following"]')
+			.or(page.getByText(/フォロー|Following/));
+		const followersCount = page
+			.locator('[data-testid="followers-count"], a[href*="followers"]')
+			.or(page.getByText(/フォロワー|Followers/));
 
 		const hasFollowingCount = (await followingCount.count()) > 0;
 		const hasFollowersCount = (await followersCount.count()) > 0;


### PR DESCRIPTION
## Summary

- `page.locator()` に渡す文字列に `text=/regex/` を CSS セレクタとカンマで混在させると、`Unexpected token "="` の構文エラーでテストが即死していたバグを修正
- CSS セレクタ部分は `locator()`、正規表現マッチは `getByText()` に分離し、`.or()` で結合する形へ書き直し
- Issue 明示の 2 ファイルに加え、`grep -rn 'text=/' apps/web/e2e/` で全件確認した結果見つかった同種の構文ミス 4 ファイルもまとめて修正（後追いPR防止）

## 修正対象（6ファイル / 8箇所）

### Issue 明示の修正対象

- `apps/web/e2e/user-mypage.spec.ts` (L26-31): フォロー数 / フォロワー数のロケータ
- `apps/web/e2e/user-profile.spec.ts` (L27-31): フォロー数 / フォロワー数のロケータ

### grep 全件確認で追加発覚した修正対象

- `apps/web/e2e/notifications.spec.ts` (L94): 通知日時のロケータ
- `apps/web/e2e/history.spec.ts` (L79): 住所のロケータ
- `apps/web/e2e/favorite-bars.spec.ts` (L74): 住所のロケータ
- `apps/web/e2e/post-like.spec.ts` (L126): いいね数のロケータ

## 修正パターン

**Before（NG）**:
\`\`\`ts
page.locator('[data-testid="following-count"], a[href*="following"], text=/フォロー|Following/')
\`\`\`

**After（OK）**:
\`\`\`ts
page
  .locator('[data-testid="following-count"], a[href*="following"]')
  .or(page.getByText(/フォロー|Following/))
\`\`\`

## Test plan

- [x] `grep -rn 'text=/' apps/web/e2e/` で残存する `text=/` がすべて単独利用形式（valid）であることを確認
- [x] 修正対象 6 ファイル合計 53 テストに対して `playwright test --list` で構文解析が成功することを確認（`Unexpected token "="` エラー 0 件）
- [x] `pnpm format` 成功
- [x] `pnpm lint` 成功（エラー・警告なし）
- [ ] CI の E2E スモークが構文エラーなく評価フェーズまで到達すること

Closes #216