### PR TITLE
fix(auth): 認証メールのコールバックURLをリクエストオリジンから動的解決 (#253)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,11 +22,15 @@ DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # https://console.cloud.google.com/apis/credentials
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
-# Site URL（任意）
+# Site URL
 # 認証メール（新規登録確認・パスワード再設定）に記載するコールバックURLのオリジン。
-# 設定した場合はリクエストヘッダーより優先される。production で固定したい場合のみ設定する。
+# 設定した場合はリクエストヘッダーより優先される。
 # 未設定の場合は Server Action のリクエストヘッダー（x-forwarded-host / host）から動的に解決される。
 # - local: 未設定でよい（自動で http://localhost:3000 が解決される）
 # - Vercel Preview: 未設定（各デプロイの動的URLに自動追従）
-# - Production: https://beersalon.com など、実ドメインを設定推奨
+# - Production: **必ず設定すること**（例: https://beersalon.com）
+#     未設定の場合、リクエストヘッダー由来の x-forwarded-host を信頼することになり、
+#     信頼できる reverse proxy（Vercel等）の背後にいない環境では Host Header Injection 攻撃で
+#     任意ドメインのパスワードリセットリンクが送られる余地が残るため。
+#     値はスキーム (http(s)://) 付きのオリジンを指定する（不正値は無視される）。
 # NEXT_PUBLIC_SITE_URL=https://beersalon.com

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,3 +21,12 @@ DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # ⚠️ Google Cloud Console で Maps JavaScript API を有効化し、APIキーを取得してください
 # https://console.cloud.google.com/apis/credentials
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+
+# Site URL（任意）
+# 認証メール（新規登録確認・パスワード再設定）に記載するコールバックURLのオリジン。
+# 設定した場合はリクエストヘッダーより優先される。production で固定したい場合のみ設定する。
+# 未設定の場合は Server Action のリクエストヘッダー（x-forwarded-host / host）から動的に解決される。
+# - local: 未設定でよい（自動で http://localhost:3000 が解決される）
+# - Vercel Preview: 未設定（各デプロイの動的URLに自動追従）
+# - Production: https://beersalon.com など、実ドメインを設定推奨
+# NEXT_PUBLIC_SITE_URL=https://beersalon.com

--- a/apps/web/src/app/password/forgot/actions.test.ts
+++ b/apps/web/src/app/password/forgot/actions.test.ts
@@ -9,11 +9,24 @@ vi.mock("@/lib/supabase/server", () => ({
 	})),
 }));
 
+// next/headers のモック（getSiteUrl がヘッダー参照するため）
+const mockHeaders = vi.fn();
+vi.mock("next/headers", () => ({
+	headers: () => mockHeaders(),
+	cookies: vi.fn(),
+}));
+
 import { forgotPasswordAction } from "./actions";
