### PR TITLE
feat: worktree起点の開発ワークフローを導入

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -13,19 +13,69 @@ agent: frontend-engineer
 
 - `/plan $ARGUMENTS` で計画を出力し、ユーザーが承認済みであること
 - 計画未承認の場合は、先に `/plan $ARGUMENTS` を実行するよう案内して終了すること
+- **このスキルは worktree 起点の常時運用が前提**。設計の全体像は `docs/worktree-workflow.md` を参照。
+  単独実装でも割り込み実装でも、1タスク = 1 worktree で行い、developメインは司令塔として clean に保つ。
+
+#### worktree モードと撤退路（`--no-worktree`）
+
+- **既定は worktree モード**（1タスク = 1 worktree）。
+- 引数に **`--no-worktree`** が含まれる場合は、worktree を作らず**従来の checkout 方式**で実装する
+  （1-0b / 1-1b を参照）。「今回は worktree が割に合わない」と判断したタスクで、その場で切り替えられる。
+  - 例: `/implement 210 --no-worktree`
+- この撤退路はコードを戻す必要がない。worktree 運用が常に割に合わないと感じたら、
+  運用として `--no-worktree` を既定にする（docs/worktree-workflow.md に方針を追記して判断を残す）。
 
 ### Phase 1: 実装
 
-#### 1-1. ブランチ作成
+> 以下 1-0 / 1-1 は worktree モードの手順。`--no-worktree` 指定時は代わりに 1-0b / 1-1b を行う。
 
-- developベースでブランチを作成する
+#### 1-0. 前提チェック（worktree モード。満たさなければ停止）
+
+- `git branch --show-current` が `develop` であること。
+  - developメイン会話を司令塔とし、ここから worktree を切る運用のため。
+  - develop 以外なら「`git switch develop` してから再実行してください」と案内して停止。
+- 司令塔（developメイン）の作業ツリーが clean であること（`git status --porcelain` が空）。
+  - clean でなければ、未コミット変更の扱いをユーザーに確認してから進む。
+
+#### 1-0b. 前提チェック（`--no-worktree` 時）
+
+- 既存の checkout 方式の作法に従う。worktree は作らない。
+- 並列実装はできない（メインの作業ツリーを1つ占有するため）。単独タスク向け。
+
+#### 1-1. worktree とブランチの作成（worktree モード）
+
+- **このタスク専用の worktree を develop 起点で作成する**（1タスク = 1 worktree）。
 - ブランチ命名規則: `feature/<issue番号>-<英語スラッグ>` または `bugfix/<issue番号>-<英語スラッグ>`
   - 例: `feature/210-add-e2e-ci`, `bugfix/305-fix-login-redirect`
-- `gh issue develop` の `--name` オプションでブランチ名を明示指定する:
+- 手順:
   ```
-  gh issue develop $ARGUMENTS --base develop --checkout --name <prefix>/$ARGUMENTS-<英語スラッグ>
+  git fetch origin develop
+  git worktree add .claude/worktrees/<prefix>-$ARGUMENTS-<英語スラッグ> origin/develop -b <prefix>/$ARGUMENTS-<英語スラッグ>
   ```
-- ブランチ名に `--name` を渡さないと、Issueタイトル（日本語）からブランチ名が自動生成され、Git操作・URL・CI/CDログで扱いにくくなるので必ず明示指定する
+  - **なぜ生の `git worktree add` か**: Claude Code の Agent `isolation: "worktree"` は既定ベースが
+    `origin/HEAD`(=main) で develop 起点に固定できない。develop追従プレビュー運用と整合させるため、
+    ベースを明示できる生コマンドを使う（`docs/worktree-workflow.md` §4 参照）。
+- 以降の実装作業（1-2〜1-6）は、すべてこの worktree ディレクトリ内で行う。
+
+##### worktree の初期化（スキルの手続きとして明示的に実行）
+
+git / Claude Code のネイティブ機能では自動化されないため、worktree 作成直後に必ず行う:
+
+1. 環境ファイルをコピー: `apps/web/.env.local` と `apps/admin/.env.local` を新 worktree へコピー。
+   （`.worktreeinclude` は標準機能ではなく取り決めにすぎないため、コピーはこの手続きで行う）
+2. 依存インストール: 新 worktree 内で `pnpm install`。
+
+#### 1-1b. ブランチ作成（`--no-worktree` 時）
+
+- worktree を作らず、メインの作業ツリー上で develop からブランチを切る:
+  ```
+  git switch develop
+  git pull origin develop
+  git switch -c <prefix>/$ARGUMENTS-<英語スラッグ>
+  ```
+- 環境ファイルのコピー・`pnpm install` は不要（既存の node_modules / .env.local をそのまま使う）。
+  これが worktree モードに対するオーバーヘッド削減の中身。
+- 以降の実装作業は通常どおりこのブランチ上で行う。
 
 ##### 英語スラッグの決め方
 
