### PR TITLE
fix: worktreeワークフローdocs/skillのE2Eコマンド誤記ほかを修正 (#264)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -112,7 +112,7 @@ git / Claude Code のネイティブ機能では自動化されないため、wo
 > **共有インフラ制約（厳守）**: 全 worktree は単一 Supabase（54421）・単一物理DB・固定ポートを共有する。
 > 以下は共有DBに触るため、複数 worktree で同時実行すると競合して非決定的になる:
 > - **IT（`pnpm test:integration`、`*.integration.test.ts`）** — seed済み共有DBに実接続する
-> - **E2E（`pnpm test:e2e`、Playwright）** — 共有DB＋固定ポートを使う
+> - **E2E（`pnpm e2e`、Playwright）** — 共有DB＋固定ポートを使う（アプリ個別は `pnpm --filter @beersalon/web e2e` / `pnpm --filter @beersalon/admin e2e`）
 >
 > 並列実装中はこれらを worktree 内で実行せず、**司令塔が `qa-engineer` を1体ずつ直列起動して消化**する
 > （`docs/worktree-workflow.md` §3）。

--- a/docs/worktree-workflow.md
+++ b/docs/worktree-workflow.md
@@ -56,7 +56,7 @@ worktree は作業ディレクトリのファイルを分離するが、**以下
 2つの worktree で同時に行うと互いに壊し合う。
 
 **対策**: スキーマ変更を含むタスクは、最初の worktree がロックを取得し、他 worktree は待機（直列化）。
-ロックは排他ファイル（例: `prisma/.migration.lock`）で表現する。
+ロックは排他ファイル（例: `prisma/.migration.lock`）で表現する（未実装の設計例。現状は司令塔が直列順序を手運用で担保する）。
 ロックは「同時書き込み事故」を防ぐが「変更の波及」は防げない点に注意——
 スキーマ変更中は他 worktree の dev/E2E も止めるのが安全。
 
@@ -117,8 +117,11 @@ DB単位の物理分離は認証層に効かない。これは CLAUDE.md の
 |---|---|---|---|
 | 実装 + **UT** | `pnpm test`（vitest、Supabase/Prismaをモック） | 触らない | **並列OK**（worktree内で完結） |
 | **IT（統合テスト）** | `pnpm test:integration`（`*.integration.test.ts`） | **触る** | **直列キュー** |
-| **E2E** | `pnpm test:e2e`（Playwright） | **触る（DB＋固定ポート）** | **直列キュー** |
+| **E2E** | `pnpm e2e`（Playwright） | **触る（DB＋固定ポート）** | **直列キュー** |
 
+- E2E のコマンドはルートとアプリ個別で異なる。ルートは `pnpm e2e`（= `e2e:web` + `e2e:admin`、web 5本 + admin 2本を一括実行）。
+  アプリ個別に走らせたいときは filter 経由で `pnpm --filter @beersalon/web e2e` / `pnpm --filter @beersalon/admin e2e` を使う。
+  `pnpm test:e2e` というスクリプトはルートには存在しない（admin サブパッケージにのみ `test:e2e` エイリアスがある）ため、ルートで叩かないこと。
 - IT は `apps/*/src/test/integration-setup.ts` が `supabase start` 必須・`DATABASE_URL` で実DB接続・
   `pnpm e2e:setup` の seed 済みDBを前提とする。**E2E と同じ共有DBを使う**ため、IT も E2E と同様に直列消化する。
 - 「並列で作る」のは **実装 + UT まで**。IT/E2E は司令塔の直列キューへ。
@@ -225,5 +228,10 @@ git worktree add .claude/worktrees/<branch> origin/develop -b <branch>
 
 ## 7. 検証の出典
 
-- DB物理複製不成立の実機検証: `.claude/agent-memory/dev-doctor/project_e2e_db_isolation_constraints.md`
-- worktree / ポート運用の制約: `.claude/agent-memory/claude-code-expert/project_worktree_constraints.md`
+本ドキュメントの制約は、いずれも 2026-06-18 時点の実機検証で確認した事実に基づく。
+
+- **DB物理複製は不成立**: ローカル Supabase（54421/54422）は単一物理DB（`postgres`）を前提とし、worktree ごとに
+  独立DBを払い出す構成は現状の `supabase/` 設定・`scripts/e2e-setup.sh` の前提と噛み合わないことを確認した。
+  よって共有DB依存テスト（IT/E2E）は並列化せず直列キューで消化する（§2 ③・§3）。
+- **worktree / ポート運用の制約**: 複数 worktree で `pnpm dev` を同時起動するとポートが衝突するため、
+  ポートプール払い出し＋`NEXT_PUBLIC_SITE_URL` 明示で回避できることを実機で確認した（§2 ②）。


### PR DESCRIPTION
## 概要

PR #263 で導入した worktree ワークフローの docs / skill にある表記上の問題（中心は E2E 実行コマンドの誤記）を修正する。プロダクトコードの変更は一切なし、docs/skill のみ。

Closes #264

## 修正内容（3点）

### ① E2E実行コマンドの誤記【実害あり】
- `pnpm test:e2e` はルート `package.json` に未定義（正しくは `pnpm e2e` = `e2e:web` + `e2e:admin`）。スキルはエージェントが実行手順として読むため、qa-engineer が存在しないコマンドを叩いて失敗する事故につながり得る。
- `docs/worktree-workflow.md:120`: テーブルを `pnpm e2e` に修正。直後にルート/アプリ個別（filter経由）の使い分けと「`test:e2e` をルートで叩かない」注意を補足。
- `.claude/skills/implement/SKILL.md:115`: `pnpm e2e` に修正し、アプリ個別の filter 例を追記。
- `.claude/skills/parallel/SKILL.md`: `pnpm test:integration` のみで `test:e2e` のルート実行誤記は無く、**修正不要**であることを grep で確認。

### ② §7 出典の agent-memory 参照がチーム非共有
- `.claude/agent-memory/...` は `.gitignore` 除外でコミットされず他者がリンクを辿れない。個人メモという設計（gitignore維持）はそのままに、出典を「2026-06-18 時点の実機検証で確認した事実」記述へ置換し、辿れなくても意味が通る形にした。

### ③ migration.lock が未実装の例表現
- `docs/worktree-workflow.md:59` の `prisma/.migration.lock` 例に「（未実装の設計例。現状は司令塔が直列順序を手運用で担保する）」を添えた。実装はしない（YAGNI）。

## 受入条件チェック

- [x] ① E2E コマンドが `pnpm e2e` に修正され、アプリ個別実行は filter 経由と区別して記載
- [x] ① grep で `test:e2e` のルート実行を促す誤記が残っていないことを確認（残存は「ルートで叩くな」という注意喚起の説明文のみ）
- [x] ② §7 出典がローカルパス依存リンクでなく、辿れなくても意味が通る記述
- [x] ③ docs:59 の migration.lock 例に「未実装」を明記

## テスト

- プロダクトコード変更なし・docs/skill（markdown）のみのため UT/E2E の追加は不要（Issue補足にも「DB・E2E には触れない」と明記）。
- 検証は grep ベースで実施。format/lint は Biome が markdown を対象外（`Checked 0 files / paths were ignored`）とするため、今回の変更に差分・指摘は発生しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)