### PR TITLE
test: Integration テスト層の基盤整備 + togglePostLike (#229 PR1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,30 @@ jobs:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
       - run: pnpm test
 
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54422/postgres
+      DIRECT_URL: postgresql://postgres:postgres@127.0.0.1:54422/postgres
+      E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Generate Prisma Client
+        run: pnpm exec prisma generate --schema=prisma/schema.prisma
+      - name: Setup E2E database
+        uses: ./.github/actions/setup-db
+        with:
+          e2e-test-user-password: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+      - name: Run integration tests
+        run: pnpm test:integration
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,6 +12,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"test": "vitest run",
+		"test:integration": "vitest run --config vitest.integration.config.ts --passWithNoTests",
 		"e2e": "playwright test",
 		"test:e2e": "playwright test",
 		"test:ui": "playwright test --ui",

--- a/apps/admin/src/test/integration-setup.ts
+++ b/apps/admin/src/test/integration-setup.ts
@@ -1,0 +1,43 @@
+const REQUIRED_ENV_VARS = [
+	"DATABASE_URL",
+	"NEXT_PUBLIC_SUPABASE_URL",
+	"NEXT_PUBLIC_SUPABASE_ANON_KEY",
+	"SUPABASE_SERVICE_ROLE_KEY",
+] as const;
+
+const SETUP_HINT = [
+	"",
+	"[integration-setup] Supabase ローカルへの疎通確認に失敗しました。",
+	"以下を順に実行してから再試行してください:",
+	"  1. supabase start",
+	"  2. pnpm e2e:setup",
+	"  3. pnpm test:integration",
+	"",
+].join("\n");
+
+// Why not: admin 側は Prisma を直接使う Server Action がまだ無いため、最小限の HTTP 疎通のみ確認。
+// PR2 以降で admin の Integration テストが必要になったら、web の integration-setup.ts と同等の
+// Prisma 疎通確認を追加する。
+export async function setup(): Promise<void> {
+	const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+	if (missing.length > 0) {
+		throw new Error(
+			`${SETUP_HINT}\n環境変数が未設定です: ${missing.join(", ")}`,
+		);
+	}
+
+	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+	try {
+		const res = await fetch(`${supabaseUrl}/auth/v1/health`, {
+			headers: {
+				apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+			},
+		});
+		if (!res.ok) {
+			throw new Error(`Supabase health check failed: HTTP ${res.status}`);
+		}
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new Error(`${SETUP_HINT}\nSupabase health check error: ${reason}`);
+	}
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	test: {
 		environment: "node",
 		globals: true,
-		exclude: ["node_modules", "tests", ".next"],
+		exclude: ["node_modules", "tests", ".next", "**/*.integration.test.ts"],
 	},
 	resolve: {
 		alias: {

--- a/apps/admin/vitest.integration.config.ts
+++ b/apps/admin/vitest.integration.config.ts
@@ -1,0 +1,27 @@
+import { resolve } from "node:path";
+import { config as loadDotenv } from "dotenv";
+import { defineConfig } from "vitest/config";
+
+// Why not: vitest run は mode=test で動くため、Vite のデフォルトでは .env.test* しか読まれない。
+// .env.local に集約された Supabase 接続情報を明示的にロードする。
+loadDotenv({ path: resolve(__dirname, ".env.local") });
+
+// Why not: admin 側でも UT と Integration を別 config に分離。
+// 現時点では Integration テスト本体は追加しないが、PR2 以降で追加可能な土台を用意する。
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["**/*.integration.test.ts"],
+		exclude: ["node_modules", ".next", "tests"],
+		globalSetup: ["./src/test/integration-setup.ts"],
+		testTimeout: 30_000,
+		hookTimeout: 30_000,
+		globals: true,
+		fileParallelism: false,
+	},
+	resolve: {
+		alias: {
+			"@": resolve(__dirname, "./src"),
+		},
+	},
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
 		"format": "biome format --write .",
 		"test": "vitest",
 		"test:coverage": "vitest --coverage",
+		"test:integration": "vitest run --config vitest.integration.config.ts",
 		"e2e": "playwright test",
 		"reset:modules": "rm -rf .next node_modules && pnpm install"
 	},

--- a/apps/web/src/actions/post.integration.test.ts
+++ b/apps/web/src/actions/post.integration.test.ts
@@ -1,0 +1,162 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+// Why not: createClient() は cookies() に依存しブラウザ context が必要。
+// Integration では「Cookie context」だけ差し替え、DB I/O は実 Supabase にそのまま流す。
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+// Why not: revalidatePath は Next.js のキャッシュ機構に依存し、テスト環境ではエラーになるため no-op 化。
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+// Why not: vi.mock のホイスト後に import すると mock が効くため、import 順を明示するために動的 import 風に整理。
+import { togglePostLike } from "@/actions/post";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser;
+let bob: TestAuthUser;
+let testBarId: bigint;
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	bob = await createTestAuthUser(prisma);
+	const bar = await createTestBar(prisma);
+	testBarId = bar.id;
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId, bob.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("togglePostLike (Integration)", () => {
+	it("他人の投稿にいいねを付けると post_likes が追加され、like_count が +1、通知が作成される", async () => {
+		const post = await prisma.post.create({
+			data: {
+				userId: bob.userProfileId,
+				barId: testBarId,
+				body: "it-post-body-by-bob",
+			},
+		});
+
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		const liked = await togglePostLike(post.id);
+		expect(liked).toBe(true);
+
+		const likeRow = await prisma.postLike.findUnique({
+			where: {
+				postId_userId: { postId: post.id, userId: alice.userProfileId },
+			},
+		});
+		expect(likeRow).not.toBeNull();
+
+		const updated = await prisma.post.findUniqueOrThrow({
+			where: { id: post.id },
+		});
+		expect(updated.likeCount).toBe(1);
+
+		const notifications = await prisma.notification.findMany({
+			where: { userId: bob.userProfileId, type: "post_liked" },
+		});
+		expect(notifications).toHaveLength(1);
+		expect(notifications[0].message).toContain(alice.nickname);
+		expect(notifications[0].linkUrl).toBe("/timeline");
+	});
+
+	it("自分の投稿にいいねを付けても通知は作成されない", async () => {
+		const post = await prisma.post.create({
+			data: {
+				userId: alice.userProfileId,
+				barId: testBarId,
+				body: "it-post-body-by-alice",
+			},
+		});
+
+		const beforeNotificationCount = await prisma.notification.count({
+			where: { userId: alice.userProfileId, type: "post_liked" },
+		});
+
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		const liked = await togglePostLike(post.id);
+		expect(liked).toBe(true);
+
+		const likeRow = await prisma.postLike.findUnique({
+			where: {
+				postId_userId: { postId: post.id, userId: alice.userProfileId },
+			},
+		});
+		expect(likeRow).not.toBeNull();
+
+		const afterNotificationCount = await prisma.notification.count({
+			where: { userId: alice.userProfileId, type: "post_liked" },
+		});
+		expect(afterNotificationCount).toBe(beforeNotificationCount);
+	});
+
+	it("既にいいね済みの投稿でトグルすると post_likes が削除され、like_count が -1 される", async () => {
+		const post = await prisma.post.create({
+			data: {
+				userId: bob.userProfileId,
+				barId: testBarId,
+				body: "it-post-body-for-untoggle",
+				likeCount: 0,
+			},
+		});
+
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		await togglePostLike(post.id);
+		const afterCreate = await prisma.post.findUniqueOrThrow({
+			where: { id: post.id },
+		});
+		expect(afterCreate.likeCount).toBe(1);
+
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		const liked = await togglePostLike(post.id);
+		expect(liked).toBe(false);
+
+		const likeRow = await prisma.postLike.findUnique({
+			where: {
+				postId_userId: { postId: post.id, userId: alice.userProfileId },
+			},
+		});
+		expect(likeRow).toBeNull();
+
+		const afterDelete = await prisma.post.findUniqueOrThrow({
+			where: { id: post.id },
+		});
+		expect(afterDelete.likeCount).toBe(0);
+	});
+});

--- a/apps/web/src/test/integration-helpers.ts
+++ b/apps/web/src/test/integration-helpers.ts
@@ -1,0 +1,134 @@
+import { faker } from "@faker-js/faker";
+import { createClient } from "@supabase/supabase-js";
+import type { PrismaClient } from "@/generated/prisma";
+
+// Why not: 衝突回避のため UUID にすると人間が grep しづらいので、固定接頭辞 + faker のランダム要素を使う。
+// クリーンアップは「`it-` 接頭辞の付いたものだけ消す」ポリシーで担保。
+export const INTEGRATION_TEST_PREFIX = "it-";
+
+export type TestAuthUser = {
+	authUserId: string;
+	email: string;
+	userProfileId: string;
+	nickname: string;
+};
+
+function buildSupabaseAdmin() {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+	if (!url || !serviceRoleKey) {
+		throw new Error(
+			"Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY",
+		);
+	}
+	return createClient(url, serviceRoleKey, {
+		auth: { autoRefreshToken: false, persistSession: false },
+	});
+}
+
+export async function createTestAuthUser(
+	prisma: PrismaClient,
+): Promise<TestAuthUser> {
+	const admin = buildSupabaseAdmin();
+	const suffix = faker.string.alphanumeric(8).toLowerCase();
+	const email = `${INTEGRATION_TEST_PREFIX}${suffix}@example.test`;
+	const nickname = `${INTEGRATION_TEST_PREFIX}${suffix}`;
+
+	const { data, error } = await admin.auth.admin.createUser({
+		email,
+		password: faker.internet.password({ length: 16 }),
+		email_confirm: true,
+	});
+	if (error || !data.user) {
+		throw new Error(
+			`Failed to create test auth user: ${error?.message ?? "unknown"}`,
+		);
+	}
+
+	const profile = await prisma.userProfile.create({
+		data: {
+			userAuthId: data.user.id,
+			lastName: `${INTEGRATION_TEST_PREFIX}last`,
+			firstName: `${INTEGRATION_TEST_PREFIX}first`,
+			nickname,
+			birthday: new Date("1990-01-01"),
+			gender: "other",
+			prefecture: "東京都",
+		},
+	});
+
+	return {
+		authUserId: data.user.id,
+		email,
+		userProfileId: profile.id,
+		nickname,
+	};
+}
+
+export async function createTestBar(
+	prisma: PrismaClient,
+	overrides: { name?: string } = {},
+): Promise<{ id: bigint; name: string }> {
+	const suffix = faker.string.alphanumeric(8).toLowerCase();
+	const name = overrides.name ?? `${INTEGRATION_TEST_PREFIX}bar-${suffix}`;
+	const bar = await prisma.bar.create({
+		data: {
+			name,
+			prefecture: "東京都",
+			city: "渋谷区",
+			addressLine1: `${INTEGRATION_TEST_PREFIX}address-${suffix}`,
+			description: `${INTEGRATION_TEST_PREFIX}description`,
+		},
+	});
+	return { id: bar.id, name: bar.name };
+}
+
+export type CleanupOptions = {
+	authUserIds?: string[];
+};
+
+// Why not: 個別 ID 指定削除を基本にする (グローバル DELETE WHERE name LIKE 'it-%' は、
+// 並列実行や seed データ侵食の事故が起きるため)。
+// 呼び出し側で作成順の逆順で個別に消すのが安全だが、本ヘルパでは
+// 「it- 接頭辞の付いた user / bar / それらに紐づく派生」のみ責任範囲とする。
+export async function cleanupTestData(
+	prisma: PrismaClient,
+	options: CleanupOptions = {},
+): Promise<void> {
+	const admin = buildSupabaseAdmin();
+
+	// it- 接頭辞の付いた user_profiles に紐づく派生をまとめて消す。
+	const profiles = await prisma.userProfile.findMany({
+		where: {
+			nickname: { startsWith: INTEGRATION_TEST_PREFIX },
+		},
+		select: { id: true, userAuthId: true },
+	});
+	const profileIds = profiles.map((p) => p.id);
+
+	if (profileIds.length > 0) {
+		await prisma.notification.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.postLike.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.post.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.userProfile.deleteMany({
+			where: { id: { in: profileIds } },
+		});
+	}
+
+	await prisma.bar.deleteMany({
+		where: { name: { startsWith: INTEGRATION_TEST_PREFIX } },
+	});
+
+	const targetAuthIds =
+		options.authUserIds ?? profiles.map((p) => p.userAuthId);
+	for (const authUserId of targetAuthIds) {
+		// Why not: 失敗を無視して進める。auth.users が既に削除済みでも、後続テストには影響しない。
+		await admin.auth.admin.deleteUser(authUserId).catch(() => undefined);
+	}
+}

--- a/apps/web/src/test/integration-setup.ts
+++ b/apps/web/src/test/integration-setup.ts
@@ -1,0 +1,58 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { PrismaClient } from "@/generated/prisma";
+
+const REQUIRED_ENV_VARS = [
+	"DATABASE_URL",
+	"NEXT_PUBLIC_SUPABASE_URL",
+	"NEXT_PUBLIC_SUPABASE_ANON_KEY",
+	"SUPABASE_SERVICE_ROLE_KEY",
+] as const;
+
+const SETUP_HINT = [
+	"",
+	"[integration-setup] Supabase ローカルへの疎通確認に失敗しました。",
+	"以下を順に実行してから再試行してください:",
+	"  1. supabase start",
+	"  2. pnpm e2e:setup   # seed.e2e.sql 投入 + Auth テストユーザー作成",
+	"  3. pnpm test:integration",
+	"",
+].join("\n");
+
+export async function setup(): Promise<void> {
+	const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+	if (missing.length > 0) {
+		throw new Error(
+			`${SETUP_HINT}\n環境変数が未設定です: ${missing.join(", ")}`,
+		);
+	}
+
+	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+
+	try {
+		const res = await fetch(`${supabaseUrl}/auth/v1/health`, {
+			headers: {
+				apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+			},
+		});
+		if (!res.ok) {
+			throw new Error(`Supabase health check failed: HTTP ${res.status}`);
+		}
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new Error(`${SETUP_HINT}\nSupabase health check error: ${reason}`);
+	}
+
+	const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+	const adapter = new PrismaPg(pool);
+	const prisma = new PrismaClient({ adapter });
+	try {
+		await prisma.$queryRaw`SELECT 1`;
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new Error(`${SETUP_HINT}\nPrisma connectivity error: ${reason}`);
+	} finally {
+		await prisma.$disconnect();
+		await pool.end();
+	}
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: ["./src/test/setup.ts"],
 		globals: true,
-		exclude: ["node_modules", "e2e", ".next"],
+		exclude: ["node_modules", "e2e", ".next", "**/*.integration.test.ts"],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "json"],

--- a/apps/web/vitest.integration.config.ts
+++ b/apps/web/vitest.integration.config.ts
@@ -1,0 +1,30 @@
+import { resolve } from "node:path";
+import { config as loadDotenv } from "dotenv";
+import { defineConfig } from "vitest/config";
+
+// Why not: vitest run は mode=test で動くため、Vite のデフォルトでは .env.test* しか読まれない。
+// Beer Salon では Supabase 接続情報を .env.local に集約しているため、明示的に読み込む。
+// (apps/web/.env.local に NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / DATABASE_URL が定義済み)
+loadDotenv({ path: resolve(__dirname, ".env.local") });
+
+// Why not: UT 側 (vitest.config.ts) と 1 ファイルにまとめて projects 構成にすることも検討したが、
+// jsdom 環境を引き継ぐと Prisma + Supabase が動かない・globalSetup が衝突するため別 config に分離。
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["**/*.integration.test.ts"],
+		exclude: ["node_modules", ".next", "e2e"],
+		globalSetup: ["./src/test/integration-setup.ts"],
+		testTimeout: 30_000,
+		hookTimeout: 30_000,
+		globals: true,
+		// Why not: 並列実行すると `it-` 接頭辞で一意化していてもクリーンアップ間の競合が
+		// 出るケースがあるため、まずは 1 プロセスで直列化する。後続 PR でテストが増えたら見直す。
+		fileParallelism: false,
+	},
+	resolve: {
+		alias: {
+			"@": resolve(__dirname, "./src"),
+		},
+	},
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
 		"lint": "turbo run lint",
 		"format": "turbo run format",
 		"test": "turbo run test",
+		"test:unit": "turbo run test",
+		"test:integration": "turbo run test:integration",
 		"dev:web": "pnpm --filter @beersalon/web dev",
 		"dev:admin": "pnpm --filter @beersalon/admin dev",
 		"e2e:web": "pnpm --filter @beersalon/web e2e",

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,17 @@
 		},
 		"lint": {},
 		"test": {},