@@ -41,25 +91,32 @@ agent: frontend-engineer
   - バグ修正系Issue → `bugfix/`
   - それ以外（機能追加・改善・リファクタ等）→ `feature/`
 
-##### `--name` が使えない場合の代替手順
+##### Issue とブランチの紐付け
 
-`gh` のバージョンが古く `--name` が使えない場合は、以下の手順でブランチを作成する:
-
-```
-git checkout develop
-git pull origin develop
-git checkout -b feature/$ARGUMENTS-<英語スラッグ> develop
-git push -u origin HEAD
-```
+- worktree で作成したブランチを push する際、PR本文に `Closes #$ARGUMENTS` を記載することで
+  Issue と紐付ける（Phase 2-2）。`gh issue develop` は worktree 運用では使わない
+  （ブランチ作成は上記の `git worktree add ... -b` で行うため）。
 
 #### 1-2. プロダクトコード実装
 
 - Issue の要件に基づきコードを実装する
 
-#### 1-3. UT実装・実行
+#### 1-3. UT実装・実行（worktree内で完結＝並列OK）
 
-- Vitest でユニットテストを実装する
+- Vitest でユニットテストを実装する（`pnpm test`。Supabase/Prismaはモックし共有DBに触らない）
 - `pnpm test` で全テストがパスすることを確認する
+- UT は共有DBに依存しないため、複数 worktree で同時に実行してよい。
+
+#### 1-3-1. 共有DB依存テスト（IT・E2E）の扱い
+
+> **共有インフラ制約（厳守）**: 全 worktree は単一 Supabase（54421）・単一物理DB・固定ポートを共有する。
+> 以下は共有DBに触るため、複数 worktree で同時実行すると競合して非決定的になる:
+> - **IT（`pnpm test:integration`、`*.integration.test.ts`）** — seed済み共有DBに実接続する
+> - **E2E（`pnpm test:e2e`、Playwright）** — 共有DB＋固定ポートを使う
+>
+> 並列実装中はこれらを worktree 内で実行せず、**司令塔が `qa-engineer` を1体ずつ直列起動して消化**する
+> （`docs/worktree-workflow.md` §3）。
+> **単独実装（worktree が1つだけ）なら競合しない**ため、このフロー内でそのまま IT/E2E を実行してよい。
 
 #### 1-4. E2Eテスト実装・実行
 
@@ -112,6 +169,15 @@ Issueが画面レイアウト系タスク（UI実装、ページ作成、レイ�
 
 - `gh pr create --base develop` でPRを作成する
 - PR本文に `Closes #Issue番号` を記載する
+
+#### 2-2-1. worktree の後片付け
+
+- **worktree モードの場合のみ実施**（`--no-worktree` 時はスキップ）。
+- PR作成が完了したら、このタスクの worktree を撤去する:
+  ```
+  git worktree remove .claude/worktrees/<このタスクのworktree>
+  ```
+- 未コミット変更が残っている場合は撤去せず、その旨を完了報告に明記する。
 
 #### 2-3. 完了報告
 

