### PR TITLE
fix: deploy.yml に pnpm/Node.js setup を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           ref: ${{ needs.guard.outputs.sha }}
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
@@ -65,6 +72,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
## Summary
- 初回main自動デプロイで「spawn pnpm ENOENT」エラーが発生したため修正
- GitHub Actions ランナーには pnpm が未インストールのため、`pnpm/action-setup@v4` と `actions/setup-node@v4` を deploy-web / deploy-admin の両ジョブに追加

## エラーログ
```
Detected `pnpm-lock.yaml` version 9 generated by pnpm@10.x with package.json#packageManager pnpm@10.24.0
Installing dependencies...
Error: spawn pnpm ENOENT
```

## Test plan
- [ ] developにマージ → mainにマージ
- [ ] mainでCI成功後、Deploy to Vercel ワークフローが workflow_run で発火
- [ ] web/admin両プロジェクトが Production にデプロイ完了
- [ ] Vercel ダッシュボードで Production URL が Ready になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)