+
+const createHeaderMap = (entries: Record<string, string>) => ({
+	get: (key: string): string | null => entries[key.toLowerCase()] ?? null,
+});
 
 describe("forgotPasswordAction", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SITE_URL = "";
+		mockHeaders.mockResolvedValue(createHeaderMap({ host: "localhost:3000" }));
 		mockResetPasswordForEmail.mockResolvedValue({
 			data: {},
 			error: null,
@@ -30,15 +43,36 @@ describe("forgotPasswordAction", () => {
 			expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
 				"user@example.com",
 				{
-					redirectTo: expect.stringContaining(
-						"/auth/callback?next=/password/reset",
-					),
+					redirectTo:
+						"http://localhost:3000/auth/callback?next=/password/reset",
 				},
 			);
 			expect(result).toEqual({
 				success: true,
 				message: "該当アドレスが登録されていればメールを送信しました",
 			});
+		});
+
+		it("x-forwarded-host / x-forwarded-proto があれば redirectTo にそのドメインが使われる", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					"x-forwarded-host": "preview.vercel.app",
+					"x-forwarded-proto": "https",
+				}),
+			);
+
+			const formData = new FormData();
+			formData.append("email", "user@example.com");
+
+			await forgotPasswordAction(undefined, formData);
+
+			expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+				"user@example.com",
+				{
+					redirectTo:
+						"https://preview.vercel.app/auth/callback?next=/password/reset",
+				},
+			);
 		});
 
 		it("Supabaseがエラーを返しても、ユーザー列挙を防ぐためsuccess: trueで返る", async () => {

--- a/apps/web/src/app/password/forgot/actions.ts
+++ b/apps/web/src/app/password/forgot/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getSiteUrl } from "@/lib/site-url";
 import { createClient } from "@/lib/supabase/server";
 import { forgotPasswordSchema } from "@/lib/validations/auth";
 
@@ -26,7 +27,7 @@ export async function forgotPasswordAction(
 	}
 
 	const supabase = await createClient();
-	const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+	const siteUrl = await getSiteUrl();
 
 	// Why not: ユーザー列挙攻撃を防ぐため、登録有無に関わらず常に同じレスポンスを返す。
 	// Supabase 側でエラーが発生してもクライアントには成功扱いで返却する。

--- a/apps/web/src/app/signup/actions.test.ts
+++ b/apps/web/src/app/signup/actions.test.ts
@@ -6,6 +6,13 @@ vi.mock("next/navigation", () => ({
 	redirect: (...args: unknown[]) => mockRedirect(...args),
 }));
 
+// next/headers のモック（getSiteUrl がヘッダー参照するため）
+const mockHeaders = vi.fn();
+vi.mock("next/headers", () => ({
+	headers: () => mockHeaders(),
+	cookies: vi.fn(),
+}));
+
 // Supabase clientのモック
 const mockSignUp = vi.fn();
 vi.mock("@/lib/supabase/server", () => ({
@@ -18,9 +25,15 @@ vi.mock("@/lib/supabase/server", () => ({
 
 import { signUp } from "./actions";
 
+const createHeaderMap = (entries: Record<string, string>) => ({
+	get: (key: string): string | null => entries[key.toLowerCase()] ?? null,
+});
+
 describe("signUp", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SITE_URL = "";
+		mockHeaders.mockResolvedValue(createHeaderMap({ host: "localhost:3000" }));
 	});
 
 	describe("正常系", () => {
@@ -43,12 +56,42 @@ describe("signUp", () => {
 				email: "newuser@example.com",
 				password: "SecurePass1!",
 				options: {
-					emailRedirectTo: expect.stringMatching(
-						/^http:\/\/(localhost|127\.0\.0\.1):3000\/auth\/callback\?next=\/signup\/profile$/,
-					),
+					emailRedirectTo:
+						"http://localhost:3000/auth/callback?next=/signup/profile",
 				},
 			});
 			expect(result).toBeUndefined();
+		});
+
+		it("x-forwarded-host / x-forwarded-proto があれば emailRedirectTo にそのドメインが使われる", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					"x-forwarded-host": "preview.vercel.app",
+					"x-forwarded-proto": "https",
+				}),
+			);
+			mockSignUp.mockResolvedValue({
+				data: {
+					user: { id: "new-user-id" },
+					session: null,
+				},
+				error: null,
+			});
+
+			const formData = new FormData();
+			formData.append("email", "newuser@example.com");
+			formData.append("password", "SecurePass1!");
+
+			await signUp(undefined, formData);
+
+			expect(mockSignUp).toHaveBeenCalledWith({
+				email: "newuser@example.com",
+				password: "SecurePass1!",
+				options: {
+					emailRedirectTo:
+						"https://preview.vercel.app/auth/callback?next=/signup/profile",
+				},
+			});
 		});
 
 		it("成功時にredirect('/signup?success=true')が呼ばれる", async () => {

--- a/apps/web/src/app/signup/actions.ts
+++ b/apps/web/src/app/signup/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { getSiteUrl } from "@/lib/site-url";
 import { createClient } from "@/lib/supabase/server";
 import { signUpSchema } from "@/lib/validations/auth";
 
@@ -23,12 +24,13 @@ export async function signUp(
 	}
 
 	const supabase = await createClient();
+	const siteUrl = await getSiteUrl();
 
 	const { data, error } = await supabase.auth.signUp({
 		email,
 		password,
 		options: {
-			emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"}/auth/callback?next=/signup/profile`,
+			emailRedirectTo: `${siteUrl}/auth/callback?next=/signup/profile`,
 		},
 	});
 

--- a/apps/web/src/lib/site-url.test.ts
+++ b/apps/web/src/lib/site-url.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHeaders = vi.fn();
+vi.mock("next/headers", () => ({
+	headers: () => mockHeaders(),
+}));
+
+import { getSiteUrl } from "./site-url";
+
+const createHeaderMap = (entries: Record<string, string>) => ({
+	get: (key: string): string | null => entries[key.toLowerCase()] ?? null,
+});
+
+describe("getSiteUrl", () => {
+	const originalEnv = process.env.NEXT_PUBLIC_SITE_URL;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SITE_URL = "";
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			process.env.NEXT_PUBLIC_SITE_URL = "";
+		} else {
+			process.env.NEXT_PUBLIC_SITE_URL = originalEnv;
+		}
+	});
+
+	describe("NEXT_PUBLIC_SITE_URL 優先", () => {
+		it("環境変数が設定されていればそれを返す", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com";
+			mockHeaders.mockResolvedValue(createHeaderMap({}));
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://beersalon.com");
+		});
+
+		it("環境変数の末尾スラッシュは除去される", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com/";
+			mockHeaders.mockResolvedValue(createHeaderMap({}));
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://beersalon.com");
+		});
+	});
+
+	describe("x-forwarded-host / x-forwarded-proto によるフォールバック", () => {
+		it("x-forwarded-host と x-forwarded-proto が揃っていればそれを組み立てる", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					"x-forwarded-host": "example.vercel.app",
+					"x-forwarded-proto": "https",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://example.vercel.app");
+		});
+
+		it("x-forwarded-host のみで host が localhost なら http スキームを使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					"x-forwarded-host": "localhost:3000",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("http://localhost:3000");
+		});
+	});
+
+	describe("host ヘッダーへのフォールバック", () => {
+		it("host: localhost:3000 のみで http スキームを使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "localhost:3000",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("http://localhost:3000");
+		});
+
+		it("host: example.com のみなら https スキームを使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "example.com",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://example.com");
+		});
+	});
+
+	describe("デフォルトフォールバック", () => {
+		it("ヘッダーが何も無ければ http://localhost:3000 を返す", async () => {
+			mockHeaders.mockResolvedValue(createHeaderMap({}));
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("http://localhost:3000");
+		});
+	});
+});