--- a/.claude/skills/parallel/SKILL.md
+++ b/.claude/skills/parallel/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: parallel
+description: 複数Issueを一括投入し、各タスクを /implement の手順でworktree並列実装する司令塔バッチ。実装ロジック本体は /implement が持つ。
+when_to_use: 文脈の異なる複数のIssueを一度にまとめて実装させたいとき、「並列で」「parallel」「まとめて実装」などの発言時。1タスクだけなら /implement を直接使う。割り込みで後から1本足すときも /implement を呼べばよい。
+agent: frontend-engineer
+---
+
+## 並列開発バッチ（司令塔オーケストレーター）
+
+引数: `$ARGUMENTS`（並列で実装したいIssue番号の列挙。例: 210 305 412）
+
+### このスキルの位置づけ
+
+**実装フローの本体は `/implement` が持つ**（worktree作成・前提チェック・実装・テスト・PR・後片付け）。
+このスキルは「複数Issueを一度にまとめて指示したいとき」に、各Issueへ `/implement` 相当の手順を
+発火し、E2Eキューを束ねるだけの薄いオーケストレーターである。
+
+> 並列は本来「`/implement` を複数回呼んだ結果として自然に発生する」もの。
+> 1タスクだけ、あるいは割り込みで後から1本足すだけなら **このスキルは不要で、`/implement` を直接呼ぶ**。
+> このスキルは「最初から複数Issueをまとめて投入したい」ときの入口にすぎない。
+
+設計の全体像・共有インフラ制約・E2Eキューの根拠は `docs/worktree-workflow.md` を参照。
+
+### 前提条件（満たさなければ停止）
+
+- `git branch --show-current` が `develop`（司令塔）であること。
+- 司令塔の作業ツリーが clean であること。
+- 並列対象の各Issueが `/plan` で承認済みであること。未承認があれば先に `/plan` を案内。
+
+### Phase 0: 適格判定
+
+各Issueについて、`docs/worktree-workflow.md` §2 の制約に照らして判定する。
+
+- **DBスキーマ変更（prisma/・supabase migration・prisma generate要）を含むタスク**は
+  並列禁止。最初の1つがロックを取り、他は待機（直列化）する。
+- 判定に迷う場合は推測せず、「このタスクはDBスキーマを触りますか？」とユーザーに確認する。
+
+### Phase 1: 並列実装（各Issueを /implement の手順で）
+
+- 適格な各Issueについて、`subagent_type: "frontend-engineer"` のサブエージェントを
+  **1メッセージ内でまとめて起動**し、並列に走らせる。
+- 各サブエージェントには `/implement` の Phase 1 手順を実行させる:
+  - develop起点で `.claude/worktrees/<branch>` を作成（`git worktree add ... origin/develop -b <branch>`）
+  - 環境ファイルコピー + `pnpm install`
+  - 実装 + UT（`pnpm test`。共有DBに触らないので並列OK）
+  - **IT（`pnpm test:integration`）・E2E・dev起動はここでは行わない**（共有DB依存。Phase 2 で司令塔が直列消化）
+- 各サブエージェントは最終報告に「変更ファイル・UT結果・IT/E2E要否・残課題」を含めて返す。
+
+### Phase 2: IT/E2E直列キュー（司令塔が qa-engineer を1体ずつ）
+
+- 共有DBに触るテスト（IT = `pnpm test:integration`、E2E）の実行主体は **`qa-engineer` エージェント**。
+  司令塔はキューを管理するだけ。
+- IT/E2E要求のあった worktree を要求順にリストアップし、上から順に:
+  1. `qa-engineer` を **1体だけ起動**し、その worktree の IT/E2E・受入条件検証を実施させる。
+  2. 完了したら結果を該当タスクのPRへ反映する。
+  3. 次の worktree へ進み、また `qa-engineer` を1体起動する。
+- **厳守**: `qa-engineer` を複数同時起動して IT/E2E を並列で回さない（共有DB＋固定ポート競合で非決定的になる）。
+
+### Phase 3: コミット・PR・後片付け
+
+各 worktree について、`/implement` の Phase 2 手順に準拠:
+
+- コミット → push → `gh pr create --base develop`（PR本文に `Closes #<Issue>`）。
+- PR作成後、`git worktree remove .claude/worktrees/<branch>` で撤去（未コミット変更が残る場合は報告）。
+
+### 完了報告
+
+- 各タスクのブランチ名・PRリンク・UT/E2E結果を一覧で報告する。
+- 直列に回したタスク・スキップしたタスクがあれば理由を明記する。
+
+### アンチパターン（`docs/worktree-workflow.md` §5 と共通）
+
+- worktreeごとに `supabase start` / 複数worktreeで同時マイグレーション
+- devポートの動的ずらし（許可リスト・SITE_URLとズレて認証が壊れる）
+- 複数worktreeで同時にE2E（共有DBシード競合）

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ playwright/.cache/
 # claude code runtime locks
 .claude/scheduled_tasks.lock
 
