### PR TITLE
feat: develop/main push 時にリモート Supabase へマイグレーションを自動適用する CI を追加 (#313)

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -3,10 +3,17 @@ name: Apply Supabase migrations
 on:
   push:
     branches: [main, develop]
+    # Why not config.toml を含める: supabase db push は migrations しか適用せず config.toml を反映しない。
+    # トリガーに含めると config.toml だけ変更した push が「CI は緑なのに何も反映されない」沈黙バグになるため、
+    # このワークフローは migrations 専用に限定する（config.toml の反映は別運用）。
     paths:
       - "supabase/migrations/**"
-      - "supabase/config.toml"
   workflow_dispatch:
+
+# Why not contents: write: マイグレーション適用はリモート DB への操作のみで、リポジトリへの書き込みは不要。
+# 最小権限の原則で read に絞る。
+permissions:
+  contents: read
 
 # Why not cancel-in-progress=true: マイグレーション適用中に後続 push でジョブを中断すると、
 # 一部の DDL だけ適用された中途半端な状態になり得るため、同一参照への適用は直列化する。
@@ -23,6 +30,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Why not link 時に空文字で進める: Secret 未登録だと link が分かりにくい形で失敗するため、
+      # 先に必須 Secret の有無を検査して原因が一目で分かる形で fail させる。
+      - name: Check required secrets
+        run: |
+          missing=0
+          for name in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Required secret '$name' is not set"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+        env:
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
       # Why not version: latest: リモート本番DBへの DDL 適用は CLI 仕様変更で
       # 非対話実行の挙動が壊れると事故に直結するため、ローカルで db push 実績のある版に固定する。
       - name: Setup Supabase CLI
@@ -30,6 +52,8 @@ jobs:
         with:
           version: 2.65.5
 
+      # Why not develop/main で適用先を分ける: 現状 preview/production は同一 Supabase プロジェクトを共用するため
+      # 適用先は1つ。将来プロジェクトを分離する場合は、ここの project-ref を環境別 Secret に切り替える。
       - name: Link to remote project
         run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_ID }}"
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,39 @@
+name: Apply Supabase migrations
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/config.toml"
+  workflow_dispatch:
+
+# Why not cancel-in-progress=true: マイグレーション適用中に後続 push でジョブを中断すると、
+# 一部の DDL だけ適用された中途半端な状態になり得るため、同一参照への適用は直列化する。
+concurrency:
+  group: migrate-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Why not version: latest: リモート本番DBへの DDL 適用は CLI 仕様変更で
+      # 非対話実行の挙動が壊れると事故に直結するため、ローカルで db push 実績のある版に固定する。
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.65.5
+
+      - name: Link to remote project
+        run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_ID }}"
+
+      # Why not --dry-run: dry-run では適用されない。CLI が schema_migrations を見て
+      # 未適用分のみ適用するため冪等。失敗時は非ゼロ終了でジョブが fail する。
+      - name: Push migrations to remote
+        run: supabase db push

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 `main` への merge では production（`https://beer-salon.vercel.app` / 管理画面本番ドメインは未確定）にデプロイされる。
 
+### DB マイグレーションの自動適用
+
+`develop` / `main` に push され、`supabase/migrations/**` または `supabase/config.toml` に変更が含まれる場合、GitHub Actions（`.github/workflows/migrate.yml`）が `supabase db push` でリモート Supabase へ未適用のマイグレーションを自動適用する。
+
+- preview / production は同一 Supabase プロジェクトを共用しているため、適用先は1つ（develop / main どちらの push でも同じプロジェクトに適用される）。
+- `supabase db push` は `supabase_migrations.schema_migrations` を見て未適用分のみを適用するため冪等。マイグレーション変更が無い push ではワークフロー自体が起動しない（paths フィルタ）。
+- 適用に失敗するとジョブが fail する。
+
+**必要な GitHub Secrets**（事前に登録すること。未登録だと自動適用が動かない）:
+
+| Secret 名 | 用途 |
+|-----------|------|
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI のアクセストークン（`supabase link` 用）。ダッシュボード → Account → Access Tokens で発行 |
+| `SUPABASE_DB_PASSWORD` | リモート DB のパスワード（`supabase db push` 用） |
+| `SUPABASE_PROJECT_ID` | リモートプロジェクトの ref（`supabase link --project-ref` に渡す） |
+
+> 過去に、この自動適用が存在せずリモート DB へマイグレーションが一切適用されていなかったため、プロフィール画像アップロード時にバケットが無く「画像のアップロードに失敗しました」が発生した経緯がある（Issue #313）。この仕組みはその再発防止のためのもの。
+
 ### トラブルシュート
 
 - **片肺で alias が古いまま残る場合**

--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 ### DB マイグレーションの自動適用
 
