### PR TITLE
test: Integration テスト 7 本を追加 (#229 PR2)

### DIFF
--- a/apps/web/src/actions/bar-detail.integration.test.ts
+++ b/apps/web/src/actions/bar-detail.integration.test.ts
@@ -1,0 +1,219 @@
+import { faker } from "@faker-js/faker";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	createTestCoupon,
+	INTEGRATION_TEST_PREFIX,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+import { getBarDetail } from "@/actions/bar";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser;
+let testBarId: bigint;
+let createdBreweryId: bigint;
+let createdBeerId: bigint;
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	const bar = await createTestBar(prisma);
+	testBarId = bar.id;
+
+	// barImages: 基本情報タブ
+	await prisma.barImage.create({
+		data: {
+			barId: testBarId,
+			imageType: "exterior",
+			imageUrl: "https://example.test/it-exterior.jpg",
+			sortOrder: 0,
+		},
+	});
+
+	// openingHours: 基本情報タブ
+	await prisma.barOpeningHour.create({
+		data: {
+			barId: testBarId,
+			dayOfWeek: 0,
+			openTime: new Date("1970-01-01T17:00:00Z"),
+			closeTime: new Date("1970-01-01T23:00:00Z"),
+			sortOrder: 0,
+		},
+	});
+
+	// barPaymentMethods: 基本情報タブ (seed 済みの "現金" を 1 つ紐付ける)
+	const cashMethod = await prisma.paymentMethod.findFirstOrThrow({
+		where: { name: "現金" },
+	});
+	await prisma.barPaymentMethod.create({
+		data: { barId: testBarId, paymentMethodId: cashMethod.id },
+	});
+
+	// メニュータブ: beerMenu と foodMenu
+	const beerCategory = await prisma.beerCategory.findFirstOrThrow({
+		where: { isActive: true },
+	});
+	const brewery = await prisma.brewery.create({
+		data: {
+			name: `${INTEGRATION_TEST_PREFIX}brewery-${faker.string.alphanumeric(6).toLowerCase()}`,
+		},
+	});
+	createdBreweryId = brewery.id;
+	const beer = await prisma.beer.create({
+		data: {
+			name: `${INTEGRATION_TEST_PREFIX}beer-${faker.string.alphanumeric(6).toLowerCase()}`,
+			beerCategoryId: beerCategory.id,
+			breweryId: brewery.id,
+		},
+	});
+	createdBeerId = beer.id;
+	const beerMenu = await prisma.barBeerMenu.create({
+		data: { barId: testBarId, beerId: beer.id },
+	});
+	await prisma.barBeerMenuSize.create({
+		data: {
+			barBeerMenuId: beerMenu.id,
+			sizeName: "パイント",
+			price: 1000,
+			sortOrder: 0,
+		},
+	});
+	await prisma.barFoodMenu.create({
+		data: {
+			barId: testBarId,
+			name: `${INTEGRATION_TEST_PREFIX}food-menu`,
+			price: 800,
+		},
+	});
+
+	// タグ付けされた投稿タブ: posts + postImages
+	const post = await prisma.post.create({
+		data: {
+			userId: alice.userProfileId,
+			barId: testBarId,
+			body: "it-bar-detail-post",
+		},
+	});
+	await prisma.postImage.create({
+		data: {
+			postId: post.id,
+			imageUrl: "https://example.test/it-post-image.jpg",
+			sortOrder: 0,
+		},
+	});
+
+	// お店からの投稿タブ: articles (status='published', deletedAt=null のみ取得対象)
+	await prisma.article.create({
+		data: {
+			barId: testBarId,
+			title: "it-article-published",
+			body: "it-article-body",
+			status: "published",
+			publishedAt: new Date("2026-01-01T00:00:00.000Z"),
+		},
+	});
+	// draft は取得されないことを確認したいので 1 件作っておく
+	await prisma.article.create({
+		data: {
+			barId: testBarId,
+			title: "it-article-draft",
+			body: "it-article-body-draft",
+			status: "draft",
+		},
+	});
+
+	// クーポンタブ
+	await createTestCoupon(prisma, testBarId, { title: "it-coupon-detail" });
+
+	// イベントタブ (未来日のイベントだけ取得される)
+	await prisma.barEvent.create({
+		data: {
+			barId: testBarId,
+			title: "it-event-future",
+			description: "future event",
+			startDate: new Date("2099-01-01T00:00:00.000Z"),
+			endDate: new Date("2099-01-02T00:00:00.000Z"),
+		},
+	});
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId],
+	});
+	await prisma.beer.deleteMany({ where: { id: createdBeerId } });
+	await prisma.brewery.deleteMany({ where: { id: createdBreweryId } });
+	await prisma.$disconnect();
+});
+
+describe("getBarDetail (Integration)", () => {
+	it("6タブ分のリレーション include を漏れなく取得できる", async () => {
+		// Why not: 実装は currentUserId が null の場合 postLikes を include せず post.postLikes.length で
+		// クラッシュする既知の挙動がある (テストでは実装変更しない方針)。
+		// ここではログイン済みユーザーで getBarDetail を呼び、6 タブ分のリレーション include を網羅検証する。
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		const bar = await getBarDetail(testBarId.toString());
+
+		expect(bar).not.toBeNull();
+		if (!bar) return;
+
+		// 基本情報タブ: barImages / openingHours / paymentMethods
+		expect(bar.barImages.length).toBeGreaterThanOrEqual(1);
+		expect(bar.barImages[0].imageType).toBe("exterior");
+		expect(bar.openingHours.length).toBeGreaterThanOrEqual(1);
+		expect(bar.openingHours[0].dayOfWeek).toBe(0);
+		expect(bar.paymentMethods.length).toBeGreaterThanOrEqual(1);
+		expect(bar.paymentMethods[0].name).toBe("現金");
+
+		// メニュータブ: beerMenus (with sizes/beer/brewery/category) + foodMenus
+		expect(bar.beerMenus.length).toBeGreaterThanOrEqual(1);
+		const menu = bar.beerMenus[0];
+		expect(menu.beer).toBeDefined();
+		expect(menu.beer.brewery).not.toBeNull();
+		expect(menu.beer.beerCategory).toBeDefined();
+		expect(menu.sizes.length).toBeGreaterThanOrEqual(1);
+		expect(menu.sizes[0].sizeName).toBe("パイント");
+		expect(bar.foodMenus.length).toBeGreaterThanOrEqual(1);
+
+		// タグ付けされた投稿タブ: posts
+		expect(bar.posts.length).toBeGreaterThanOrEqual(1);
+		const detailPost = bar.posts.find((p) => p.body === "it-bar-detail-post");
+		expect(detailPost).toBeDefined();
+		expect(detailPost?.postImages.length).toBeGreaterThanOrEqual(1);
+
+		// お店からの投稿タブ: articles (published のみ。draft は除外)
+		expect(bar.articles.length).toBeGreaterThanOrEqual(1);
+		const publishedTitles = bar.articles.map((a) => a.title);
+		expect(publishedTitles).toContain("it-article-published");
+		expect(publishedTitles).not.toContain("it-article-draft");
+
+		// クーポンタブ
+		expect(bar.coupons.length).toBeGreaterThanOrEqual(1);
+		expect(bar.coupons.map((c) => c.title)).toContain("it-coupon-detail");
+
+		// イベントタブ
+		expect(bar.events.length).toBeGreaterThanOrEqual(1);
+		expect(bar.events.map((e) => e.title)).toContain("it-event-future");
+	});
+});