--- a/apps/web/src/lib/site-url.test.ts
+++ b/apps/web/src/lib/site-url.test.ts
@@ -25,6 +25,8 @@ describe("getSiteUrl", () => {
 		} else {
 			process.env.NEXT_PUBLIC_SITE_URL = originalEnv;
 		}
+		// Why not: NODE_ENV を直接代入すると Node の型制約で TypeError になるため vi.unstubAllEnvs で復元する。
+		vi.unstubAllEnvs();
 	});
 
 	describe("NEXT_PUBLIC_SITE_URL 優先", () => {
@@ -45,6 +47,34 @@ describe("getSiteUrl", () => {
 
 			expect(url).toBe("https://beersalon.com");
 		});
+
+		it("環境変数にパスが含まれていても origin に正規化される", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com/some/path";
+			mockHeaders.mockResolvedValue(createHeaderMap({}));
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://beersalon.com");
+		});
+
+		it("環境変数に不正値が入っていれば warn を出してヘッダー解決にフォールバックする", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "not-a-url";
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "example.com",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
+			);
+			expect(url).toBe("https://example.com");
+
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("x-forwarded-host / x-forwarded-proto によるフォールバック", () => {
@@ -53,6 +83,18 @@ describe("getSiteUrl", () => {
 				createHeaderMap({
 					"x-forwarded-host": "example.vercel.app",
 					"x-forwarded-proto": "https",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://example.vercel.app");
+		});
+
+		it("x-forwarded-host のみ（proto なし）で非localhost なら https を補完する", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					"x-forwarded-host": "example.vercel.app",
 				}),
 			);
 
@@ -98,6 +140,54 @@ describe("getSiteUrl", () => {
 
 			expect(url).toBe("https://example.com");
 		});
+
+		it("host: localhost.evil.com は localhost と誤判定せず https を使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "localhost.evil.com",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://localhost.evil.com");
+		});
+
+		it("host: 127.0.0.1.evil.com も localhost と誤判定せず https を使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "127.0.0.1.evil.com",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("https://127.0.0.1.evil.com");
+		});
+
+		it("host: [::1] は IPv6 loopback として http スキームを使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "[::1]",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("http://[::1]");
+		});
+
+		it("host: [::1]:3000 も IPv6 loopback として http スキームを使う", async () => {
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "[::1]:3000",
+				}),
+			);
+
+			const url = await getSiteUrl();
+
+			expect(url).toBe("http://[::1]:3000");
+		});
 	});
 
 	describe("デフォルトフォールバック", () => {
@@ -107,6 +197,57 @@ describe("getSiteUrl", () => {
 			const url = await getSiteUrl();
 
 			expect(url).toBe("http://localhost:3000");
+		});
+	});
+
+	describe("production での warn", () => {
+		it("NODE_ENV=production かつ NEXT_PUBLIC_SITE_URL 未設定なら warn を出す", async () => {
+			vi.stubEnv("NODE_ENV", "production");
+			process.env.NEXT_PUBLIC_SITE_URL = "";
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "example.com",
+				}),
+			);
+
+			await getSiteUrl();
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
+			);
+
+			warnSpy.mockRestore();
+		});
+
+		it("NODE_ENV=production でも NEXT_PUBLIC_SITE_URL が設定されていれば warn を出さない", async () => {
+			vi.stubEnv("NODE_ENV", "production");
+			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com";
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			mockHeaders.mockResolvedValue(createHeaderMap({}));
+
+			await getSiteUrl();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+
+			warnSpy.mockRestore();
+		});
+
+		it("NODE_ENV=development では env 未設定でも warn を出さない", async () => {
+			vi.stubEnv("NODE_ENV", "development");
+			process.env.NEXT_PUBLIC_SITE_URL = "";
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			mockHeaders.mockResolvedValue(
+				createHeaderMap({
+					host: "localhost:3000",
+				}),
+			);
+
+			await getSiteUrl();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+
+			warnSpy.mockRestore();
 		});
 	});
 });

