### PR TITLE
release: Prisma generate を build に組み込む修正を main へ反映

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Build project (web)
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
 
       - name: Deploy to Vercel (web)
         id: deploy

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev -p 3000",
-		"build": "next build",
+		"build": "pnpm db:generate && next build",
 		"db:generate": "prisma generate --schema=../../prisma/schema.prisma",
 		"start": "next start",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
PR #238 で修正した build前のPrisma Client生成を main に反映します。前回のデプロイ失敗を解消する修正です。

## マージ後の動作
1. mainでCIワークフロー実行 → 成功
2. Deploy to Vercel が workflow_run で発火
3. vercel build時に pnpm db:generate が走り、Prisma Clientが生成される
4. その後 next build が成功
5. apps/web → beer-salon Production にデプロイ
6. apps/admin → beer-salon-admin Production にデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)