### PR TITLE
feat: Vercel本番デプロイの自動化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+name: Deploy to Vercel
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    outputs:
+      sha: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Log trigger
+        run: |
+          echo "Triggered by CI run: ${{ github.event.workflow_run.id }}"
+          echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
+
+  deploy-web:
+    needs: guard
+    runs-on: ubuntu-latest
+    environment:
+      name: production-web
+      url: ${{ steps.deploy.outputs.url }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project (web)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (web)
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed web: $url"
+
+  deploy-admin:
+    needs: guard
+    runs-on: ubuntu-latest
+    environment:
+      name: production-admin
+      url: ${{ steps.deploy.outputs.url }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project (admin)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (admin)
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed admin: $url"

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,16 @@
     "Playwright": {
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
+    },
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
     }
   }
 }

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"git": {
+		"deploymentEnabled": false
+	}
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"git": {
+		"deploymentEnabled": false
+	}
+}


### PR DESCRIPTION
## Summary
- mainブランチへのマージ後、CI全成功時に web/admin両方のVercelプロジェクトを本番デプロイする仕組みを追加
- Vercel側のGit自動デプロイは無効化し、GitHub Actions経由でCI通過後のみデプロイされるよう制御
- 本番Supabase管理用のSupabase MCPサーバーも追加

## 変更内容
- `.github/workflows/deploy.yml`: workflow_runトリガーでCI成功時にVercelの web/adminを並列デプロイ
- `apps/web/vercel.json` / `apps/admin/vercel.json`: `git.deploymentEnabled: false` でVercel側の自動デプロイ無効化
- `.mcp.json`: Supabase MCPサーバー（@supabase/mcp-server-supabase）を追加

## 事前準備（完了済み）
- ✅ Supabase本番プロジェクト作成（`beer-salon-production` / ap-northeast-1）
- ✅ Vercelプロジェクト作成（`beer-salon` / `beer-salon-admin`）
- ✅ Vercel環境変数の投入（production/preview、web 5件 + admin 11件）
- ✅ Vercel ↔ GitHubリポジトリ連携 + Root Directory設定（apps/web、apps/admin）
- ✅ GitHub Secrets登録（VERCEL_TOKEN、VERCEL_ORG_ID、VERCEL_PROJECT_ID_WEB、VERCEL_PROJECT_ID_ADMIN）

## 動作フロー
1. main へのpush → 既存の `CI` ワークフロー実行
2. CI 全ジョブ（lint/typecheck/test/integration/build/prisma-validate）が成功
3. `Deploy to Vercel` ワークフローが `workflow_run` で発火
4. web/admin それぞれで `vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod`
5. 両プロジェクトの production URL に反映

## Test plan
- [ ] このPRが develop にマージされる
- [ ] develop → main のPRを別途作成
- [ ] main マージ後、`CI` ワークフローが成功することを確認
- [ ] `Deploy to Vercel` ワークフローが自動発火することを確認
- [ ] Vercel ダッシュボードで web/admin両方の Production デプロイが完了することを確認
- [ ] `beer-salon.vercel.app` と `beer-salon-admin.vercel.app` に疎通確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)