-`develop` / `main` に push され、`supabase/migrations/**` または `supabase/config.toml` に変更が含まれる場合、GitHub Actions（`.github/workflows/migrate.yml`）が `supabase db push` でリモート Supabase へ未適用のマイグレーションを自動適用する。
+`develop` / `main` に push され、`supabase/migrations/**` に変更が含まれる場合、GitHub Actions（`.github/workflows/migrate.yml`）が `supabase db push` でリモート Supabase へ未適用のマイグレーションを自動適用する。
 
 - preview / production は同一 Supabase プロジェクトを共用しているため、適用先は1つ（develop / main どちらの push でも同じプロジェクトに適用される）。
 - `supabase db push` は `supabase_migrations.schema_migrations` を見て未適用分のみを適用するため冪等。マイグレーション変更が無い push ではワークフロー自体が起動しない（paths フィルタ）。
 - 適用に失敗するとジョブが fail する。
+- **`supabase/config.toml`（認証メールテンプレート・`enable_confirmations` 等）は `supabase db push` の対象外**。このワークフローでは反映されないため、config.toml を変更した場合は別途リモートへ反映する必要がある（誤って「自動反映される」と誤認しないよう、トリガーの paths からも `config.toml` を除外している）。
+- **`deploy.yml`（Vercel デプロイ）と `migrate.yml` は実行順序が保証されず並列で走る**。スキーマ追加に依存するアプリ変更を同一 push に含めると、マイグレーション適用前にデプロイが先行して実行時エラーになり得る。スキーマ変更とそれに依存するアプリ変更は、マイグレーションを先行 push してから（または別 PR で先にマージしてから）アプリ変更を入れるのが安全。
 
 **必要な GitHub Secrets**（事前に登録すること。未登録だと自動適用が動かない）:
 


### PR DESCRIPTION
## 概要

リモート Supabase（preview/production が共用する `srgecvsxybsqyyhjnzsc`）に `supabase/migrations/` を自動適用する仕組みが無く、スキーマ変更をマージしてもリモート DB に反映されない問題を解消する。

実際、この欠落により今までリモート DB にマイグレーションが一度も適用されておらず、`profile-images` バケットが存在せずプロフィール画像アップロードが「画像のアップロードに失敗しました」で失敗していた（暫定対応として手動 `supabase db push` で復旧済み）。本 PR はその再発防止。

## 変更内容

- **`.github/workflows/migrate.yml`（新規）**
  - トリガー: `develop` / `main` への push、かつ `supabase/migrations/**` または `supabase/config.toml` の変更を含む場合（＋ `workflow_dispatch`）
  - `supabase/setup-cli@v1` をバージョン固定（`2.65.5`）で導入 → `supabase link` → `supabase db push`
  - `supabase db push` は `schema_migrations` を参照し未適用分のみ適用するため冪等。失敗時は非ゼロ終了でジョブが fail
  - `concurrency` で同一参照への適用を直列化（中途半端な DDL 適用を防ぐ）
- **`README.md`**
  - 「DB マイグレーションの自動適用」セクションを追記。運用と必要な GitHub Secrets を明記

## 設計判断（/plan で確認済み）

- **project-ref**: `SUPABASE_PROJECT_ID` Secret で渡す（将来の環境分離時に差し替えやすいため）
- **環境分離**: 今回は分離なし。preview/production は同一プロジェクト共用のため適用先は1つ
- **CLI バージョン**: 固定（`latest` だと将来の CLI 仕様変更で非対話実行が壊れるリスクがあるため）

## 必要な GitHub Secrets（マージ前にユーザー登録が必要）

| Secret 名 | 用途 |
|-----------|------|
| `SUPABASE_ACCESS_TOKEN` | `supabase link` 用アクセストークン |
| `SUPABASE_DB_PASSWORD` | `supabase db push` 用 DB パスワード |
| `SUPABASE_PROJECT_ID` | リモートプロジェクトの ref |

> ⚠️ これらの Secret が未登録だとワークフローは失敗する。マージ後の初回 push 前に登録すること。

## 受入条件

- [x] `develop`/`main` の push かつマイグレーション変更時に `supabase db push` が走る（トリガー設計で担保）
- [x] 既適用のみの場合スキップして成功（CLI の冪等性で担保）
- [x] 適用失敗時に CI が fail（CLI 非ゼロ終了の伝播で担保）
- [x] `main` への push でも適用される（トリガーに `main` を含む）

## テスト

GitHub Actions ワークフロー（CI/CD インフラ）であり、アプリの UT/E2E（Vitest/Playwright）の対象外。アプリコード・ロジックの変更は無いため UT 追加なし。実際の適用検証はマージ後、Secrets 登録のうえ Actions のログで確認する。

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)