### PR TITLE
fix: deploy.ymlのトリガーをpushに変更しdevelopのPreview自動デプロイを動作させる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,33 @@
 name: Deploy to Vercel
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [main, develop]
+  workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.event.workflow_run.head_branch }}
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   guard:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'develop') }}
     outputs:
-      sha: ${{ github.event.workflow_run.head_sha }}
+      sha: ${{ github.sha }}
       target: ${{ steps.target.outputs.target }}
       prod_flag: ${{ steps.target.outputs.prod_flag }}
     steps:
       - name: Determine deploy target
         id: target
         run: |
-          if [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+          if [ "${{ github.ref_name }}" = "main" ]; then
             echo "target=production" >> "$GITHUB_OUTPUT"
             echo "prod_flag=--prod" >> "$GITHUB_OUTPUT"
           else
             echo "target=preview" >> "$GITHUB_OUTPUT"
             echo "prod_flag=" >> "$GITHUB_OUTPUT"
           fi
-          echo "Triggered by CI run: ${{ github.event.workflow_run.id }} on ${{ github.event.workflow_run.head_branch }}"
+          echo "Triggered by push to ${{ github.ref_name }} (sha: ${{ github.sha }})"
 
   deploy-web:
     needs: guard


### PR DESCRIPTION
## Summary
- \`Deploy to Vercel\` ワークフローのトリガーを \`workflow_run\` から \`push: branches: [main, develop]\` に変更
- \`workflow_dispatch\` を追加して手動再実行を可能に
- これにより develop マージ時に Preview 環境への自動デプロイが動くようになる

## 背景
develop ブランチでは \`Deploy to Vercel\` ワークフローが **過去一度も起動していなかった**（履歴0件）。
原因は \`workflow_run\` トリガーの GitHub Actions 仕様上の制約。

\`\`\`
$ gh api "repos/.../actions/workflows/.../runs?branch=develop"
total_count: 0
\`\`\`

main ブランチへのデプロイは動作しているため、本番デプロイには影響なし。

## 変更内容
| Before | After |
|---|---|
| \`on.workflow_run\` (CIの成功を待って発火) | \`on.push: [main, develop]\` (push 即発火) |
| \`github.event.workflow_run.head_branch\` | \`github.ref_name\` |
| \`github.event.workflow_run.head_sha\` | \`github.sha\` |
| \`if: workflow_run.conclusion == 'success'\` | 削除（pushトリガーのため不要） |

## 設計判断
PR時 CI でコード品質はゲートされているため、マージ後の CI 完走を待たずに即デプロイしても安全。
マージ後 CI は安全網として残し、Deploy と並列実行する構成にする。

## Test plan
- [ ] 本 PR を develop にマージ後、\`Deploy to Vercel\` ワークフローが develop で発火することを確認
- [ ] Preview 環境の URL が払い出され、アクセス可能であることを確認
- [ ] main へのマージ時の Production デプロイが引き続き動作することを確認（後続のmain向けPRで検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)