### PR TITLE
refactor: メニュー画像アップロード処理を共通関数に集約 (#316)

### DIFF
--- a/apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { uploadMenuImage } from "@/lib/menu-image-upload";
 import type { BeerCategory, Country, Region } from "@/types/database";
 
 interface SizeRow {
@@ -171,18 +172,13 @@ export default function BeerMenuCreateForm({ barId }: BeerMenuCreateFormProps) {
 			let imageUrl: string | null = null;
 
 			if (imageFile) {
-				const formData = new FormData();
-				formData.append("file", imageFile);
-				formData.append("type", "beer-menu");
-
-				const uploadRes = await fetch(`/api/bars/${barId}/media`, {
-					method: "POST",
-					body: formData,
-				});
-
-				if (uploadRes.ok) {
-					const uploadData = await uploadRes.json();
-					imageUrl = uploadData.url || null;
+				const uploadResult = await uploadMenuImage(
+					barId,
+					imageFile,
+					"beer-menu",
+				);
+				if (uploadResult.ok) {
+					imageUrl = uploadResult.url;
 				}
 			}
 

--- a/apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { type FormEvent, useState } from "react";
+import { uploadMenuImage } from "@/lib/menu-image-upload";
 
 interface FoodMenuCreateFormProps {
 	barId: string;
@@ -54,18 +55,13 @@ export default function FoodMenuCreateForm({ barId }: FoodMenuCreateFormProps) {
 			let imageUrl: string | null = null;
 
 			if (imageFile) {
-				const formData = new FormData();
-				formData.append("file", imageFile);
-				formData.append("type", "food-menu");
-
-				const uploadRes = await fetch(`/api/bars/${barId}/media`, {
-					method: "POST",
-					body: formData,
-				});
-
-				if (uploadRes.ok) {
-					const uploadData = await uploadRes.json();
-					imageUrl = uploadData.url || null;
+				const uploadResult = await uploadMenuImage(
+					barId,
+					imageFile,
+					"food-menu",
+				);
+				if (uploadResult.ok) {
+					imageUrl = uploadResult.url;
 				}
 			}
 

--- a/apps/admin/src/components/BeerMenuForm.tsx
+++ b/apps/admin/src/components/BeerMenuForm.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useRef, useState } from "react";
+import { uploadMenuImage } from "@/lib/menu-image-upload";
 import type { BarBeerMenuDetail } from "@/types/database";
 
 interface SizeRow {
@@ -103,23 +104,18 @@ export default function BeerMenuForm({
 			let nextImageUrl: string | null = imageUrl;
 
 			if (imageFile) {
-				const uploadForm = new FormData();
-				uploadForm.append("file", imageFile);
-				uploadForm.append("type", "beer-menu");
+				const uploadResult = await uploadMenuImage(
+					barId,
+					imageFile,
+					"beer-menu",
+				);
 
-				const uploadRes = await fetch(`/api/bars/${barId}/media`, {
-					method: "POST",
-					body: uploadForm,
-				});
-
-				if (!uploadRes.ok) {
-					const data = await uploadRes.json();
-					setError(data.error || "画像のアップロードに失敗しました");
+				if (!uploadResult.ok) {
+					setError(uploadResult.error);
 					return;
 				}
 
-				const uploadData = await uploadRes.json();
-				nextImageUrl = uploadData.url || null;
+				nextImageUrl = uploadResult.url;
 			}
 
 			const url = `/api/bars/${barId}/menus/beers/${menu?.id}`;

--- a/apps/admin/src/components/FoodMenuForm.tsx
+++ b/apps/admin/src/components/FoodMenuForm.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { uploadMenuImage } from "@/lib/menu-image-upload";
 import type { BarFoodMenu } from "@/types/database";
 
 interface FoodMenuFormProps {
@@ -85,23 +86,18 @@ export default function FoodMenuForm({ barId, menuId }: FoodMenuFormProps) {
 			let nextImageUrl: string | null = imageUrl;
 
 			if (imageFile) {
-				const uploadForm = new FormData();
-				uploadForm.append("file", imageFile);
-				uploadForm.append("type", "food-menu");
+				const uploadResult = await uploadMenuImage(
+					barId,
+					imageFile,
+					"food-menu",
+				);
 
-				const uploadRes = await fetch(`/api/bars/${barId}/media`, {
-					method: "POST",
-					body: uploadForm,
-				});
-
-				if (!uploadRes.ok) {
-					const data = await uploadRes.json();
-					setError(data.error || "画像のアップロードに失敗しました");
+				if (!uploadResult.ok) {
+					setError(uploadResult.error);
 					return;
 				}
 
-				const uploadData = await uploadRes.json();
-				nextImageUrl = uploadData.url || null;
+				nextImageUrl = uploadResult.url;
 			}
 
 			const url = menuId

--- a/apps/admin/src/lib/menu-image-upload.test.ts
+++ b/apps/admin/src/lib/menu-image-upload.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadMenuImage } from "@/lib/menu-image-upload";
+
+function makeFile(): File {
+	return new File(["dummy"], "menu.png", { type: "image/png" });
+}
+
+describe("uploadMenuImage", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("アップロード成功時は ok:true と公開URLを返す", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ url: "https://example.com/menu.png" }), {
+				status: 200,
+			}),
+		);
+
+		const result = await uploadMenuImage("42", makeFile(), "beer-menu");
+
+		expect(result).toEqual({ ok: true, url: "https://example.com/menu.png" });
+	});
+
+	it("成功レスポンスに url が無い場合は ok:true / url:null を返す", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({}), { status: 200 }),
+		);
+
+		const result = await uploadMenuImage("42", makeFile(), "food-menu");
+
+		expect(result).toEqual({ ok: true, url: null });
+	});
+
+	it("正しいエンドポイントへ file / type を FormData で POST する", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ url: "https://example.com/menu.png" }), {
+				status: 200,
+			}),
+		);
+
+		const file = makeFile();
+		await uploadMenuImage("7", file, "beer-menu");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("/api/bars/7/media");
+		expect(init?.method).toBe("POST");
+		const body = init?.body as FormData;
+		expect(body).toBeInstanceOf(FormData);
+		expect(body.get("file")).toBe(file);
+		expect(body.get("type")).toBe("beer-menu");
+	});
+
+	it("アップロード失敗時はレスポンスの error 文言を ok:false で返す", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({ error: "ファイルサイズは5MB以下にしてください" }),
+				{
+					status: 400,
+				},
+			),
+		);
+
+		const result = await uploadMenuImage("42", makeFile(), "food-menu");
+
+		expect(result).toEqual({
+			ok: false,
+			error: "ファイルサイズは5MB以下にしてください",
+		});
+	});
+
+	it("失敗レスポンスに error が無い場合は既定文言で ok:false を返す", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({}), { status: 500 }),
+		);
+
+		const result = await uploadMenuImage("42", makeFile(), "beer-menu");
+
+		expect(result).toEqual({
+			ok: false,
+			error: "画像のアップロードに失敗しました",
+		});
+	});
+});