--- a/apps/web/src/lib/site-url.ts
+++ b/apps/web/src/lib/site-url.ts
@@ -2,15 +2,60 @@ import { headers } from "next/headers";
 
 const DEFAULT_SITE_URL = "http://localhost:3000";
 
-const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, "");
+const isLocalHost = (host: string): boolean => {
+	// Why not: startsWith だと `localhost.evil.com` のような偽装ホスト名を localhost と誤判定し、
+	// production で誤って http スキームを返す経路を作りうるため、ホスト部分のみ完全一致で判定する。
+	const hostname = host.split(":")[0];
+	if (hostname === "localhost" || hostname === "127.0.0.1") {
+		return true;
+	}
+	// Why not: IPv6 loopback (`[::1]` または `[::1]:3000`) を扱うため、`[::1]` から始まるかも許可する。
+	return host === "[::1]" || host.startsWith("[::1]:");
+};
 
-const isLocalHost = (host: string): boolean =>
-	host.startsWith("localhost") || host.startsWith("127.0.0.1");
+const normalizeEnvUrl = (envUrl: string): string | null => {
+	try {
+		return new URL(envUrl).origin;
+	} catch {
+		return null;
+	}
+};
 
+/**
+ * 認証メール（新規登録確認・パスワード再設定）の `emailRedirectTo` / `redirectTo` に
+ * 使うベースURL（origin）を動的に解決する。
+ *
+ * Server Component / Server Action / Route Handler から呼び出し可能（`next/headers` を
+ * 利用するためリクエストコンテキストが必要）。リクエスト毎に最新のヘッダーから解決され、
+ * キャッシュは行わない。リクエスト内で複数回呼んでも問題ないが、頻繁に呼ぶ場合は
+ * 呼び出し元でローカル変数に保持してよい。
+ *
+ * 解決順序:
+ * 1. `NEXT_PUBLIC_SITE_URL`（最優先。`new URL().origin` で正規化する。不正値は無視）
+ * 2. `x-forwarded-host` + `x-forwarded-proto`（Vercel など信頼できる reverse proxy 経由時）
+ * 3. `host` ヘッダー（localhost は http、それ以外は https を補完）
+ * 4. `http://localhost:3000`（デフォルトフォールバック）
+ *
+ * production 環境で `NEXT_PUBLIC_SITE_URL` が未設定の場合、`x-forwarded-host` 由来の
+ * Host Header Injection 攻撃に対する耐性が信頼できる reverse proxy に依存するため、
+ * production では `NEXT_PUBLIC_SITE_URL` を必ず設定すること（未設定時は warn を出す）。
+ */
 export async function getSiteUrl(): Promise<string> {
 	const envUrl = process.env.NEXT_PUBLIC_SITE_URL;
 	if (envUrl && envUrl.length > 0) {
-		return stripTrailingSlash(envUrl);
+		const normalized = normalizeEnvUrl(envUrl);
+		if (normalized !== null) {
+			return normalized;
+		}
+		console.warn(
+			`[site-url] NEXT_PUBLIC_SITE_URL の値 "${envUrl}" が不正なURLのため無視します。スキーム (http(s)://) 付きのオリジンを設定してください。`,
+		);
+	}
+
+	if (process.env.NODE_ENV === "production") {
+		console.warn(
+			"[site-url] production では NEXT_PUBLIC_SITE_URL の設定を推奨します（x-forwarded-host 由来の Host Header Injection を防ぐため）。",
+		);
 	}
 
 	// Why not: 環境変数で固定値を持たせず動的解決にしているのは、Vercel のプレビュー環境ごとに
@@ -26,5 +71,5 @@ export async function getSiteUrl(): Promise<string> {
 
 	const protocol = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
 
-	return stripTrailingSlash(`${protocol}://${host}`);
+	return `${protocol}://${host}`;
 }

--- a/apps/web/src/lib/site-url.ts
+++ b/apps/web/src/lib/site-url.ts
@@ -1,0 +1,30 @@
+import { headers } from "next/headers";
+
+const DEFAULT_SITE_URL = "http://localhost:3000";
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, "");
+
+const isLocalHost = (host: string): boolean =>
+	host.startsWith("localhost") || host.startsWith("127.0.0.1");
+
+export async function getSiteUrl(): Promise<string> {
+	const envUrl = process.env.NEXT_PUBLIC_SITE_URL;
+	if (envUrl && envUrl.length > 0) {
+		return stripTrailingSlash(envUrl);
+	}
+
+	// Why not: 環境変数で固定値を持たせず動的解決にしているのは、Vercel のプレビュー環境ごとに
+	// ドメインが変わるため。`NEXT_PUBLIC_SITE_URL` 未設定時はリクエストヘッダーから組み立てる。
+	const headerList = await headers();
+	const forwardedHost = headerList.get("x-forwarded-host");
+	const forwardedProto = headerList.get("x-forwarded-proto");
+	const host = forwardedHost ?? headerList.get("host");
+
+	if (!host) {
+		return DEFAULT_SITE_URL;
+	}
+
+	const protocol = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
+
+	return stripTrailingSlash(`${protocol}://${host}`);
+}

