### PR TITLE
fix: プロフィール入力の「登録内容を確認」で確認ページへ遷移するよう修正 (#285)

### DIFF
--- a/apps/web/e2e/auth-signup.spec.ts
+++ b/apps/web/e2e/auth-signup.spec.ts
@@ -94,4 +94,58 @@ test.describe("新規登録ページ", () => {
 			page.getByRole("heading", { name: "プロフィール入力" }),
 		).toBeVisible();
 	});
+
+	// Why not: プロフィール入力→確認の遷移は Server Action の redirect 例外処理に依存し、
+	// 複数画面にまたがるためブラウザ統合動作として E2E で担保する（Issue #285 の再発防止の核）。
+	test("プロフィール入力後、登録内容を確認すると /signup/confirm へ遷移し入力値が表示される", async ({
+		page,
+	}) => {
+		const email = faker.internet.email().toLowerCase();
+		const password = "Test1234!@#";
+
+		await page.goto("/signup");
+		await page.fill('input[name="email"]', email);
+		await page.fill('input[name="password"]', password);
+		await page.click('button[type="submit"]');
+		await page.waitForURL("/signup?success=true");
+
+		await expect
+			.poll(async () => (await findConfirmationMessage(email)) !== null, {
+				timeout: 15000,
+				message: "確認メールが Mailpit に届くこと",
+			})
+			.toBe(true);
+
+		const confirmed = await findConfirmationMessage(email);
+		if (confirmed === null) {
+			throw new Error("確認メールが見つかりませんでした");
+		}
+		const html = await getMessageHtml(confirmed.ID);
+		const callbackLink = html.match(
+			/https?:\/\/[^"\s<>]+\/auth\/callback\?[^"\s<>]+/,
+		)?.[0];
+		const linkUrl = new URL(callbackLink as string);
+		await page.goto(`${linkUrl.pathname}${linkUrl.search}`);
+		await page.waitForURL("/signup/profile");
+
+		await page.fill('input[name="lastName"]', "下井田");
+		await page.fill('input[name="firstName"]', "陸");
+		await page.fill('input[name="nickname"]', "りく");
+		await page.selectOption('select[name="year"]', "1994");
+		await page.selectOption('select[name="month"]', "5");
+		await page.selectOption('select[name="day"]', "13");
+		await page.selectOption('select[name="gender"]', "male");
+		await page.selectOption('select[name="prefecture"]', "静岡県");
+
+		await page.getByRole("button", { name: "登録内容を確認" }).click();
+
+		await page.waitForURL("/signup/confirm");
+		await expect(
+			page.getByRole("heading", { name: "登録内容の確認" }),
+		).toBeVisible();
+		await expect(page.getByText("下井田")).toBeVisible();
+		await expect(page.getByText("りく")).toBeVisible();
+		await expect(page.getByText("1994年5月13日")).toBeVisible();
+		await expect(page.getByText("静岡県")).toBeVisible();
+	});
 });

--- a/apps/web/src/app/signup/profile/actions.test.ts
+++ b/apps/web/src/app/signup/profile/actions.test.ts
@@ -338,6 +338,36 @@ describe("saveProfileToSession", () => {
 		});
 	});
 
