### PR TITLE
fix: build前にPrisma Clientを生成するよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Build project (web)
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
 
       - name: Deploy to Vercel (web)
         id: deploy

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev -p 3000",
-		"build": "next build",
+		"build": "pnpm db:generate && next build",
 		"db:generate": "prisma generate --schema=../../prisma/schema.prisma",
 		"start": "next start",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Vercel本番デプロイで「Module not found: Can't resolve '@/generated/prisma'」エラーが発生していたため修正
- `apps/web/package.json` の build スクリプトで Prisma Client生成 → next build の順に実行するよう変更
- `.github/workflows/deploy.yml` で `vercel build` 時にダミーDATABASE_URLを渡してprisma generateが動くように

## エラーログ
```
Error: Turbopack build failed with 1 errors:
./apps/web/src/lib/prisma.ts:3:1
Module not found: Can't resolve '@/generated/prisma'
```

## Why
Prisma Clientは `prisma generate` 実行時に `apps/web/src/generated/prisma` 配下に動的生成される。
buildのタイミングで生成ファイルが存在しないため、Turbopackが module not found エラーで止まっていた。

## Test plan
- [ ] developにマージ → mainにマージ
- [ ] mainCI成功 → Deploy to Vercel 発火
- [ ] web/admin両プロジェクトが Production にデプロイ完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)