### PR TITLE
chore: PR自動レビュー(claude-code-review)をworkflow_dispatch限定に (#273)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,8 @@
 name: Claude Code Review
 
+# Why not pull_request: 個人開発では Pro 枠を push 毎に重複消費し、レビューはローカル /pr-review（設計md整合に特化）と二重化するため自動発火を止める。チーム開発化したら pull_request トリガーへ戻す。
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
 
 jobs:
   claude-review:


### PR DESCRIPTION
## 概要

Closes #273

`claude-code-review.yml`（Claude Code Action による PR 自動レビュー）の自動発火を停止する。`pull_request` トリガーを `workflow_dispatch` のみに変更し、設定自体は残す。

## 変更内容

- `on: pull_request (opened/synchronize/ready_for_review/reopened)` → `on: workflow_dispatch` に変更
- 変更理由を Why not コメントとして併記

## なぜこの変更が必要か

- 認証は `CLAUDE_CODE_OAUTH_TOKEN`（Pro サブスク枠を消費）。`synchronize` により push 毎にフルレビューが走り、限られた Pro 枠をコントロール外で重複消費していた
- レビュー観点は既存のローカルスキル `/pr-review`（system-architect が設計md整合をレビュー）と二重化していた
- 個人開発（ポートフォリオ目的）では、設計ドキュメント駆動に特化した `/pr-review` の方がレビューの質・運用思想（司令塔フロー組込済み・単一の真実の源）の両面で適する
- `claude.yml`（@claude メンション応答）は維持。自分が明示的に呼んだ時だけ動くため枠を自分で管理でき、スマホ等からのトリガーという固有価値があるため

## 受入条件

- [x] `claude-code-review.yml` が PR の push/作成では自動実行されない
- [x] `workflow_dispatch`（手動実行）でのみ起動できる
- [x] `claude.yml` は変更していない

## 将来の復活方法

チーム開発化し、ローカルに `.claude/` 資産を持たない協業者が PR を出すようになったら、`on:` を `pull_request` トリガーへ戻す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)