### PR TITLE
ci: develop プレビューデプロイに固定エイリアスを付与 (#257)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Why not cancel-in-progress=true: develop 連続 push 時に古いデプロイの alias 付与が
+# 新しいデプロイより遅れて走ると、固定エイリアスが古いビルドを指し続ける事故が起きるため、
+# 同一ブランチのデプロイは直列化する。
 concurrency:
   group: deploy-${{ github.ref_name }}
   cancel-in-progress: false
@@ -38,6 +41,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,24 +58,30 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }}
 
       - name: Build project (web)
-        run: vercel build ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ needs.guard.outputs.prod_flag }}
         env:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
 
       - name: Deploy to Vercel (web)
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }})
+          raw=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }})
+          url=$(echo "$raw" | grep -oE 'https://[^[:space:]]+\.vercel\.app' | tail -n 1)
+          if [ -z "$url" ]; then
+            echo "Failed to extract deployment URL from vercel deploy output:"
+            echo "$raw"
+            exit 1
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed web (${{ needs.guard.outputs.target }}): $url"
 
       - name: Assign develop preview alias (web)
-        if: needs.guard.outputs.target == 'preview'
+        if: needs.guard.outputs.target == 'preview' && github.ref_name == 'develop'
         run: |
-          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-develop.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-develop.vercel.app
           echo "Aliased web preview to https://beer-salon-develop.vercel.app"
 
   deploy-admin:
@@ -83,6 +93,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,20 +110,26 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ needs.guard.outputs.target }}
 
       - name: Build project (admin)
-        run: vercel build ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ needs.guard.outputs.prod_flag }}
 
       - name: Deploy to Vercel (admin)
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }})
+          raw=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }})
+          url=$(echo "$raw" | grep -oE 'https://[^[:space:]]+\.vercel\.app' | tail -n 1)
+          if [ -z "$url" ]; then
+            echo "Failed to extract deployment URL from vercel deploy output:"
+            echo "$raw"
+            exit 1
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed admin (${{ needs.guard.outputs.target }}): $url"
 
       - name: Assign develop preview alias (admin)
-        if: needs.guard.outputs.target == 'preview'
+        if: needs.guard.outputs.target == 'preview' && github.ref_name == 'develop'
         run: |
-          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-admin-develop.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-admin-develop.vercel.app
           echo "Aliased admin preview to https://beer-salon-admin-develop.vercel.app"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,12 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed web (${{ needs.guard.outputs.target }}): $url"
 
+      - name: Assign develop preview alias (web)
+        if: needs.guard.outputs.target == 'preview'
+        run: |
+          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-develop.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          echo "Aliased web preview to https://beer-salon-develop.vercel.app"
+
   deploy-admin:
     needs: guard
     runs-on: ubuntu-latest