+		"test:integration": {
+			"dependsOn": ["db:generate"],
+			"cache": false,
+			"passThroughEnv": [
+				"DATABASE_URL",
+				"DIRECT_URL",
+				"NEXT_PUBLIC_SUPABASE_URL",
+				"NEXT_PUBLIC_SUPABASE_ANON_KEY",
+				"SUPABASE_SERVICE_ROLE_KEY"
+			]
+		},
 		"format": {
 			"cache": false
 		}


### PR DESCRIPTION
## 概要

Issue #229「テストピラミッド原則に従ったテスト戦略の整備（Integration層の導入）」の **PR1（基盤整備 + togglePostLike の Integration テスト 1 本）** です。

現状欠落している **Integration Test 層**（実 Supabase ローカルに対する Server Action / Prisma クエリ検証）を導入し、最初の 1 本として \`togglePostLike\` を実 DB で検証します。残り 7 本の追加とドキュメント更新は PR2 / PR3 に分割します。

### PR1 のスコープ（このPRに含まれるもの）

- Integration テスト基盤一式
- \`togglePostLike\` の Integration テスト 3 ケース
- CI ワークフローへの \`integration\` ジョブ追加

### PR1 のスコープ外（後続PRで対応）

- PR2: 残り 7 本の Integration テスト追加（\`createPost\` / \`toggleFavoriteBar\` / \`toggleFollow\` / \`getUserCoupon\` / タイムライン / 検索 / 店舗詳細 include）
- PR3: ドキュメント更新（\`docs/e2e.md\` / \`.claude/rules/testing.md\` / \`README.md\`）と既存 UT の Integration への再分類

## 変更内容

### 追加ファイル

| ファイル | 内容 |
|---|---|
| \`apps/web/vitest.integration.config.ts\` | Integration 用 Vitest 設定。\`environment: node\`、\`include: ['**/*.integration.test.ts']\`、\`globalSetup\`、\`fileParallelism: false\` |
| \`apps/admin/vitest.integration.config.ts\` | 同上（admin 側、今回はテスト本体なし） |
| \`apps/web/src/test/integration-setup.ts\` | globalSetup。Supabase ローカルへの HTTP 疎通 + Prisma \`SELECT 1\` 疎通確認。失敗時は \`pnpm e2e:setup\` を案内 |
| \`apps/admin/src/test/integration-setup.ts\` | 同上（admin 側、最小限） |
| \`apps/web/src/test/integration-helpers.ts\` | \`createTestAuthUser()\` / \`createTestBar()\` / \`cleanupTestData()\`。\`it-\` 接頭辞 + faker でテストデータを一意化 |
| \`apps/web/src/actions/post.integration.test.ts\` | \`togglePostLike\` の Integration テスト 3 ケース |

### 既存ファイルの変更

| ファイル | 変更 |
|---|---|
| \`apps/web/vitest.config.ts\` / \`apps/admin/vitest.config.ts\` | \`exclude\` に \`**/*.integration.test.ts\` を追加 |
| \`apps/web/package.json\` / \`apps/admin/package.json\` | \`test:integration\` スクリプト追加（admin は \`--passWithNoTests\`） |
| ルート \`package.json\` | \`test:unit\` / \`test:integration\` turbo タスクを追加 |
| \`turbo.json\` | \`test:integration\` タスク定義を追加（\`dependsOn: db:generate\`、\`passThroughEnv\` で DB/Supabase 系を通す） |
| \`.github/workflows/ci.yml\` | \`integration\` ジョブを新設（\`.github/actions/setup-db\` を再利用） |

## Integration テスト本体（3 ケース）

\`apps/web/src/actions/post.ts\` の \`togglePostLike\` を実 Supabase ローカル（54421）に接続して検証:

1. **他人の投稿にいいね** → \`post_likes\` 行追加 + \`posts.like_count\` が +1 + \`notifications\` に \`post_liked\` が追加される
2. **自分の投稿にいいね** → \`post_likes\` は追加されるが \`notifications\` は作成されない
3. **既にいいね済みの投稿でトグル** → \`post_likes\` 行削除 + \`like_count\` が -1 される

- すべて \`it-\` 接頭辞 + faker でテストデータを生成
- \`afterAll\` で \`it-\` 接頭辞のレコードのみクリーンアップ
- \`auth.users\` は Supabase Admin API 経由で作成・削除（直接 SQL 触らない）

## 設計上の判断

- **Cookie 依存の \`createClient\` のみモック化**: \`togglePostLike\` は内部で \`cookies()\` 経由の Supabase クライアントを使う。Cookie コンテキスト無しの Node 環境では動かないため、\`auth.getUser\` だけ差し替え、それ以外の DB I/O は実 Supabase にそのまま流す。\`prisma\` は一切モックしない
- **\`fileParallelism: false\`**: \`it-\` 接頭辞で一意化していても、\`afterAll\` のクリーンアップが他テストの \`beforeAll\` と競合するリスクがあるため、まずは 1 プロセス直列実行。並列化は PR2 でテストが増えた時点で再検討
- **\`.env.local\` の明示ロード**: \`vitest run\` は \`mode=test\` で動くため、Vite デフォルトでは \`.env.test*\` しか読まれない。Beer Salon は Supabase 接続情報を \`.env.local\` に集約しているため、\`dotenv\` で明示ロード
- **\`PR3 で\` 廃止予定の \`pnpm test\`**: 既存の \`pnpm test\` は維持し、別途 \`pnpm test:unit\` / \`pnpm test:integration\` を追加。後続 PR で運用ガイドラインを更新する際に \`test\` をエイリアスに整理する

## 動作確認

### \`pnpm test:unit\`（既存 UT が壊れていないこと）

\`\`\`
Test Files  20 passed (20)
     Tests  233 passed (233)
\`\`\`

### \`pnpm test:integration\`（新規 3 ケース）

\`\`\`
✓ src/actions/post.integration.test.ts (3 tests)
  ✓ 他人の投稿にいいねを付けると post_likes が追加され、like_count が +1、通知が作成される
  ✓ 自分の投稿にいいねを付けても通知は作成されない
  ✓ 既にいいね済みの投稿でトグルすると post_likes が削除され、like_count が -1 される

Test Files  1 passed (1)
     Tests  3 passed (3)
\`\`\`

連続実行しても緑（冪等性確認済み）。実行後の DB を確認し、\`it-\` 接頭辞の \`user_profiles\` / \`bars\` / \`notifications\` がすべて 0 件にクリーンアップされていることを目視確認済み。

### ローカル実行手順

\`\`\`bash
supabase start
pnpm e2e:setup
pnpm test:integration
\`\`\`

## 破壊的変更

- \`package.json\` / \`turbo.json\` を変更したため、CI 上では \`pnpm install\` が必要
- 各開発者のローカルでも \`pnpm install\` の再実行を推奨（既存スクリプトには影響なし）

## 関連

- Refs #229（このPRでは Close しない。Close は PR3 で実施）
- 後続 PR:
  - PR2: 残り 7 本の Integration テスト追加
  - PR3: ドキュメント更新（\`docs/e2e.md\` / \`.claude/rules/testing.md\` / \`README.md\`）と既存 UT 再分類、Issue Close

🤖 Generated with [Claude Code](https://claude.com/claude-code)