### PR TITLE
fix: メニュー登録フォームの画像アップロード失敗を握り潰さず setError する (#317)

### DIFF
--- a/apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx
@@ -177,9 +177,13 @@ export default function BeerMenuCreateForm({ barId }: BeerMenuCreateFormProps) {
 					imageFile,
 					"beer-menu",
 				);
-				if (uploadResult.ok) {
-					imageUrl = uploadResult.url;
+
+				if (!uploadResult.ok) {
+					setError(uploadResult.error);
+					return;
 				}
+
+				imageUrl = uploadResult.url;
 			}
 
 			const res = await fetch(`/api/bars/${barId}/menus/beers`, {

--- a/apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx
@@ -60,9 +60,13 @@ export default function FoodMenuCreateForm({ barId }: FoodMenuCreateFormProps) {
 					imageFile,
 					"food-menu",
 				);
-				if (uploadResult.ok) {
-					imageUrl = uploadResult.url;
+
+				if (!uploadResult.ok) {
+					setError(uploadResult.error);
+					return;
 				}
+
+				imageUrl = uploadResult.url;
 			}
 
 			const res = await fetch(`/api/bars/${barId}/menus/foods`, {

--- a/apps/admin/src/lib/menu-image-upload.ts
+++ b/apps/admin/src/lib/menu-image-upload.ts
@@ -5,9 +5,9 @@ export type MenuImageUploadResult =
 	| { ok: false; error: string };
 
 // Why not 戻り値を string | null にしない:
-//   登録フォームはアップロード失敗を握りつぶし、編集フォームは失敗レスポンスの
-//   error 文言を読んで中断する。両者の挙動を維持するには成功/失敗を判別できる
-//   結果型が必要で、string | null では「成功かつ url なし」と「失敗」を区別できない。
+//   登録フォーム・編集フォームとも、失敗レスポンスの error 文言を読んで中断する。
+//   この挙動には成功/失敗を判別できる結果型が必要で、string | null では
+//   「成功かつ url なし」と「失敗」を区別できない。
 export async function uploadMenuImage(
 	barId: string,
 	file: File,


### PR DESCRIPTION
## 概要

メニュー登録フォーム（ビール/フード）で画像アップロードAPIが失敗した場合、エラーがユーザーに伝わらず画像なし（`image_url=null`）のままメニューが登録されてしまう不具合を修正する。

Closes #317

## 変更内容

- `apps/admin/src/app/bars/[barId]/menus/new/BeerMenuCreateForm.tsx`
- `apps/admin/src/app/bars/[barId]/menus/new/FoodMenuCreateForm.tsx`

両登録フォームのアップロード失敗ハンドリングを、編集フォーム（`BeerMenuForm.tsx` / `FoodMenuForm.tsx`、PR #314 で導入済み）と同じパターンに統一:

```ts
const uploadResult = await uploadMenuImage(...);
if (!uploadResult.ok) {
  setError(uploadResult.error);
  return; // 登録APIを呼ばずに中断
}
imageUrl = uploadResult.url;
```

- アップロード失敗時は `setError(uploadResult.error)` でエラー表示し、登録処理に進まない。
- 成功パスの挙動（url を imageUrl に入れて登録）は不変。
- `menu-image-upload.ts` の旧挙動を記述していた Why not コメントを現挙動に合わせて更新（ロジック変更なし）。

## テスト

- `pnpm --filter ./apps/admin test`: 緑（13 files / 91 tests passed）
- 共通関数 `uploadMenuImage` の失敗時契約は既存 `menu-image-upload.test.ts`（5ケース）でロック済み。
- フォーム側フローは既存 E2E `beer-menu-image-upload.spec.ts`（#295）でカバー。
- フォームコンポーネントの単体UTは admin の Vitest が `environment: node` 固定で testing-library/jsdom 未導入のため見送り（基盤新設はスコープ外）。

## format / lint

- `pnpm format`（Biome）: No fixes applied
- `pnpm lint`（Biome）: No fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)