@@ -104,3 +110,9 @@ jobs:
           url=$(vercel deploy --prebuilt ${{ needs.guard.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed admin (${{ needs.guard.outputs.target }}): $url"
+
+      - name: Assign develop preview alias (admin)
+        if: needs.guard.outputs.target == 'preview'
+        run: |
+          vercel alias set "${{ steps.deploy.outputs.url }}" beer-salon-admin-develop.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          echo "Aliased admin preview to https://beer-salon-admin-develop.vercel.app"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 ---
 
+## 🌐 プレビュー環境（develop 追従）
+
+`develop` ブランチに push されると、GitHub Actions が Vercel に自動デプロイし、以下の固定 URL を最新ビルドに付け替える。
+共有時はコミット別ハッシュ URL ではなく **必ずこちらを使うこと**（ハッシュ URL はそのコミット時点のビルドに固定されるため、共有後に追加修正が反映されない）。
+
+| アプリ | プレビュー URL |
+|--------|---------------|
+| BeerSalon（ユーザー画面） | https://beer-salon-develop.vercel.app |
+| BeerSalonAdmin（管理画面） | https://beer-salon-admin-develop.vercel.app |
+
+`main` への merge では production（`https://beer-salon.vercel.app` / 管理画面の本番ドメイン）にデプロイされる。
+
+---
+
 ## ✅ MVPに含める機能
 
 - ユーザー登録 / ログイン

--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 | BeerSalon（ユーザー画面） | https://beer-salon-develop.vercel.app |
 | BeerSalonAdmin（管理画面） | https://beer-salon-admin-develop.vercel.app |
 
-`main` への merge では production（`https://beer-salon.vercel.app` / 管理画面の本番ドメイン）にデプロイされる。
+`main` への merge では production（`https://beer-salon.vercel.app` / 管理画面本番ドメインは未確定）にデプロイされる。
+
+### トラブルシュート
+
+- **片肺で alias が古いまま残る場合**
+  - `deploy-web` / `deploy-admin` は並列実行されるため、片方の alias 付与だけ失敗すると web/admin の指すコミットがズレる可能性がある。
+  - 対処: `develop` に空コミット等で再 push し、両ジョブを揃え直す。
+- **初回マージで `vercel alias set` が失敗する場合**
+  - 同名 alias が他用途で予約済みの可能性あり。Vercel ダッシュボード → Project → Settings → Domains で該当 alias を解放してから再 push する。
+- **最新を確認したいのに古いビルドが見える場合**
+  - 上記固定 URL は CDN キャッシュの影響を受けることがある。ブラウザのスーパーリロード（Cmd+Shift+R）か、curl の `-H 'Cache-Control: no-cache'` で確認する。
 
 ---
 


### PR DESCRIPTION
## Summary
- `develop` への push で動く Vercel デプロイステップ（`.github/workflows/deploy.yml`）に `vercel alias set` を追加
- web / admin それぞれに固定エイリアス URL を割り当て、コミット別ハッシュ URL を共有した際に古いビルドが見えてしまう問題を解消
- README に「プレビュー環境（develop 追従）」セクションを追記

Closes #257

## Changes
| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | `deploy-web` / `deploy-admin` ジョブの末尾に、`target == 'preview'` 時のみ実行される `vercel alias set` ステップを追加 |
| `README.md` | 「ローカル E2E 実行」の直後に「プレビュー環境（develop 追従）」セクションを追加し、固定 URL を明記 |

## 固定エイリアス URL

| アプリ | URL |
|--------|-----|
| BeerSalon（ユーザー画面） | https://beer-salon-develop.vercel.app |
| BeerSalonAdmin（管理画面） | https://beer-salon-admin-develop.vercel.app |

## Acceptance Criteria
- [ ] `develop` への push で `Deploy to Vercel` ワークフローが成功する
- [ ] 成功後、`beer-salon-develop.vercel.app` が最新の develop プレビューを指している
- [ ] 成功後、`beer-salon-admin-develop.vercel.app` が最新の develop プレビューを指している
- [ ] 次の `develop` push の後、上記固定エイリアスがさらに最新のプレビューに切り替わっている
- [ ] `main` への push（production デプロイ）では alias 付与ステップが skip される
- [ ] 既存の production デプロイの挙動に影響がない

## Test plan
- [ ] PR を develop にマージ後、`Deploy to Vercel` ワークフローのログで `Assign develop preview alias (web/admin)` ステップが成功していることを確認
- [ ] `curl -sI https://beer-salon-develop.vercel.app/login` で 401（SSO）または 200 が返ることを確認
- [ ] ブラウザで `https://beer-salon-develop.vercel.app/login` にアクセスし、最新の `develop` のビルド（PR #248 の placeholder 削除等）が反映されていることを確認
- [ ] 次に `develop` へ別の PR をマージし、同じ URL が更新後のビルドを指していることを確認
- [ ] `main` への merge 時に alias ステップが skip され、production デプロイが従来通り完了することを確認

## 補足
- alias 付与失敗は CI 失敗として扱う設計（`continue-on-error` は付けない）。デプロイ自体は成功しても alias が古いままだと共有 URL が破綻するため、即気付ける方が良いという判断
- Vercel 側で同名 alias が既に他用途で使われていた場合は、初回 push で `vercel alias set` がエラーになる可能性あり。その場合は Vercel ダッシュボードで該当 alias を解放してから再 push

🤖 Generated with [Claude Code](https://claude.com/claude-code)