--- a/routing.md
+++ b/routing.md
@@ -103,6 +103,11 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
   - `type=signup`（または `code` パラメータ）: 新規登録完了処理 → `/signup/profile` へ遷移
   - `type=recovery`: `verifyOtp` でリカバリーセッションを発行 → `next` クエリ（既定 `/password/reset`）へ遷移
   - リカバリー時に検証エラー: `/password/forgot?error=invalid_token` へリダイレクト
+- ベースURLの解決:
+  - 認証メールに記載するコールバックURLのオリジンは、Server Action 実行時のリクエストヘッダー（`x-forwarded-host` / `host`）から動的に解決する
+  - `NEXT_PUBLIC_SITE_URL` が設定されている場合はそれを最優先で使用する（production で固定したい場合のみ設定）
+  - これにより local / Vercel Preview / production のいずれの環境からの申請でも、メール内URLがリクエスト元のオリジンを指す
+  - 実装は `apps/web/src/lib/site-url.ts` の `getSiteUrl()` を参照
 
 #### 2-1-7. パスワード再設定ページ
 

--- a/routing.md
+++ b/routing.md
@@ -105,8 +105,9 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
   - リカバリー時に検証エラー: `/password/forgot?error=invalid_token` へリダイレクト
 - ベースURLの解決:
   - 認証メールに記載するコールバックURLのオリジンは、Server Action 実行時のリクエストヘッダー（`x-forwarded-host` / `host`）から動的に解決する