+# claude code worktrees (並列開発スキルが develop 起点で作成する作業ツリー。メインチェックアウトに含めない)
+.claude/worktrees/
+
 # claude code subagent personal memory (not shared across team)
 .claude/agent-memory/
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+# 並列開発スキル(/parallel)が develop 起点で worktree を作るとき、
+# gitignore 済みでチェックアウトに含まれない環境ファイルを新worktreeへ自動コピーする対象。
+# web/admin は同一Supabase(54421)・同一env構成を共有するため、両方の .env.local が必要。
+apps/web/.env.local
+apps/admin/.env.local

--- a/docs/worktree-workflow.md
+++ b/docs/worktree-workflow.md
@@ -1,0 +1,229 @@
+# Worktree 開発ワークフロー設計
+
+BeerSalon の「常時 worktree 開発」と並列開発の設計をまとめたドキュメント。
+2026-06-18 にユーザーと設計合意。技術的成立性は実機検証済み（後述）。
+
+---
+
+## 0. 撤退路（`--no-worktree`）と費用対効果の前提
+
+このワークフローは「常時worktree」を既定とするが、**worktree作成にはタスクごとの固定オーバーヘッド
+（`pnpm install` 数十秒〜数分、必要なら `prisma generate`）がある**。一方で並列化の旨味は
+「実装＋UT」フェーズに限られ、IT/E2E は共有DBのため直列キューになる（§3）。
+
+そのため、個人開発では「重い独立タスクが本当に同時に複数ある」場面以外は worktree が割に合わないことがある。
+
+**撤退路**: `/implement <Issue> --no-worktree` でその場で従来の checkout 方式に切り替えられる
+（worktree を作らず install もスキップ）。コードを巻き戻す必要はない。
+worktree が恒常的に割に合わないと判断したら、運用として `--no-worktree` を既定にし、その判断をこの節に追記する。
+
+> 「やめる」は Git で戻すのではなくスキルのスイッチで切る、が原則。
+> どうしても全撤去したい場合に限り、導入PRごと revert する（再現性のある最終手段）。
+
+## 1. 基本思想
+
+**並列・単独を問わず、開発は必ず git worktree で行う（既定）。developメインのチェックアウトは「司令塔」専用とし、実装で汚さない。**
+（`--no-worktree` 指定時はこの限りでない。§0参照）
+
+- `develop` メインチェックアウト = 司令塔（指揮所）。常に clean に保つ。
+- 各タスクの実装は `.claude/worktrees/<branch>` で行う。
+- これにより「単独開発」も「並列開発」もフローの入口が統一される。
+
+### なぜこの形か（Why）
+
+- 司令塔の `git status` がいつ見ても綺麗で、ブランチ取り違え・stash地獄が起きない。
+- `/implement`（単独）も `/parallel`（並列）も「worktreeを切る」が共通の起点になる。
+- worktree はファイルを物理的に分離するので、複数タスクのコードが混ざらない。
+
+### 重要な前提：worktree が隔離するのは「ファイルだけ」
+
+worktree は作業ディレクトリのファイルを分離するが、**以下は全 worktree で共有されたまま**：
+
+- **Supabase（Kong 54421 / Postgres 54422、単一インスタンス・単一物理DB）**
+- **devサーバーのポート（web 3000 / admin 3001 が既定）**
+
+→ 「常時worktree化」が解決するのは *ファイルの分離* であって *ランタイムの分離* ではない。
+この事実が、以下の①②③の制約すべての根っこにある。
+
+---
+
+## 2. 確定した制約と対策
+
+### ① DBスキーマ変更は直列ロック
+
+全 worktree が同一物理DB（54422 の `postgres`）を共有するため、スキーマ変更
+（`prisma/` 変更・`supabase/migrations/` 追加・`prisma generate` を要する変更）を
+2つの worktree で同時に行うと互いに壊し合う。
+
+**対策**: スキーマ変更を含むタスクは、最初の worktree がロックを取得し、他 worktree は待機（直列化）。
+ロックは排他ファイル（例: `prisma/.migration.lock`）で表現する。
+ロックは「同時書き込み事故」を防ぐが「変更の波及」は防げない点に注意——
+スキーマ変更中は他 worktree の dev/E2E も止めるのが安全。
+
+### ② devサーバーはポートプールから払い出し
+
+複数 worktree で `pnpm dev` を同時起動するとポートが衝突する。
+
+**対策（実機検証済みで成立）**:
+- ポートを「プール」から払い出す（例: 3000/3001, 3100/3101, 3200/3201）。
+- **`NEXT_PUBLIC_SITE_URL` を明示**してオリジンのポートを制御する。
+  これを設定すれば `getSiteUrl()` の host 解決を上書きできる（実装確認済み）。
+- **Supabase の Redirect URL 許可リストにポートを exact 列挙**する
+  （例: `http://localhost:3000/**`, `http://localhost:3100/**` …）。
+  ポート番号のワイルドカードは公式保証がないため、有限個を個別列挙して回避する。
+
+**やってはいけない**: ポートを動的に好き勝手ずらすこと。
+`getSiteUrl()`（`apps/web/src/lib/site-url.ts`）の host 解決と Supabase 許可リストがズレ、
+認証・パスワードリセットのメールリンクが壊れる（routing.md 記載の挙動）。
+
+**現状の改修要否**:
+- `package.json` の dev script（`-p 3000` / `-p 3001` 固定）をポート可変にする改修が必要。
+- Playwright config の baseURL / webServer.url 固定を解除する改修が必要。
+
+### ③ E2E用DBの物理複製は「不成立」（採用しない）
+
+> 当初「マスターDBを TEMPLATE で複製→テスト→DROP し、worktree ごとに使い捨てDBで
+> ステートレスにE2E並列」という案を検討したが、**実機検証で技術的に不成立と判明した**。
+
+**検証で確認した事実（2026-06-18、実コマンド実行）**:
+
+1. **複製できない** — `postgres` DB に Supabase サービスの常時接続が約11本
+   （PostgREST / Realtime / pg_cron / pg_net / Storage）。スタック稼働中は
+   `CREATE DATABASE ... TEMPLATE postgres` が
+   `source database "postgres" is being accessed by other users` で恒久的に失敗する。
+2. **仮に複製できても無意味** — GoTrue（`GOTRUE_DB_DATABASE_URL`）・
+   PostgREST（`PGRST_DB_URI`）・Webアプリの Prisma（`DATABASE_URL`）が
+   全員 DB名 `postgres` にハードコード結合。クローンDBは認証層が誰も参照しない。
+   E2Eテストユーザーは `supabase.auth.admin.createUser()` で
+   Kong(54421)→GoTrue→`postgres`DB の `auth.users` に作られるため、別名DBには届かない。
+
+**結論**: GoTrue/PostgREST/アプリが全員 `postgres` DB名に密結合しているため、
+DB単位の物理分離は認証層に効かない。これは CLAUDE.md の
+「supabase init 禁止・54421固定」ルールの裏返しでもある。
+
+**代替（ステートレス化の現実解）**:
+現行の「固定ID + `ON CONFLICT DO NOTHING` による冪等seed」維持を基本とし、
+必要ならテスト前後の truncate でデータ空間を綺麗にする。物理DB分離は採らない。
+
+---
+
+## 3. 共有DB依存テスト（IT・E2E）は「司令塔での直列キュー」
+
+③が不成立のため、共有DBに触るテストは並列化せず**司令塔（developメイン会話）が1つずつ直列実行**する。
+
+### テストの3分類（現状のテスト実体に基づく・実機調査済み）
+
+| フェーズ | スクリプト | 共有DB依存 | 並列可否 |
+|---|---|---|---|
+| 実装 + **UT** | `pnpm test`（vitest、Supabase/Prismaをモック） | 触らない | **並列OK**（worktree内で完結） |
+| **IT（統合テスト）** | `pnpm test:integration`（`*.integration.test.ts`） | **触る** | **直列キュー** |
+| **E2E** | `pnpm test:e2e`（Playwright） | **触る（DB＋固定ポート）** | **直列キュー** |
+
+- IT は `apps/*/src/test/integration-setup.ts` が `supabase start` 必須・`DATABASE_URL` で実DB接続・
+  `pnpm e2e:setup` の seed 済みDBを前提とする。**E2E と同じ共有DBを使う**ため、IT も E2E と同様に直列消化する。
+- 「並列で作る」のは **実装 + UT まで**。IT/E2E は司令塔の直列キューへ。
+
+以下、本節で「E2E」と書く箇所は **IT も含む共有DB依存テスト全般**を指す。
+
+```
+worktree-A (実装サブエージェント) ──「実装＋UT完了。IT/E2E要求」──┐
+worktree-B (実装サブエージェント) ──「実装＋UT完了。IT/E2E要求」──┤
+worktree-C (実装サブエージェント) ──「実装＋UT完了。IT/E2E要求」──┤
+                                                               ▼
+                                       ┌──────────────────────────────┐
+                                       │ 司令塔 (developメイン)          │
+                                       │ IT/E2E実行キューを管理（直列消化）│
+                                       │  ① qa-engineer起動→A検証→結果へ │
+                                       │  ② qa-engineer起動→B検証→結果へ │
+                                       │  ③ qa-engineer起動→C検証→結果へ │
+                                       └──────────────────────────────┘
+```
+
+- **並列なのは「実装＋UT」まで**。ここは各 worktree で実装サブエージェントが同時に走る（短縮効果大）。
+  IT/E2E は共有DBに触るため司令塔のキューへ集約する。
+- **E2E は司令塔が交通整理し、実行は `qa-engineer` エージェントに1体ずつ任せる**。
+  司令塔が worktree ごとに `qa-engineer` を **1体だけ起動 → 検証完了 → 次を起動** の順で直列消化する。
+- 各実装サブエージェントは最終報告に「E2E要否」を含めて返す。司令塔が要求順に消化し、
+  1本終わるごとに該当タスクのPRへ結果を反映する。
+
+### なぜ qa-engineer に任せるか（実行主体の確定）
+
+- BeerSalon には既に `qa-engineer`（受入条件検証・Playwright担当）と `/playwright`・`/layout-review`
+  スキルがあり、E2E はこのエージェントが担う前提で設計されている。司令塔が直接 `pnpm e2e` を回すより、
+  検証の専門性と既存資産との一貫性を保てる。
+- 司令塔が直接回すと、E2Eログや試行錯誤が司令塔のコンテキスト窓に流れ込んで肥大化する。
+  実行を qa-engineer に切り出すことで司令塔は「キュー管理」に専念できる。
+
+### 厳守事項
+
+- **`qa-engineer` を複数同時に起動して E2E を並列で回してはいけない**（共有DB＋固定ポート競合で
+  結果が非決定的になる）。司令塔は必ず「1体起動 → 完了 → 次」を守る。
+
+### なぜ許容範囲か
+
+BeerSalon の E2E はテストピラミッド原則で最小化されている（web 5本 + admin 2本 = 計7本、
+残りは UT で担保）。1タスク分のE2Eは数分で済むため、「数分 × タスク数」の直列キューで収まる。
+「並列で作って、直列で検品する」生産ライン型。検品台（共有DB＋固定ポート）が1つなので
+そこだけ列になる。
+
+---
+
+## 4. worktree 作成の正確な手順
+
+### develop 起点で切る（必須）
+
+```
+git fetch origin develop
+git worktree add .claude/worktrees/<branch> origin/develop -b <branch>
+```
+
+- ブランチ命名は /implement と同じ規則: `feature/<issue番号>-<英語スラッグ>` 等。
+- **なぜ生の `git worktree add` か**: Claude Code の Agent `isolation: "worktree"` /
+  `--worktree` は既定ベースが `origin/HEAD`(=main) で、`worktree.baseRef` も
+  `"fresh"`/`"head"` の2択のみ。`origin/develop` を直接指定できない（公式確認済み）。
+  develop追従プレビュー運用と整合させるため、ベースを明示できる生コマンドを使う。
+
+### worktree の初期化はスキルの手続きで行う
+
+以下は git / Claude Code のネイティブ機能では**自動化されない**ため、スキルが明示的に実行する：
+
+- **環境ファイルのコピー**: `apps/web/.env.local` / `apps/admin/.env.local` を新worktreeへコピー。
+  - 注意: `.worktreeinclude` は git/Claude Code 標準機能では**ない**（このリポジトリ独自の取り決め）。
+    実際のコピーはスキルの手続きとしてエージェントが行う。
+- **依存インストール**: 新worktree内で `pnpm install`（pnpm はハードリンクで比較的速い）。
+
+### 後片付け
+
+- PR作成完了後、`git worktree remove .claude/worktrees/<branch>`。
+- 未コミット変更が残る場合は撤去せずユーザーに報告。
+- `.gitignore` に `.claude/worktrees/` を追加済み（メインチェックアウトを汚さない）。
+
+---
+
+## 5. アンチパターン（やってはいけない）
+
+- worktree ごとに `supabase start`（54421単一インスタンス共有の設計に反する）
+- 複数 worktree で同時にマイグレーション / `prisma generate`
+- devポートを動的に好き勝手ずらす（許可リスト・SITE_URLとズレて認証が壊れる）
+- E2E用にDBを物理複製しようとする（§2-③のとおり不成立）
+- 複数 worktree で同時にE2Eを回す（共有DBシードが競合し非決定的になる）
+
+---
+
+## 6. 既存資産への影響
+
+| 対象 | 影響 |
+|---|---|
+| `/implement` スキル | **worktree起点に統合済み**。1タスク=1worktreeの実装フロー本体。単独でも割り込みでもこれを呼ぶ |
+| `/parallel` スキル | **薄い司令塔バッチに変更済み**。複数Issue一括投入時のみ使用。中身は各Issueへ/implement相当を発火しE2Eキューを束ねるだけ |
+| `package.json` dev script | ポート可変化の改修が必要（②） |
+| Playwright config | baseURL/webServer.url 固定解除の改修が必要（②） |
+| `scripts/e2e-setup.sh` | 現行維持（DB名 `postgres` 固定、冪等seed）。物理分離は採らない |
+| Supabase Redirect URL 許可リスト | ポートプールを exact 列挙で事前登録（②） |
+
+---
+
+## 7. 検証の出典
+
+- DB物理複製不成立の実機検証: `.claude/agent-memory/dev-doctor/project_e2e_db_isolation_constraints.md`
+- worktree / ポート運用の制約: `.claude/agent-memory/claude-code-expert/project_worktree_constraints.md`


