### PR TITLE
feat: developマージ時にPreview環境へ自動デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,29 +4,38 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:
   guard:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'develop') }}
     outputs:
       sha: ${{ github.event.workflow_run.head_sha }}
+      target: ${{ steps.target.outputs.target }}
+      prod_flag: ${{ steps.target.outputs.prod_flag }}
     steps:
-      - name: Log trigger
+      - name: Determine deploy target
+        id: target
         run: |
-          echo "Triggered by CI run: ${{ github.event.workflow_run.id }}"
-          echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
+          if [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            echo "target=production" >> "$GITHUB_OUTPUT"
+            echo "prod_flag=--prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=preview" >> "$GITHUB_OUTPUT"
+            echo "prod_flag=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Triggered by CI run: ${{ github.event.workflow_run.id }} on ${{ github.event.workflow_run.head_branch }}"
 
   deploy-web:
     needs: guard
     runs-on: ubuntu-latest
     environment:
-      name: production-web
+      name: ${{ needs.guard.outputs.target }}-web
       url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -47,25 +56,25 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build project (web)
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
 
       - name: Deploy to Vercel (web)
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Deployed web: $url"
+          echo "Deployed web (${{ needs.guard.outputs.target }}): $url"
 
   deploy-admin:
     needs: guard
     runs-on: ubuntu-latest
     environment:
-      name: production-admin
+      name: ${{ needs.guard.outputs.target }}-admin
       url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -86,14 +95,14 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build project (admin)
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel (admin)
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Deployed admin: $url"
+          echo "Deployed admin (${{ needs.guard.outputs.target }}): $url"


### PR DESCRIPTION
## Summary
- mainマージ時のProduction自動デプロイに加え、developマージ時にもPreview環境への自動デプロイを追加
- 両方とも CI成功後のみ発火する仕組みは維持

## なぜこの変更が必要か
mainマージ前の最終確認用にPreview環境が欲しい。理由:
- 「ローカルで動いた」と「本番で動く」のギャップを **mainマージ前** に検出できる
- 環境変数の typo、本番Supabase接続の問題を main 前に発見できる
- ステークホルダーやチームに「mainに入る前の状態」をURLで共有できる

## 動作
| ブランチ | アクション | 環境 | デプロイ先 |
|---|---|---|---|
| feature/xxx | push（PR作成） | なし | デプロイされない（CIのみ） |
| develop | マージ（CI成功時） | Preview | beer-salon-{hash}.vercel.app |
| main | マージ（CI成功時） | Production | beer-salon.vercel.app |

## 変更内容
- `workflow_run` のトリガーブランチに `develop` を追加
- `guard` ジョブで `head_branch` を判定し、`target` (production/preview) と `prod_flag` (--prod / 空) を出力
- `deploy-web` / `deploy-admin` の各ステップで動的にフラグを切替
- `environment` 名も target に応じて切替 (production-web / preview-web など)

## Test plan
- [ ] このPRをdevelopにマージ
- [ ] developでCIが成功することを確認
- [ ] Deploy to Vercelワークフローが workflow_run で発火することを確認
- [ ] web/admin両方が Preview 環境にデプロイ完了することを確認
- [ ] Preview URL でログイン画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)