-  - `NEXT_PUBLIC_SITE_URL` が設定されている場合はそれを最優先で使用する（production で固定したい場合のみ設定）
+  - `NEXT_PUBLIC_SITE_URL` が設定されている場合はそれを最優先で使用する（production では Host Header Injection 対策のため必ず設定すること）
   - これにより local / Vercel Preview / production のいずれの環境からの申請でも、メール内URLがリクエスト元のオリジンを指す
+  - Supabase ダッシュボード側の Redirect URLs 許可リストには local / preview / production のいずれのオリジンも登録する必要がある。Vercel Preview はワイルドカード（例: `https://*.vercel.app/auth/callback`）で登録する
   - 実装は `apps/web/src/lib/site-url.ts` の `getSiteUrl()` を参照
 
 #### 2-1-7. パスワード再設定ページ


### PR DESCRIPTION
## Summary
- 認証メール（新規登録確認・パスワード再設定）の `emailRedirectTo` / `redirectTo` が `NEXT_PUBLIC_SITE_URL || "http://localhost:3000"` 固定で、Vercel Preview のような動的URL環境に追従できていなかった問題を修正
- Server Action 実行時のリクエストヘッダー（`x-forwarded-host` + `x-forwarded-proto`、無ければ `host`）からベースURLを動的解決する共通ユーティリティ `getSiteUrl()` を新設
- `NEXT_PUBLIC_SITE_URL` を最優先で見るためproduction で固定したい場合は引き続きそれが効く

## 主な変更
- `apps/web/src/lib/site-url.ts`: `getSiteUrl()` 新規追加（NEXT_PUBLIC_SITE_URL → x-forwarded-host+proto → host → fallback の順で解決）
- `apps/web/src/app/signup/actions.ts`: `emailRedirectTo` を `getSiteUrl()` ベースに置き換え
- `apps/web/src/app/password/forgot/actions.ts`: `redirectTo` を `getSiteUrl()` ベースに置き換え
- `apps/web/src/lib/site-url.test.ts`: 7 ケースの UT を追加（env優先 / 末尾スラッシュ除去 / x-forwarded-host / host単体 / localhost判定 / フォールバック）
- `apps/web/src/app/signup/actions.test.ts`, `apps/web/src/app/password/forgot/actions.test.ts`: `next/headers` をモックして URL アサーションを更新
- `routing.md` §2-1-6, `apps/web/.env.example`: ベースURL解決方針を追記

## Test plan
- [x] `pnpm test` 全パス（apps/web: 25 files / 281 tests）
- [x] `pnpm format` / `pnpm lint` クリーン
- [x] Playwright MCP で `/signup` 申請がエラーなく `?success=true` 遷移
- [x] Playwright MCP で `/password/forgot` 申請がエラーなく完了
- [x] `/login` 画面の表示・ナビゲーション回帰なし
- [ ] Vercel Preview デプロイでメール内URLが preview オリジンを指すこと（merge後のpreviewで確認）
- [ ] Supabase ダッシュボード側の Redirect URLs 許可リストに preview ワイルドカード登録の要否を確認

## 補足
- local Supabase は `enable_confirmations = false` のため確認メール送信が発生せず、メール内URL自体の目視確認は preview デプロイで実施する必要がある
- 渡している URL 値の正しさは UT で担保（actions テストで `http://localhost:3000/auth/callback?next=/signup/profile` 等が引数に渡ることを検証済み）

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)