### PR DESCRIPTION
## 概要

developメイン会話を司令塔とし、1タスク = 1 worktree で実装するワークフローを設計・スキル化した。並列開発（複数タスク同時進行）の土台であると同時に、単独開発でも司令塔を clean に保つための仕組み。

設計の全体像は `docs/worktree-workflow.md` を参照。

## 背景・検証で判明した制約

このワークフローは「机上でいけそう」だった案を実機検証で潰しながら設計した。

- **E2E用DBの物理複製はSupabaseアーキ上不成立**: GoTrue/PostgREST/Prisma が全員 DB名 `postgres` に密結合し、`postgres` DB には常時接続が多数張られ TEMPLATE 複製できない。→ 冪等seed維持で対応。
- **IT/E2Eは共有DBに触るため並列不可**: `pnpm test:integration` は seed済み共有DBに実接続する。並列で回すと競合し非決定的になる。→ 司令塔が `qa-engineer` を1体ずつ直列起動して消化。
- **UTは共有DB非依存**なので worktree 並列OK。

## 変更内容

| ファイル | 内容 |
|---|---|
| `docs/worktree-workflow.md` | 設計の全体像（共有インフラ制約・テスト3分類のDB依存・IT/E2E直列キュー・撤退路） |
| `.claude/skills/implement/SKILL.md` | worktree起点に統合。`--no-worktree` で従来checkout方式へ即時退避できる撤退路を追加 |
| `.claude/skills/parallel/SKILL.md` | 複数Issue一括投入時の薄い司令塔バッチに再構成（実装本体は /implement が持つ） |
| `.worktreeinclude` / `.gitignore` | worktree運用の補助設定 |

## 費用対効果と撤退路

worktree にはタスクごとの固定オーバーヘッド（`pnpm install` 等）があり、個人開発では割に合わない場面もある。そのため:

- `/implement <Issue> --no-worktree` でその場で従来方式に切替可能（コードを戻す不要）
- 恒常的にやめる場合は `--no-worktree` を既定にする運用判断（docs §0）
- **完全撤去したい場合はこのPRごと revert する**（再現性のある最終手段）

## テスト

設計・スキル・ドキュメントの整備であり、プロダクトコードの変更はない。