--- a/apps/web/src/actions/bar-search.integration.test.ts
+++ b/apps/web/src/actions/bar-search.integration.test.ts
@@ -1,0 +1,198 @@
+import { faker } from "@faker-js/faker";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestBar,
+	INTEGRATION_TEST_PREFIX,
+} from "@/test/integration-helpers";
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+		},
+	}),
+}));
+
+import { getBars } from "@/actions/bar";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+// 検証用に固有名を使う (既存 seed の bar と混在しても it- prefix で安全に絞り込める)
+const uniqueCity = `it-city-${faker.string.alphanumeric(6).toLowerCase()}`;
+const uniqueCategoryName = `it-cat-${faker.string.alphanumeric(6).toLowerCase()}`;
+const uniqueCountryName = `it-country-${faker.string.alphanumeric(6).toLowerCase()}`;
+const uniqueRegionName = `it-region-${faker.string.alphanumeric(6).toLowerCase()}`;
+
+let barOnlyCityId: bigint;
+let barOnlyCategoryId: bigint;
+let barOnlyOriginId: bigint;
+let barAllMatchedId: bigint;
+let createdCategoryId: bigint;
+let createdCountryId: bigint;
+let createdRegionId: bigint;
+let createdBreweryId: bigint;
+
+beforeAll(async () => {
+	// Why not: 既存 seed のマスタを汚さないよう、すべて it- prefix で新規作成して
+	// テスト用 bar のみが該当するよう仕込む。cleanup では bars と user系のみが消えるため、
+	// このテスト固有のマスタ (beer / beer_category / region / country / brewery) は
+	// afterAll で明示的に削除する。
+	const cat = await prisma.beerCategory.create({
+		data: { name: uniqueCategoryName },
+	});
+	createdCategoryId = cat.id;
+
+	const country = await prisma.country.create({
+		data: { name: uniqueCountryName },
+	});
+	createdCountryId = country.id;
+
+	const region = await prisma.region.create({
+		data: { name: uniqueRegionName, countryId: country.id },
+	});
+	createdRegionId = region.id;
+
+	const brewery = await prisma.brewery.create({
+		data: {
+			name: `it-brewery-${faker.string.alphanumeric(6).toLowerCase()}`,
+			countryId: country.id,
+			regionId: region.id,
+		},
+	});
+	createdBreweryId = brewery.id;
+
+	// 1) city のみ一致: city=uniqueCity, ビールなし
+	const barOnlyCity = await createTestBar(prisma, { city: uniqueCity });
+	barOnlyCityId = barOnlyCity.id;
+
+	// 2) category のみ一致: ビールメニュー (category=uniqueCategoryName), city は異なる
+	const barOnlyCategory = await createTestBar(prisma);
+	barOnlyCategoryId = barOnlyCategory.id;
+	const beer1 = await prisma.beer.create({
+		data: {
+			name: `it-beer-cat-${faker.string.alphanumeric(6).toLowerCase()}`,
+			beerCategoryId: cat.id,
+			breweryId: brewery.id,
+			// region は category 単独テスト時に origin と被らないよう null にしておく
+			regionId: null,
+		},
+	});
+	await prisma.barBeerMenu.create({
+		data: { barId: barOnlyCategoryId, beerId: beer1.id },
+	});
+
+	// 3) origin のみ一致: ビールメニュー (region=uniqueRegionName, country=uniqueCountryName)
+	const barOnlyOrigin = await createTestBar(prisma);
+	barOnlyOriginId = barOnlyOrigin.id;
+	const beer2 = await prisma.beer.create({
+		data: {
+			name: `it-beer-origin-${faker.string.alphanumeric(6).toLowerCase()}`,
+			// category は別カテゴリを使いたいので seed のものを 1 つ持ってくる
+			beerCategoryId: (
+				await prisma.beerCategory.findFirstOrThrow({
+					where: { name: { not: uniqueCategoryName } },
+				})
+			).id,
+			breweryId: brewery.id,
+			regionId: region.id,
+		},
+	});
+	await prisma.barBeerMenu.create({
+		data: { barId: barOnlyOriginId, beerId: beer2.id },
+	});
+
+	// 4) city + category + origin すべて一致
+	const barAllMatched = await createTestBar(prisma, { city: uniqueCity });
+	barAllMatchedId = barAllMatched.id;
+	const beer3 = await prisma.beer.create({
+		data: {
+			name: `it-beer-all-${faker.string.alphanumeric(6).toLowerCase()}`,
+			beerCategoryId: cat.id,
+			breweryId: brewery.id,
+			regionId: region.id,
+		},
+	});
+	await prisma.barBeerMenu.create({
+		data: { barId: barAllMatched.id, beerId: beer3.id },
+	});
+});
+
+afterAll(async () => {
+	// bars 系のクリーンアップは cleanupTestData が CASCADE 経由でやってくれる。
+	await cleanupTestData(prisma, {});
+
+	// このテストで作成したマスタを掃除する。
+	await prisma.beer.deleteMany({
+		where: { name: { startsWith: INTEGRATION_TEST_PREFIX } },
+	});
+	await prisma.brewery.deleteMany({ where: { id: createdBreweryId } });
+	await prisma.region.deleteMany({ where: { id: createdRegionId } });
+	await prisma.country.deleteMany({ where: { id: createdCountryId } });
+	await prisma.beerCategory.deleteMany({ where: { id: createdCategoryId } });
+
+	await prisma.$disconnect();
+});
+
+describe("getBars (Integration)", () => {
+	it("city 単独フィルタは指定市町村の bar のみ返す", async () => {
+		const result = await getBars({ city: uniqueCity });
+		const ids = result.map((bar) => bar.id);
+		expect(ids).toEqual(
+			expect.arrayContaining([
+				barOnlyCityId.toString(),
+				barAllMatchedId.toString(),
+			]),
+		);
+		expect(ids).not.toContain(barOnlyCategoryId.toString());
+		expect(ids).not.toContain(barOnlyOriginId.toString());
+	});
+
+	it("category 単独フィルタはそのカテゴリのビールを提供する bar のみ返す", async () => {
+		const result = await getBars({ category: uniqueCategoryName });
+		const ids = result.map((bar) => bar.id);
+		expect(ids).toEqual(
+			expect.arrayContaining([
+				barOnlyCategoryId.toString(),
+				barAllMatchedId.toString(),
+			]),
+		);
+		expect(ids).not.toContain(barOnlyCityId.toString());
+		expect(ids).not.toContain(barOnlyOriginId.toString());
+	});
+
+	it("origin 単独フィルタは指定産地のビールを提供する bar のみ返す", async () => {
+		const result = await getBars({
+			origin: `${uniqueCountryName}/${uniqueRegionName}`,
+		});
+		const ids = result.map((bar) => bar.id);
+		expect(ids).toEqual(
+			expect.arrayContaining([
+				barOnlyOriginId.toString(),
+				barAllMatchedId.toString(),
+			]),
+		);
+		expect(ids).not.toContain(barOnlyCityId.toString());
+		expect(ids).not.toContain(barOnlyCategoryId.toString());
+	});
+
+	it("city + category + origin の AND 複合フィルタは 3 条件すべてを満たす bar のみ返す", async () => {
+		const result = await getBars({
+			city: uniqueCity,
+			category: uniqueCategoryName,
+			origin: `${uniqueCountryName}/${uniqueRegionName}`,
+		});
+		const ids = result.map((bar) => bar.id);
+		expect(ids).toContain(barAllMatchedId.toString());
+		expect(ids).not.toContain(barOnlyCityId.toString());
+		expect(ids).not.toContain(barOnlyCategoryId.toString());
+		expect(ids).not.toContain(barOnlyOriginId.toString());
+	});
+});