--- a/apps/admin/src/lib/menu-image-upload.test.ts
+++ b/apps/admin/src/lib/menu-image-upload.test.ts
@@ -92,4 +92,21 @@ describe("uploadMenuImage", () => {
 			error: "画像のアップロードに失敗しました",
 		});
 	});
+
+	it("失敗レスポンスのボディが非JSON（json() が reject）でも throw せず既定文言で ok:false を返す", async () => {
+		const fetchMock = vi.mocked(fetch);
+		const nonJsonFailure = {
+			ok: false,
+			json: () =>
+				Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+		} as unknown as Response;
+		fetchMock.mockResolvedValue(nonJsonFailure);
+
+		const result = await uploadMenuImage("42", makeFile(), "food-menu");
+
+		expect(result).toEqual({
+			ok: false,
+			error: "画像のアップロードに失敗しました",
+		});
+	});
 });

--- a/apps/admin/src/lib/menu-image-upload.ts
+++ b/apps/admin/src/lib/menu-image-upload.ts
@@ -23,7 +23,11 @@ export async function uploadMenuImage(
 	});
 
 	if (!uploadRes.ok) {
-		const data = await uploadRes.json();
+		// Why not 失敗パスで素の uploadRes.json() を使わない:
+		//   変更前の登録フォームは失敗ボディを一切読まず握りつぶしていたため、
+		//   空ボディや HTML を返す失敗（502/プロキシエラー等）でも json() を throw
+		//   させず既定文言にフォールバックして元の挙動と等価にする。
+		const data = await uploadRes.json().catch(() => ({}) as { error?: string });
 		return {
 			ok: false,
 			error: data.error || "画像のアップロードに失敗しました",

--- a/apps/admin/src/lib/menu-image-upload.ts
+++ b/apps/admin/src/lib/menu-image-upload.ts
@@ -1,0 +1,35 @@
+export type MenuImageType = "beer-menu" | "food-menu";
+
+export type MenuImageUploadResult =
+	| { ok: true; url: string | null }
+	| { ok: false; error: string };
+
+// Why not 戻り値を string | null にしない:
+//   登録フォームはアップロード失敗を握りつぶし、編集フォームは失敗レスポンスの
+//   error 文言を読んで中断する。両者の挙動を維持するには成功/失敗を判別できる
+//   結果型が必要で、string | null では「成功かつ url なし」と「失敗」を区別できない。
+export async function uploadMenuImage(
+	barId: string,
+	file: File,
+	type: MenuImageType,
+): Promise<MenuImageUploadResult> {
+	const formData = new FormData();
+	formData.append("file", file);
+	formData.append("type", type);
+
+	const uploadRes = await fetch(`/api/bars/${barId}/media`, {
+		method: "POST",
+		body: formData,
+	});
+
+	if (!uploadRes.ok) {
+		const data = await uploadRes.json();
+		return {
+			ok: false,
+			error: data.error || "画像のアップロードに失敗しました",
+		};
+	}
+
+	const uploadData = await uploadRes.json();
+	return { ok: true, url: uploadData.url || null };
+}


### PR DESCRIPTION
## 概要

Issue #316 のリファクタ。`/api/bars/[barId]/media` への画像アップロード処理が4箇所にコピペされていたのを共通関数 `uploadMenuImage` に集約する。**機能挙動は変えない純粋なリファクタ**。

Closes #316

## 変更

- 新規: `apps/admin/src/lib/menu-image-upload.ts` — `uploadMenuImage(barId, file, type): Promise<MenuImageUploadResult>`
- 新規: `apps/admin/src/lib/menu-image-upload.test.ts` — 成功/失敗/URL欠落/既定エラー文言/POST内容の5ケース
- 書き換え（4箇所を共通関数呼び出しへ）:
  - `apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx`
  - `apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx`
  - `apps/admin/src/components/BeerMenuForm.tsx`
  - `apps/admin/src/components/FoodMenuForm.tsx`

## 設計判断（要レビュー）

Issue は戻り値を `Promise<string | null>` と「基本とする」と記載していたが、4箇所の既存挙動は2系統に分かれていた:

- **登録フォーム**: アップロード失敗を握りつぶして `imageUrl` を null のまま続行
- **編集フォーム**: 失敗レスポンスの `data.error` を `setError` 表示して `return` で中断

`string | null` では「成功かつ url なし」と「失敗」を区別できず、編集フォームのエラー文言表示・中断挙動を維持できない。最優先制約「機能挙動不変」を守るため、成功/失敗を判別できる結果型 `{ ok: true; url } | { ok: false; error }` を採用した。

## テスト

- UT: web 346 + admin 90 = 436 全パス
- IT/E2E: 司令塔フェーズで実施

## 補足

このPRは `/loop-issues`（半自動Issue消化ループ）スキルの初回動作確認として、ループ経由で自動生成されたもの。