### PR TITLE
perf: Vercel関数リージョンを東京(hnd1)に固定しプレビューのレスポンスを改善

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"regions": ["hnd1"],
 	"git": {
 		"deploymentEnabled": false
 	}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"regions": ["hnd1"],
 	"git": {
 		"deploymentEnabled": false
 	}


### PR DESCRIPTION
## 背景

プレビュー環境（develop 追従）のレスポンスが遅いという報告を受け、system-architect エージェントで診断した。

### 診断結果

主因は **Vercel 関数リージョン（`iad1` / 米バージニア）と Supabase リージョン（`ap-northeast-1` / 東京）の不一致**。

`middleware.ts` が保護ページのリクエストごとに Supabase Auth + `user_profiles` への DB 往復を行うため、太平洋を横断するレイテンシ（往復 ~170ms）が毎リクエストに乗り、ウォーム時でも `/login` の TTFB が 0.5s 前後、コールド時は 2s 超になっていた。

N+1・バンドルサイズ・画像・CDN は無実（静的アセットは東京エッジで CDN HIT）。

## 変更内容

- `apps/web/vercel.json` / `apps/admin/vercel.json` に `"regions": ["hnd1"]`（東京）を追加し、両アプリのデプロイ先を Supabase と同一リージョンに固定。

Supabase MCP でプロジェクト `srgecvsxybsqyyhjnzsc`（beer-salon-production）の実リージョンが `ap-northeast-1`（東京）であることを確認済み。`hnd1` と同一リージョン。

## 計測（マージ前 / web /login TTFB）

| 試行 | http | TTFB |
|------|------|------|
| コールド | 200 | 2.34s |
| ウォーム定常 | 200 | 0.45〜0.84s |

マージ後にプレビューへ反映されたところでアフター計測し、本 PR にコメントで記録する。

## 残課題（本 PR の対象外・効果計測後に判断）

- middleware の `user_profiles` 毎回チェックの削減
- コールドスタート低減（Fluid Compute 等）
- admin の Vercel Authentication 設定確認（ダッシュボード操作。現時点では 200 到達を確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)