--- a/apps/web/src/actions/bar.integration.test.ts
+++ b/apps/web/src/actions/bar.integration.test.ts
@@ -1,0 +1,103 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+import {
+	addFavoriteBar,
+	getBeerRegions,
+	removeFavoriteBar,
+} from "@/actions/bar";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser;
+let testBarId: bigint;
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	const bar = await createTestBar(prisma);
+	testBarId = bar.id;
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("addFavoriteBar / removeFavoriteBar (Integration)", () => {
+	it("addFavoriteBar で favorite_bars に行が追加される", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		await addFavoriteBar(testBarId.toString());
+
+		const favorite = await prisma.favoriteBar.findUnique({
+			where: {
+				userId_barId: {
+					userId: alice.userProfileId,
+					barId: testBarId,
+				},
+			},
+		});
+		expect(favorite).not.toBeNull();
+	});
+
+	it("removeFavoriteBar で favorite_bars 行が削除される", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		await removeFavoriteBar(testBarId.toString());
+
+		const favorite = await prisma.favoriteBar.findUnique({
+			where: {
+				userId_barId: {
+					userId: alice.userProfileId,
+					barId: testBarId,
+				},
+			},
+		});
+		expect(favorite).toBeNull();
+	});
+});
+
+describe("getBeerRegions (Integration)", () => {
+	it("実 DB のレコードを { 国名: [地域名, ...] } 形式でグループ化して返す", async () => {
+		// Why not: seed.e2e.sql に { 日本: [静岡, 東京], アメリカ, ベルギー } が投入されている前提。
+		// 順序や追加された地域の影響を受けにくいよう「期待するキー/値の包含」を assert する。
+		const grouped = await getBeerRegions();
+
+		expect(grouped).toHaveProperty("日本");
+		expect(Array.isArray(grouped.日本)).toBe(true);
+		expect(grouped.日本).toEqual(expect.arrayContaining(["静岡", "東京"]));
+
+		// 国名キーは ASC ソートされている (実装側で orderBy country.name asc + region name asc)。
+		// 1 つ以上の地域を持つ国だけがキーになる。
+		for (const regions of Object.values(grouped)) {
+			expect(regions.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/apps/web/src/actions/coupon.integration.test.ts
+++ b/apps/web/src/actions/coupon.integration.test.ts
@@ -1,0 +1,113 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	createTestCoupon,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+import { getUserCoupons } from "@/actions/user";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser;
+let firstCouponId: bigint;
+let secondCouponId: bigint;
+const firstBarName = "it-coupon-bar-first";
+const secondBarName = "it-coupon-bar-second";
+const validUntilDate = new Date("2099-12-31T00:00:00.000Z");
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	const firstBar = await createTestBar(prisma, { name: firstBarName });
+	const secondBar = await createTestBar(prisma, { name: secondBarName });
+
+	const firstCoupon = await createTestCoupon(prisma, firstBar.id, {
+		title: "it-coupon-title-first",
+		description: "it-coupon-desc-first",
+		validUntil: validUntilDate,
+	});
+	firstCouponId = firstCoupon.id;
+
+	const secondCoupon = await createTestCoupon(prisma, secondBar.id, {
+		title: "it-coupon-title-second",
+		description: null,
+		validUntil: null,
+	});
+	secondCouponId = secondCoupon.id;
+
+	// Why not: getUserCoupons は obtainedAt の DESC ソートを assert する。
+	// 1 つめを先に作って後から 2 つめを作れば 2 つめが先頭になるはずだが、
+	// 同タイムスタンプでも差異が出るよう obtainedAt を明示的にずらして登録する。
+	await prisma.userCoupon.create({
+		data: {
+			userId: alice.userProfileId,
+			couponId: firstCouponId,
+			obtainedAt: new Date("2026-01-01T00:00:00.000Z"),
+			isUsed: false,
+		},
+	});
+	await prisma.userCoupon.create({
+		data: {
+			userId: alice.userProfileId,
+			couponId: secondCouponId,
+			obtainedAt: new Date("2026-06-01T00:00:00.000Z"),
+			isUsed: true,
+		},
+	});
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("getUserCoupons (Integration)", () => {
+	it("認証ユーザーの取得済みクーポンを obtainedAt DESC で返し、各フィールドを実 DB から正しく整形する", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		const result = await getUserCoupons();
+
+		expect(result).not.toBeNull();
+		expect(result).toHaveLength(2);
+
+		// 1 件目: obtainedAt が新しい second 側
+		const [latest, oldest] = result ?? [];
+		expect(latest.title).toBe("it-coupon-title-second");
+		expect(latest.description).toBe("");
+		expect(latest.barName).toBe(secondBarName);
+		expect(latest.validUntil).toBeNull();
+		expect(latest.isUsed).toBe(true);
+		expect(latest.obtainedAt.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+
+		// 2 件目: 古い first 側
+		expect(oldest.title).toBe("it-coupon-title-first");
+		expect(oldest.description).toBe("it-coupon-desc-first");
+		expect(oldest.barName).toBe(firstBarName);
+		expect(oldest.validUntil).not.toBeNull();
+		expect(oldest.validUntil?.toISOString()).toBe(validUntilDate.toISOString());
+		expect(oldest.isUsed).toBe(false);
+		expect(oldest.obtainedAt.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+	});
+});

--- a/apps/web/src/actions/timeline.integration.test.ts
+++ b/apps/web/src/actions/timeline.integration.test.ts
@@ -1,0 +1,100 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+import { getTimelinePosts } from "@/actions/user";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser; // 認証ユーザー
+let bob: TestAuthUser; // フォロー中
+let carol: TestAuthUser; // 非フォロー
+let testBarId: bigint;
+let alicePostId: bigint;
+let bobPostId: bigint;
+let carolPostId: bigint;
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	bob = await createTestAuthUser(prisma);
+	carol = await createTestAuthUser(prisma);
+	const bar = await createTestBar(prisma);
+	testBarId = bar.id;
+
+	// alice -> bob のみフォロー
+	await prisma.userFollowRelation.create({
+		data: {
+			followerId: alice.userProfileId,
+			followeeId: bob.userProfileId,
+		},
+	});
+
+	const alicePost = await prisma.post.create({
+		data: {
+			userId: alice.userProfileId,
+			barId: testBarId,
+			body: "it-timeline-body-alice",
+		},
+	});
+	alicePostId = alicePost.id;
+
+	const bobPost = await prisma.post.create({
+		data: {
+			userId: bob.userProfileId,
+			barId: testBarId,
+			body: "it-timeline-body-bob",
+		},
+	});
+	bobPostId = bobPost.id;
+
+	const carolPost = await prisma.post.create({
+		data: {
+			userId: carol.userProfileId,
+			barId: testBarId,
+			body: "it-timeline-body-carol",
+		},
+	});
+	carolPostId = carolPost.id;
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId, bob.authUserId, carol.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("getTimelinePosts (Integration)", () => {
+	it("自分とフォロー中ユーザーの投稿は含まれ、非フォローユーザーの投稿は除外される", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		const posts = await getTimelinePosts();
+		expect(posts).not.toBeNull();
+
+		const ids = (posts ?? []).map((p) => p.id);
+		expect(ids).toEqual(expect.arrayContaining([alicePostId, bobPostId]));
+		expect(ids).not.toContain(carolPostId);
+	});
+});

--- a/apps/web/src/actions/user.integration.test.ts
+++ b/apps/web/src/actions/user.integration.test.ts
@@ -1,0 +1,99 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+}));
+
+import { followUser, unfollowUser } from "@/actions/user";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let alice: TestAuthUser;
+let bob: TestAuthUser;
+
+beforeAll(async () => {
+	alice = await createTestAuthUser(prisma);
+	bob = await createTestAuthUser(prisma);
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [alice.authUserId, bob.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("followUser / unfollowUser (Integration)", () => {
+	it("followUser でフォロー関係が1件作成される", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		await followUser(bob.userProfileId);
+
+		const relation = await prisma.userFollowRelation.findUnique({
+			where: {
+				followerId_followeeId: {
+					followerId: alice.userProfileId,
+					followeeId: bob.userProfileId,
+				},
+			},
+		});
+		expect(relation).not.toBeNull();
+		expect(relation?.followerId).toBe(alice.userProfileId);
+		expect(relation?.followeeId).toBe(bob.userProfileId);
+	});
+
+	it("同じ相手を再度 followUser すると UNIQUE 制約で失敗する", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		// Why not: 1 度目で行を作っているので 2 度目は @@unique([followerId, followeeId]) に
+		// 違反する。実装は try/catch していないため Prisma の例外がそのまま伝播する想定。
+		await expect(followUser(bob.userProfileId)).rejects.toThrow();
+
+		const relations = await prisma.userFollowRelation.findMany({
+			where: {
+				followerId: alice.userProfileId,
+				followeeId: bob.userProfileId,
+			},
+		});
+		expect(relations).toHaveLength(1);
+	});
+
+	it("unfollowUser でフォロー関係が削除される", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+
+		await unfollowUser(bob.userProfileId);
+
+		const relation = await prisma.userFollowRelation.findUnique({
+			where: {
+				followerId_followeeId: {
+					followerId: alice.userProfileId,
+					followeeId: bob.userProfileId,
+				},
+			},
+		});
+		expect(relation).toBeNull();
+	});
+});

--- a/apps/web/src/app/posts/new/actions.integration.test.ts
+++ b/apps/web/src/app/posts/new/actions.integration.test.ts
@@ -1,0 +1,132 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma";
+import {
+	cleanupTestData,
+	createTestAuthUser,
+	createTestBar,
+	type TestAuthUser,
+} from "@/test/integration-helpers";
+
+// Why not: createClient() / createAdminClient() は cookies() に依存するため Integration では
+// 直接利用できない。auth.getUser() は実認証ユーザーの id を返すように差し替え、
+// Storage 操作はモックで成功扱いにして DB 挿入の正常系のみを検証する。
+// (Storage ロールバックパスは UT 側で createAdminClient をモックして網羅する)
+const mockGetUser = vi.fn();
+const mockUpload = vi.fn();
+const mockGetPublicUrl = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	}),
+	createAdminClient: async () => ({
+		storage: {
+			from: () => ({
+				upload: mockUpload,
+				getPublicUrl: mockGetPublicUrl,
+			}),
+		},
+	}),
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+// Why not: createPost は成功時に redirect() を呼び throw する。Integration では
+// "redirect が呼ばれたこと" だけ検知できれば良いので、throw を握り潰せる形に差し替える。
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn((url: string) => {
+		throw new Error(`NEXT_REDIRECT:${url}`);
+	}),
+}));
+
+import { createPost } from "@/app/posts/new/actions";
+
+const prisma = new PrismaClient({
+	adapter: new PrismaPg(
+		new Pool({ connectionString: process.env.DATABASE_URL }),
+	),
+});
+
+let user: TestAuthUser;
+let testBarId: bigint;
+
+beforeAll(async () => {
+	user = await createTestAuthUser(prisma);
+	const bar = await createTestBar(prisma);
+	testBarId = bar.id;
+});
+
+afterAll(async () => {
+	await cleanupTestData(prisma, {
+		authUserIds: [user.authUserId],
+	});
+	await prisma.$disconnect();
+});
+
+describe("createPost (Integration)", () => {
+	it("本文と画像4枚を渡すと posts が 1 件、post_images が 4 件挿入される", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: { id: user.authUserId } },
+		});
+		mockUpload.mockResolvedValue({ data: { path: "ok" }, error: null });
+		mockGetPublicUrl.mockReturnValue({
+			data: { publicUrl: "https://example.test/it-image.jpg" },
+		});
+
+		const formData = new FormData();
+		formData.set("barId", testBarId.toString());
+		formData.set("body", "it-post-body-with-images");
+
+		// Why not: File は Web Standard API。size>0 を満たすために 1byte 以上のデータを入れる。
+		for (let i = 0; i < 4; i++) {
+			const file = new File([new Uint8Array([i + 1])], `it-image-${i}.jpg`, {
+				type: "image/jpeg",
+			});
+			formData.set(`image-${i}`, file);
+		}
+
+		// Why not: createPost は成功時 redirect() を投げるので catch して期待した URL かを確認する。
+		let redirectUrl: string | null = null;
+		try {
+			await createPost(undefined, formData);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "";
+			if (message.startsWith("NEXT_REDIRECT:")) {
+				redirectUrl = message.replace("NEXT_REDIRECT:", "");
+			} else {
+				throw error;
+			}
+		}
+		expect(redirectUrl).toBe(`/bars/${testBarId.toString()}`);
+
+		const createdPosts = await prisma.post.findMany({
+			where: {
+				userId: user.userProfileId,
+				body: "it-post-body-with-images",
+			},
+			include: {
+				postImages: {
+					orderBy: { sortOrder: "asc" },
+				},
+			},
+		});
+		expect(createdPosts).toHaveLength(1);
+		const createdPost = createdPosts[0];
+		expect(createdPost.barId).toBe(testBarId);
+
+		// Why not: Server Action 側で sortOrder=0..3 を順に振っているので件数とソート順の両方を assert。
+		expect(createdPost.postImages).toHaveLength(4);
+		expect(createdPost.postImages.map((img) => img.sortOrder)).toEqual([
+			0, 1, 2, 3,
+		]);
+
+		// Storage アップロード API も 4 回呼ばれていることを確認しておく。
+		expect(mockUpload).toHaveBeenCalledTimes(4);
+	});
+});

