### PR TITLE
release: deploy.yml の pnpm setup 修正を main へ反映

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           ref: ${{ needs.guard.outputs.sha }}
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
@@ -65,6 +72,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
## Summary
PR #236 で修正した deploy.yml の pnpm setup を main に反映します。これにより、main 上で再度CIが実行され、CI成功後にVercelへの本番デプロイが自動発火します。

## 差分
- PR #236: deploy.yml に `pnpm/action-setup@v4` と `actions/setup-node@v4` を追加

## マージ後の動作
1. main更新
2. CIワークフロー実行 → 成功
3. Deploy to Vercel ワークフローが workflow_run で自動発火
4. 今度は pnpm が使えるので、`vercel build` がモノレポビルドを正常に実行
5. apps/web → beer-salon Production にデプロイ
6. apps/admin → beer-salon-admin Production にデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)