### PR TITLE
fix: 新規登録ページのメール/パスワード欄からplaceholderを削除 (#267)

### DIFF
--- a/apps/web/src/app/signup/signup-form.test.tsx
+++ b/apps/web/src/app/signup/signup-form.test.tsx
@@ -62,13 +62,16 @@ describe("SignUpForm", () => {
 			expect(passwordInput).toHaveAttribute("id", "password");
 		});
 
-		it("プレースホルダーが正しく表示される", () => {
+		it("メールアドレス・パスワード欄にプレースホルダーが表示されない", () => {
 			render(<SignUpForm />);
 
-			expect(
-				screen.getByPlaceholderText("example@mail.com"),
-			).toBeInTheDocument();
-			expect(screen.getByPlaceholderText("••••••••")).toBeInTheDocument();
+			const emailInput = screen.getByRole("textbox", {
+				name: "メールアドレス",
+			});
+			const passwordInput = screen.getByLabelText("パスワード");
+
+			expect(emailInput).not.toHaveAttribute("placeholder");
+			expect(passwordInput).not.toHaveAttribute("placeholder");
 		});
 
 		it("送信ボタンが表示される", () => {

--- a/apps/web/src/app/signup/signup-form.tsx
+++ b/apps/web/src/app/signup/signup-form.tsx
@@ -20,7 +20,6 @@ export function SignUpForm() {
 					type="email"
 					id="email"
 					name="email"
-					placeholder="example@mail.com"
 					className="glass-input px-4 py-3 rounded-xl text-card-foreground placeholder:text-muted-foreground focus:outline-none transition-all duration-300"
 					required
 				/>
@@ -37,7 +36,6 @@ export function SignUpForm() {
 					type="password"
 					id="password"
 					name="password"
-					placeholder="••••••••"
 					className="glass-input px-4 py-3 rounded-xl text-card-foreground placeholder:text-muted-foreground focus:outline-none transition-all duration-300"
 					required
 				/>


### PR DESCRIPTION
## 概要
新規登録ページ（`/signup`）のメールアドレス欄・パスワード欄から `placeholder` 属性を削除した。

`/login`（`login-form.tsx`）には placeholder が無いのに対し、`/signup` だけ削除対応が漏れており、`example@mail.com` / `••••••••` が表示されて画面間で表示が不統一になっていた。

Closes #267

## 変更内容
- `apps/web/src/app/signup/signup-form.tsx`
  - メールアドレス欄の `placeholder="example@mail.com"` を削除
  - パスワード欄の `placeholder="••••••••"` を削除
  - 他属性（`type` / `id` / `name` / `className` / `required`）は変更なし
- `apps/web/src/app/signup/signup-form.test.tsx`
  - 既存の「プレースホルダーが正しく表示される」テストを「プレースホルダーが表示されない」検証に更新

## テスト
- **UT（Vitest）**: signup-form 16 テスト全てパス。placeholder 属性が両欄に無いことを検証。
- **E2E（Playwright MCP）**: 起動済み localhost（:3000）の `/signup` で検証。
  - メール欄・パスワード欄ともに `placeholder` 属性なし（PC幅 / モバイル375px の両方で確認）
  - `type` / `required` / 強度ヒント「8文字以上…」は従来どおり維持
  - テストピラミッド原則により、静的属性の検証は UT で担保できるため E2E コードは追加せず MCP 検証のみとした。

## 設計ドキュメント同期
- 不要。wireframe.md の 1-2 新規登録ページにはプレースホルダ記載が元々無く、コード実態と整合済み（125行目の `example@mail.com` 記載は 1-5 `/password/forgot` のもので対象外）。

## スクリーンショット
モバイル（375px）/ PC のキャプチャは別途コメントで添付予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)