--- a/apps/web/src/test/integration-helpers.ts
+++ b/apps/web/src/test/integration-helpers.ts
@@ -67,20 +67,46 @@ export async function createTestAuthUser(
 
 export async function createTestBar(
 	prisma: PrismaClient,
-	overrides: { name?: string } = {},
+	overrides: { name?: string; city?: string; prefecture?: string } = {},
 ): Promise<{ id: bigint; name: string }> {
 	const suffix = faker.string.alphanumeric(8).toLowerCase();
 	const name = overrides.name ?? `${INTEGRATION_TEST_PREFIX}bar-${suffix}`;
 	const bar = await prisma.bar.create({
 		data: {
 			name,
-			prefecture: "東京都",
-			city: "渋谷区",
+			prefecture: overrides.prefecture ?? "東京都",
+			city: overrides.city ?? "渋谷区",
 			addressLine1: `${INTEGRATION_TEST_PREFIX}address-${suffix}`,
 			description: `${INTEGRATION_TEST_PREFIX}description`,
 		},
 	});
 	return { id: bar.id, name: bar.name };
+}
+
+export async function createTestCoupon(
+	prisma: PrismaClient,
+	barId: bigint,
+	overrides: {
+		title?: string;
+		description?: string | null;
+		validUntil?: Date | null;
+	} = {},
+): Promise<{ id: bigint }> {
+	const suffix = faker.string.alphanumeric(8).toLowerCase();
+	const coupon = await prisma.barCoupon.create({
+		data: {
+			barId,
+			title: overrides.title ?? `${INTEGRATION_TEST_PREFIX}coupon-${suffix}`,
+			description:
+				overrides.description === undefined
+					? `${INTEGRATION_TEST_PREFIX}coupon-desc`
+					: overrides.description,
+			discountType: "percentage",
+			discountValue: 10,
+			validUntil: overrides.validUntil ?? null,
+		},
+	});
+	return { id: coupon.id };
 }
 
 export type CleanupOptions = {
@@ -113,6 +139,26 @@ export async function cleanupTestData(
 		await prisma.postLike.deleteMany({
 			where: { userId: { in: profileIds } },
 		});
+		await prisma.articleLike.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.userCoupon.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.favoriteBar.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.viewHistory.deleteMany({
+			where: { userId: { in: profileIds } },
+		});
+		await prisma.userFollowRelation.deleteMany({
+			where: {
+				OR: [
+					{ followerId: { in: profileIds } },
+					{ followeeId: { in: profileIds } },
+				],
+			},
+		});
 		await prisma.post.deleteMany({
 			where: { userId: { in: profileIds } },
 		});
@@ -121,6 +167,9 @@ export async function cleanupTestData(
 		});
 	}
 
+	// Why not: bars の CASCADE で bar_coupons / bar_beer_menus / bar_food_menus / articles / posts /
+	// bar_payment_methods / bar_events / favorite_bars / view_histories などは自動で消える。
+	// it- 接頭辞の bar だけを対象に絞ることで seed.e2e.sql の固定店舗を侵さない。
 	await prisma.bar.deleteMany({
 		where: { name: { startsWith: INTEGRATION_TEST_PREFIX } },
 	});


### PR DESCRIPTION
## 概要

Issue #229 の PR2 として、PR1 ([#231](https://github.com/RikuShimoida/BeerSalon/pull/231)) で整備した Integration テスト基盤を使い、Server Action / Prisma クエリの実 DB 検証を 7 本追加する。

PR1 の `togglePostLike` 1 本と合わせて、`pnpm test:integration` で **計 8 本** が緑になる。

> このPRは `feature/229-integration-test-foundation`（PR1）をベースにしている。**PR1 がマージされたら base を `develop` に切り替える必要がある**。

## 追加した 7 本のテスト

| # | ファイル | 対象 | 検証内容 |
|---|---|---|---|
| 1 | `apps/web/src/app/posts/new/actions.integration.test.ts` | `createPost` (正常系) | 本文 + 画像 4 枚で `posts` 1 件 + `post_images` 4 件挿入。`sortOrder` 0..3 の昇順を assert。Storage は `createAdminClient` をモックして DB 挿入のみを検証 |
| 2 | `apps/web/src/actions/user.integration.test.ts` | `followUser` / `unfollowUser` | フォロー作成で `user_follow_relations` 行追加 → 2 回フォローで `@@unique` 違反 → unfollow で削除 |
| 3 | `apps/web/src/actions/bar.integration.test.ts` | `addFavoriteBar` / `removeFavoriteBar` + `getBeerRegions` | `favorite_bars` の追加/削除を実 DB で確認 + `getBeerRegions` で seed 済みの国×地域がグループ化されることを assert |
| 4 | `apps/web/src/actions/coupon.integration.test.ts` | `getUserCoupons` | 2 件の `user_coupons` を直接 INSERT して、戻り値スキーマ（`title` / `description` / `barName` / `validUntil` / `isUsed` / `obtainedAt`）と `obtainedAt` DESC ソートを実データで検証 |
| 5 | `apps/web/src/actions/timeline.integration.test.ts` | `getTimelinePosts` | alice → bob のみフォロー。タイムラインには alice (自分) と bob (フォロー中) が含まれ、carol (非フォロー) は除外される |
| 6 | `apps/web/src/actions/bar-search.integration.test.ts` | `getBars` | `city` / `category` / `origin` の各単独フィルタと 3 条件 AND 複合の絞り込みを検証 |
| 7 | `apps/web/src/actions/bar-detail.integration.test.ts` | `getBarDetail` | 6 タブ分のリレーション include を網羅: 基本情報 (`barImages` / `openingHours` / `paymentMethods`) / メニュー (`beerMenus` + sizes + brewery + category + `foodMenus`) / タグ付け投稿 (`posts` + `postImages`) / お店からの投稿 (`articles` の `published` のみ) / クーポン / イベント |

## ヘルパ拡張

`apps/web/src/test/integration-helpers.ts` を以下のように拡張:

- `cleanupTestData` に `userCoupon` / `favoriteBar` / `viewHistory` / `userFollowRelation` / `articleLike` の deleteMany を追加（user_profiles の FK 違反を回避）
- `createTestBar` に `city` / `prefecture` のオーバーライドを追加
- `createTestCoupon` ヘルパを新設（PR2 で複数のテストが利用）

## 計画から外したスコープ

ユーザー方針確認に基づき、以下は本 PR では検証しない（別途検討）:

- **`followUser` 通知作成**: 実装にロジックが存在しないため検証対象外。通知機能は別途検討
- **店舗検索のフリーワード `q`**: 実装にロジックが存在しないため検証対象外
- **`createPost` ロールバック**: 実 DB に対する Storage 失敗の差し込みは脆く、UT 側で `createAdminClient` を完全モックして網羅する方が適切。本 PR では正常系のみ
- **`getUserCoupons` の `bar.barImages` include 追加**: 現状の戻り値スキーマを尊重し、include 拡張は別途検討

## 動作確認結果

```bash
# Integration: 計 8 本緑
$ pnpm test:integration
 Test Files  8 passed (8)
      Tests  17 passed (17)
   Duration  3.88s

# UT: 緑維持
$ pnpm test:unit
 Test Files  20 passed (20)
      Tests  233 passed (233)
   Duration  3.20s

# 品質チェック
$ pnpm format  # No fixes applied
$ pnpm lint    # No fixes applied
```

## マージ前の作業

- [ ] PR1 ([#231](https://github.com/RikuShimoida/BeerSalon/pull/231)) のマージ
- [ ] このPRの base を `develop` に切り替え

## チェックリスト

- [x] `pnpm test:integration` が緑 (8 本)
- [x] `pnpm test:unit` が緑 (233 本)
- [x] `pnpm format` 通過
- [x] `pnpm lint` 通過
- [x] 実装変更なし（テスト追加のみ）
- [x] PR1 の `integration-helpers.ts` パターン踏襲

Refs #229