+	describe("回帰防止 - redirect例外がエラーに握りつぶされない", () => {
+		// Why not message判定: Next.jsのredirect()はNEXT_REDIRECTを含む例外をthrowして動く。
+		// この例外をtry/catchで捕捉し{error}に変換してしまうと、確認ページへ遷移できない（Issue #285）。
+		// 本物のredirect同様にthrowするモックを与え、その例外が呼び出し元へ伝播することを検証する。
+		it("redirectがthrowしても{error}に変換されず、例外がそのまま伝播する", async () => {
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: "test-user-id" } },
+				error: null,
+			});
+			const redirectError = new Error("NEXT_REDIRECT");
+			mockRedirect.mockImplementation(() => {
+				throw redirectError;
+			});
+
+			const formData = new FormData();
+			formData.append("lastName", "山田");
+			formData.append("firstName", "太郎");
+			formData.append("nickname", "やまちゃん");
+			formData.append("birthday", "1990-01-01");
+			formData.append("gender", "male");
+			formData.append("prefecture", "東京都");
+			formData.append("bio", "");
+
+			await expect(saveProfileToSession(undefined, formData)).rejects.toThrow(
+				"NEXT_REDIRECT",
+			);
+			expect(mockRedirect).toHaveBeenCalledWith("/signup/confirm");
+		});
+	});
+
 	describe("異常系 - 認証エラー", () => {
 		it("未認証ユーザーの場合、エラーが返る", async () => {
 			mockGetUser.mockResolvedValue({

--- a/apps/web/src/app/signup/profile/actions.ts
+++ b/apps/web/src/app/signup/profile/actions.ts
@@ -16,6 +16,9 @@ export async function saveProfileToSession(
 	_prevState: FormState | undefined,
 	formData: FormData,
 ): Promise<FormState | undefined> {
+	// Why not try/catch 全体で囲む: redirect() は NEXT_REDIRECT 例外を throw して動くため、
+	// 副作用処理を try で囲むと redirect 例外まで捕捉され、確認ページへ遷移できなくなる。
+	// 副作用は try で囲み、redirect() は try の外で呼ぶ。
 	try {
 		const profileImage = formData.get("profileImage") as File | null;
 
@@ -44,11 +47,8 @@ export async function saveProfileToSession(
 			bio: formData.get("bio") as string | undefined,
 		};
 
-		console.log("[saveProfileToSession] Validating profile data");
-
 		const result = profileSchema.safeParse(data);
 		if (!result.success) {
-			console.error("[saveProfileToSession] Validation error:", result.error);
 			return {
 				error: result.error.issues[0].message,
 			};
@@ -62,14 +62,12 @@ export async function saveProfileToSession(
 		} = await supabase.auth.getUser();
 
 		if (authError) {
-			console.error("[saveProfileToSession] Auth error:", authError);
 			return {
 				error: `認証エラーが発生しました: ${authError.message}`,
 			};
 		}
 
 		if (!user) {
-			console.warn("[saveProfileToSession] No user found");
 			return {
 				error: "認証が必要です",
 			};
@@ -89,14 +87,12 @@ export async function saveProfileToSession(
 				});
 
 			if (uploadError) {
-				console.error("[saveProfileToSession] Upload error:", uploadError);
 				return {
 					error: "画像のアップロードに失敗しました。もう一度お試しください。",
 				};
 			}
 
 			imagePath = filePath;
-			console.log("[saveProfileToSession] Image uploaded:", filePath);
 		}
 
 		const cookieStore = await cookies();
@@ -119,18 +115,11 @@ export async function saveProfileToSession(
 			maxAge: 60 * 10, // 10分
 			path: "/",
 		});
-
-		console.log("[saveProfileToSession] Redirecting to confirm page");
-		redirect("/signup/confirm");
-	} catch (error) {
-		console.error("[saveProfileToSession] Unexpected error:", error);
-
-		if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
-			throw error;
-		}
-
+	} catch (_error) {
 		return {
 			error: "予期しないエラーが発生しました。もう一度お試しください。",
 		};
 	}
+
+	redirect("/signup/confirm");
 }

--- a/apps/web/src/app/signup/profile/profile-form.test.tsx
+++ b/apps/web/src/app/signup/profile/profile-form.test.tsx
@@ -223,7 +223,53 @@ describe("ProfileForm", () => {
 		});
 	});
 
-	// NOTE: フォーム送信のテストは生年月日selectの複雑な処理のため省略
+	describe("正常系 - 生年月日のhidden birthday連動", () => {
+		it("年月日を選択すると hidden birthday が YYYY-MM-DD 形式で埋まる", async () => {
+			const user = userEvent.setup();
+			render(<ProfileForm />);
+
+			const yearSelect = document.querySelector(
+				'select[name="year"]',
+			) as HTMLSelectElement;
+			const monthSelect = document.querySelector(
+				'select[name="month"]',
+			) as HTMLSelectElement;
+			const daySelect = document.querySelector(
+				'select[name="day"]',
+			) as HTMLSelectElement;
+			const birthdayInput = document.querySelector(
+				'input[name="birthday"]',
+			) as HTMLInputElement;
+
+			await user.selectOptions(yearSelect, "1990");
+			await user.selectOptions(monthSelect, "5");
+			await user.selectOptions(daySelect, "3");
+
+			// 1桁の月日は0埋めされる
+			expect(birthdayInput.value).toBe("1990-05-03");
+		});
+
+		it("年月日のいずれかが未選択なら hidden birthday は空のままになる", async () => {
+			const user = userEvent.setup();
+			render(<ProfileForm />);
+
+			const yearSelect = document.querySelector(
+				'select[name="year"]',
+			) as HTMLSelectElement;
+			const monthSelect = document.querySelector(
+				'select[name="month"]',
+			) as HTMLSelectElement;
+			const birthdayInput = document.querySelector(
+				'input[name="birthday"]',
+			) as HTMLInputElement;
+
+			await user.selectOptions(yearSelect, "1990");
+			await user.selectOptions(monthSelect, "5");
+			// 日は未選択
+
+			expect(birthdayInput.value).toBe("");
+		});
+	});
 
 	describe("正常系 - エラー表示", () => {
 		it("エラーメッセージが表示される", () => {

--- a/apps/web/src/app/signup/profile/profile-form.tsx
+++ b/apps/web/src/app/signup/profile/profile-form.tsx
@@ -12,6 +12,14 @@ export function ProfileForm() {
 	);
 	const [imagePreview, setImagePreview] = useState<string | null>(null);
 	const [bioLength, setBioLength] = useState(0);
+	const [year, setYear] = useState("");
+	const [month, setMonth] = useState("");
+	const [day, setDay] = useState("");
+
+	const birthday =
+		year && month && day
+			? `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`
+			: "";
 
 	const currentYear = new Date().getFullYear();
 	const years = Array.from({ length: 100 }, (_, i) => currentYear - i);
@@ -99,42 +107,48 @@ export function ProfileForm() {
 				<div className="grid grid-cols-3 gap-2">
 					<select
 						name="year"
+						value={year}
+						onChange={(e) => setYear(e.target.value)}
 						className="glass-input px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
 						required
 					>
 						<option value="">年</option>
-						{years.map((year) => (
-							<option key={year} value={year}>
-								{year}
+						{years.map((y) => (
+							<option key={y} value={y}>
+								{y}
 							</option>
 						))}
 					</select>
 					<select
 						name="month"
+						value={month}
+						onChange={(e) => setMonth(e.target.value)}
 						className="glass-input px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
 						required
 					>
 						<option value="">月</option>
-						{months.map((month) => (
-							<option key={month} value={month}>
-								{month}
+						{months.map((m) => (
+							<option key={m} value={m}>
+								{m}
 							</option>
 						))}
 					</select>
 					<select
 						name="day"
+						value={day}
+						onChange={(e) => setDay(e.target.value)}
 						className="glass-input px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
 						required
 					>
 						<option value="">日</option>
-						{days.map((day) => (
-							<option key={day} value={day}>
-								{day}
+						{days.map((d) => (
+							<option key={d} value={d}>
+								{d}
 							</option>
 						))}
 					</select>
 				</div>
-				<input type="hidden" name="birthday" id="birthday" />
+				<input type="hidden" name="birthday" id="birthday" value={birthday} />
 			</div>
 
 			<div className="flex flex-col gap-2">
@@ -243,24 +257,6 @@ export function ProfileForm() {
 				type="submit"
 				disabled={isPending}
 				className="w-full px-4 py-3 text-primary-foreground gradient-primary rounded-xl font-medium hover:shadow-lg hover:scale-105 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed transition-all duration-300 shadow-md"
-				onClick={(e) => {
-					const form = e.currentTarget.form;
-					if (form) {
-						const year = (form.elements.namedItem("year") as HTMLSelectElement)
-							.value;
-						const month = (
-							form.elements.namedItem("month") as HTMLSelectElement
-						).value;
-						const day = (form.elements.namedItem("day") as HTMLSelectElement)
-							.value;
-						const birthdayInput = form.elements.namedItem(
-							"birthday",
-						) as HTMLInputElement;
-						if (year && month && day) {
-							birthdayInput.value = `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
-						}
-					}
-				}}
 			>
 				{isPending ? "確認中..." : "登録内容を確認"}
 			</button>


### PR DESCRIPTION
## 概要

プロフィール入力ページ（`/signup/profile`）で「登録内容を確認」を押すと、確認ページへ遷移せずリロードのような挙動になり入力値が消える不具合を修正する。

Closes #285

## 根本原因

2つの複合だった。

1. **redirect 例外の握りつぶし（主因）**: `saveProfileToSession`（Server Action）が `try/catch` 全体の中で `redirect("/signup/confirm")` を呼んでいた。Next.js の `redirect()` は `NEXT_REDIRECT` 例外を throw して動くため、この例外を `catch` が捕捉し `{ error: "予期しないエラー..." }` に変換してしまい、確認ページへ遷移できなかった。Next.js 16 では `error.message.includes("NEXT_REDIRECT")` による再 throw ガードが効かず（digest 側に入るため）、握りつぶされていた。
2. **birthday の DOM 直書き**: hidden `birthday` を submit ボタンの `onClick` で DOM に直接書き込んでおり、FormData シリアライズとの発火順序が保証されず、タイミング次第で空送信されうる構造だった。

## 修正内容

- **actions.ts**: 副作用は `try` で囲みつつ `redirect()` を `try` の外で呼ぶ（Next.js 公式推奨パターン）。デバッグ用 `console.log/error` を除去。
- **profile-form.tsx**: `year/month/day` を `useState` 管理にし、hidden `birthday` を派生値の controlled `value=` に変更。`onClick` の DOM 直書きを廃止。

## テスト

- **UT（Vitest）**: web 全体 320 件パス。追加分:
  - actions.test.ts: redirect が throw しても `{error}` に変換されず例外が伝播する回帰防止テスト
  - profile-form.test.tsx: 年月日選択で hidden birthday が `YYYY-MM-DD`（0埋め）になる検証 / 未選択なら空のままの検証
- **E2E（Playwright）**: auth-signup.spec.ts に「プロフィール入力→登録内容を確認→`/signup/confirm` 遷移＆入力値表示」を追加。Mailpit 経由の実フローで 3 件パス。
- Playwright MCP でも実ブラウザ検証済み（profile→confirm 遷移、生年月日「1994年5月13日」含む全項目が確認ページに表示されることを確認）。

## 影響範囲

- ユーザー画面の新規登録フロー（`/signup/profile` → `/signup/confirm`）のみ。DBスキーマ・ルーティング設計・他画面への影響なし。
- 設計ドキュメント（routing.md 2-1-3）の仕様どおりに修正したため、ドキュメント更新は不要。