### PR TITLE
fix: 店舗詳細「お店からの投稿」タブに ArticlesTab を結線 (#289)

### DIFF
--- a/apps/web/src/app/bars/[barId]/page.tsx
+++ b/apps/web/src/app/bars/[barId]/page.tsx
@@ -3,6 +3,7 @@ import { getBarDetail, isFavoriteBar, recordViewHistory } from "@/actions/bar";
 import { BarTabs } from "@/components/bar/bar-tabs";
 import { FavoriteButton } from "@/components/bar/favorite-button";
 import { MediaSlideshow } from "@/components/bar/media-slideshow";
+import { ArticlesTab } from "@/components/bar/tabs/articles-tab";
 import { CouponsTab } from "@/components/bar/tabs/coupons-tab";
 import { EventsTab } from "@/components/bar/tabs/events-tab";
 import { MenuTab } from "@/components/bar/tabs/menu-tab";
@@ -56,7 +57,7 @@ export default async function BarDetailPage({
 							posts: (
 								<PostsTab posts={bar.posts} barId={barId} barName={bar.name} />
 							),
-							articles: <div />,
+							articles: <ArticlesTab articles={bar.articles} />,
 							coupons: <CouponsTab coupons={bar.coupons} />,
 							events: <EventsTab events={bar.events} />,
 						}}

--- a/apps/web/src/components/bar/tabs/articles-tab.test.tsx
+++ b/apps/web/src/components/bar/tabs/articles-tab.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ArticlesTab } from "./articles-tab";
+
+vi.mock("next/image", () => ({
+	default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+		// biome-ignore lint/performance/noImgElement: テスト用next/imageモック
+		<img {...props} alt={props.alt} />
+	),
+}));
+
+vi.mock("next/link", () => ({
+	default: ({
+		href,
+		children,
+		...props
+	}: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+const baseArticle = {
+	id: "1",
+	title: "夏の限定IPAが登場しました",
+	body: "今年も季節限定のIPAをご用意しました。ぜひお越しください。",
+	imageUrl: "/images/article1.jpg",
+	publishedAt: new Date("2026-06-15T10:00:00+09:00"),
+};
+
+describe("ArticlesTab", () => {
+	describe("記事が0件の場合", () => {
+		it("空状態メッセージが表示される", () => {
+			render(<ArticlesTab articles={[]} />);
+			expect(
+				screen.getByText("記事はまだ投稿されていません。"),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("記事が存在する場合", () => {
+		it("記事タイトルが表示される", () => {
+			render(<ArticlesTab articles={[baseArticle]} />);
+			expect(screen.getByText("夏の限定IPAが登場しました")).toBeInTheDocument();
+		});
+
+		it("記事本文の冒頭が表示される", () => {
+			render(<ArticlesTab articles={[baseArticle]} />);
+			expect(
+				screen.getByText(
+					"今年も季節限定のIPAをご用意しました。ぜひお越しください。",
+				),
+			).toBeInTheDocument();
+		});
+
+		it("投稿日が表示される", () => {
+			render(<ArticlesTab articles={[baseArticle]} />);
+			expect(
+				screen.getByText(
+					new Date(baseArticle.publishedAt).toLocaleDateString("ja-JP"),
+				),
+			).toBeInTheDocument();
+		});
+
+		it("記事リンクが /articles/[articleId] を指す", () => {
+			render(<ArticlesTab articles={[baseArticle]} />);
+			const link = screen.getByRole("link", {
+				name: /夏の限定IPAが登場しました/,
+			});
+			expect(link).toHaveAttribute("href", "/articles/1");
+		});
+
+		it("画像が表示される", () => {
+			render(<ArticlesTab articles={[baseArticle]} />);
+			expect(
+				screen.getByAltText("夏の限定IPAが登場しました"),
+			).toBeInTheDocument();
+		});
+
+		it("imageUrlがnullの場合は画像が表示されない", () => {
+			const article = { ...baseArticle, imageUrl: null };
+			render(<ArticlesTab articles={[article]} />);
+			expect(
+				screen.queryByAltText("夏の限定IPAが登場しました"),
+			).not.toBeInTheDocument();
+		});
+
+		it("publishedAtがnullの場合は投稿日が表示されない", () => {
+			const article = { ...baseArticle, publishedAt: null };
+			render(<ArticlesTab articles={[article]} />);
+			expect(
+				screen.queryByText(
+					new Date("2026-06-15T10:00:00+09:00").toLocaleDateString("ja-JP"),
+				),
+			).not.toBeInTheDocument();
+		});
+
+		it("複数記事が表示される", () => {
+			const articles = [
+				baseArticle,
+				{
+					...baseArticle,
+					id: "2",
+					title: "新メニュー入荷のお知らせ",
+				},
+			];
+			render(<ArticlesTab articles={articles} />);
+			expect(screen.getByText("夏の限定IPAが登場しました")).toBeInTheDocument();
+			expect(screen.getByText("新メニュー入荷のお知らせ")).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## 概要

Issue #289: 店舗詳細ページの「お店からの投稿」タブが空コンポーネント（`<div />`）のまま放置され、公開記事が表示されない問題を修正。

## 根本原因

`apps/web/src/app/bars/[barId]/page.tsx` で `articles: <div />` という空プレースホルダのまま、実装済みの `ArticlesTab` コンポーネントが結線されていなかった。データ取得層（`getBarDetail` の `bar.articles`）・`ArticlesTab`・`BarTabs` はいずれも揃っており、結線のみが欠落していた。

## 変更内容

- `page.tsx` に `ArticlesTab` の import を追加し、`articles: <div />` を `articles: <ArticlesTab articles={bar.articles} />` に差し替え（2行）
- `ArticlesTab` の UT（`articles-tab.test.tsx`）を新規追加

## テスト

- **UT**: `apps/web` 全329件パス。`ArticlesTab` のUT8件を追加（タイトル/冒頭文/投稿日の表示、リンク先 `/articles/[id]`、画像の有無、空状態「記事はまだ投稿されていません。」）
- **E2E（Playwright MCP）**: ログイン → `/bars/1` → 「お店からの投稿」タブ切替で公開記事カードが表示 → 記事クリックで `/articles/[articleId]` へ遷移、を確認。テストピラミッドの原則により描画・リンク・空状態はUTで担保するため、E2Eコードは追加せず既存構成を維持。

## 設計ドキュメント

routing.md §2-3-3 / wireframe.md §2-2 の既存仕様通りの実装のため、ドキュメント更新は不要。

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)