### PR TITLE
feat: 通知生成を補完する（フォロー通知・お気に入り店舗の新着記事通知） (#334)

### DIFF
--- a/apps/admin/src/__tests__/article-api.test.ts
+++ b/apps/admin/src/__tests__/article-api.test.ts
@@ -14,6 +14,16 @@ vi.mock("@/lib/supabase", () => ({
 	},
 }));
 
+// 通知生成は article-notification.test.ts で検証するため、ここでは副作用を切り離す
+const mockShouldNotifyNewArticle = vi.fn().mockReturnValue(false);
+const mockNotifyFavoriteUsers = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/article-notification", () => ({
+	shouldNotifyNewArticle: (...args: unknown[]) =>
+		mockShouldNotifyNewArticle(...args),
+	notifyFavoriteUsersOfNewArticle: (...args: unknown[]) =>
+		mockNotifyFavoriteUsers(...args),
+}));
+
 import { PUT } from "@/app/api/bars/[barId]/articles/[articleId]/route";
 import { POST } from "@/app/api/bars/[barId]/articles/route";
 
@@ -31,13 +41,26 @@ function mockInsertChain(result: { data: unknown; error: unknown }) {
 	return { insert, select, single };
 }
 
-function mockUpdateChain(result: { data: unknown; error: unknown }) {
+function mockUpdateChain(
+	result: { data: unknown; error: unknown },
+	previousStatus: string | null = "draft",
+) {
 	const single = vi.fn().mockResolvedValue(result);
-	const select = vi.fn().mockReturnValue({ single });
-	const eqBar = vi.fn().mockReturnValue({ select });
+	const updateSelect = vi.fn().mockReturnValue({ single });
+	const eqBar = vi.fn().mockReturnValue({ select: updateSelect });
 	const eqId = vi.fn().mockReturnValue({ eq: eqBar });
 	const update = vi.fn().mockReturnValue({ eq: eqId });
-	mockSupabaseFrom.mockReturnValue({ update });
+
+	// 更新前の保存前ステータス取得（.select("status").eq().eq().is().single()）に対応する
+	const fetchSingle = vi
+		.fn()
+		.mockResolvedValue({ data: { status: previousStatus }, error: null });
+	const fetchIs = vi.fn().mockReturnValue({ single: fetchSingle });
+	const fetchEqBar = vi.fn().mockReturnValue({ is: fetchIs });
+	const fetchEqId = vi.fn().mockReturnValue({ eq: fetchEqBar });
+	const fetchSelect = vi.fn().mockReturnValue({ eq: fetchEqId });
+
+	mockSupabaseFrom.mockReturnValue({ select: fetchSelect, update });
 	return { update };
 }
 

--- a/apps/admin/src/__tests__/article-notification.test.ts
+++ b/apps/admin/src/__tests__/article-notification.test.ts
@@ -207,3 +207,125 @@ describe("PUT 記事編集時の新着記事通知", () => {
 		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
 	});
 });
+
+describe("通知配信が失敗しても記事保存レスポンスは成功で返る（観点3 High）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	it("POST: 通知配信が例外を投げても記事は 201 で返る", async () => {
+		mockInsertChain({ data: { id: 30 }, error: null });
+		mockNotifyFavoriteUsers.mockRejectedValueOnce(
+			new Error("notification failed"),
+		);
+
+		const response = await POST(
+			createMockRequest({
+				title: "公開記事",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(201);
+	});
+
+	it("PUT: 通知配信が例外を投げても記事は 200 で返る", async () => {
+		mockUpdateChain({ data: { id: 31 }, error: null }, "draft");
+		mockNotifyFavoriteUsers.mockRejectedValueOnce(
+			new Error("notification failed"),
+		);
+
+		const response = await PUT(
+			createMockRequest({
+				title: "公開記事",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "31" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(200);
+	});
+});
+
+describe("PUT 保存前 status 取得失敗時の挙動（観点2 Medium）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	function mockUpdateChainWithFetchError(fetchError: {
+		code?: string;
+		message: string;
+	}) {
+		const update = vi.fn();
+		const fetchSingle = vi
+			.fn()
+			.mockResolvedValue({ data: null, error: fetchError });
+		const fetchIs = vi.fn().mockReturnValue({ single: fetchSingle });
+		const fetchEqBar = vi.fn().mockReturnValue({ is: fetchIs });
+		const fetchEqId = vi.fn().mockReturnValue({ eq: fetchEqBar });
+		const fetchSelect = vi.fn().mockReturnValue({ eq: fetchEqId });
+		mockSupabaseFrom.mockReturnValue({ select: fetchSelect, update });
+		return { update };
+	}
+
+	it("保存前 status が PGRST116（該当なし）なら 404 を返し update も通知もしない", async () => {
+		const { update } = mockUpdateChainWithFetchError({
+			code: "PGRST116",
+			message: "no rows",
+		});
+
+		const response = await PUT(
+			createMockRequest({
+				title: "公開記事",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "404" }) },
+		);
+
+		expect(response.status).toBe(404);
+		expect(update).not.toHaveBeenCalled();
+		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
+	});
+
+	it("保存前 status 取得が PGRST116 以外のエラーなら 500 を返し update も通知もしない", async () => {
+		const { update } = mockUpdateChainWithFetchError({
+			code: "PGRST500",
+			message: "db error",
+		});
+
+		const response = await PUT(
+			createMockRequest({
+				title: "公開記事",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "1" }) },
+		);
+
+		expect(response.status).toBe(500);
+		expect(update).not.toHaveBeenCalled();
+		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
+	});
+});

--- a/apps/admin/src/__tests__/article-notification.test.ts
+++ b/apps/admin/src/__tests__/article-notification.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+const mockCanAccessBar = vi.fn();
+vi.mock("@/lib/auth", () => ({
+	getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+	canAccessBar: (...args: unknown[]) => mockCanAccessBar(...args),
+}));
+
+const mockSupabaseFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+	},
+}));
+
+const mockNotifyFavoriteUsers = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/article-notification", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/article-notification")>();
+	return {
+		// shouldNotifyNewArticle は純粋ロジックなので本物を使い、副作用のある通知配信のみモックする
+		shouldNotifyNewArticle: actual.shouldNotifyNewArticle,
+		notifyFavoriteUsersOfNewArticle: (...args: unknown[]) =>
+			mockNotifyFavoriteUsers(...args),
+	};
+});
+
+import { PUT } from "@/app/api/bars/[barId]/articles/[articleId]/route";
+import { POST } from "@/app/api/bars/[barId]/articles/route";
+import { shouldNotifyNewArticle } from "@/lib/article-notification";
+
+function createMockRequest(body: unknown): { json: () => Promise<unknown> } {
+	return {
+		json: () => Promise.resolve(body),
+	};
+}
+
+function mockInsertChain(result: { data: unknown; error: unknown }) {
+	const single = vi.fn().mockResolvedValue(result);
+	const select = vi.fn().mockReturnValue({ single });
+	const insert = vi.fn().mockReturnValue({ select });
+	mockSupabaseFrom.mockReturnValue({ insert });
+}
+
+function mockUpdateChain(
+	result: { data: unknown; error: unknown },
+	previousStatus: string | null,
+) {
+	const single = vi.fn().mockResolvedValue(result);
+	const updateSelect = vi.fn().mockReturnValue({ single });
+	const eqBar = vi.fn().mockReturnValue({ select: updateSelect });
+	const eqId = vi.fn().mockReturnValue({ eq: eqBar });
+	const update = vi.fn().mockReturnValue({ eq: eqId });
+
+	const fetchSingle = vi
+		.fn()
+		.mockResolvedValue({ data: { status: previousStatus }, error: null });
+	const fetchIs = vi.fn().mockReturnValue({ single: fetchSingle });
+	const fetchEqBar = vi.fn().mockReturnValue({ is: fetchIs });
+	const fetchEqId = vi.fn().mockReturnValue({ eq: fetchEqBar });
+	const fetchSelect = vi.fn().mockReturnValue({ eq: fetchEqId });
+
+	mockSupabaseFrom.mockReturnValue({ select: fetchSelect, update });
+}
+
+describe("shouldNotifyNewArticle（公開遷移判定）", () => {
+	it("新規作成で published なら通知対象", () => {
+		expect(shouldNotifyNewArticle(null, "published")).toBe(true);
+	});
+
+	it("新規作成で draft なら通知対象外", () => {
+		expect(shouldNotifyNewArticle(null, "draft")).toBe(false);
+	});
+
+	it("新規作成で scheduled なら通知対象外", () => {
+		expect(shouldNotifyNewArticle(null, "scheduled")).toBe(false);
+	});
+
+	it("draft → published は通知対象", () => {
+		expect(shouldNotifyNewArticle("draft", "published")).toBe(true);
+	});
+
+	it("scheduled → published は通知対象", () => {
+		expect(shouldNotifyNewArticle("scheduled", "published")).toBe(true);
+	});
+
+	it("published → published（再保存）は二重通知防止のため通知対象外", () => {
+		expect(shouldNotifyNewArticle("published", "published")).toBe(false);
+	});
+
+	it("published → draft（非公開化）は通知対象外", () => {
+		expect(shouldNotifyNewArticle("published", "draft")).toBe(false);
+	});
+});
+
+describe("POST 記事作成時の新着記事通知", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	it("published で作成すると通知配信が呼ばれる", async () => {
+		mockInsertChain({ data: { id: 10 }, error: null });
+
+		await POST(
+			createMockRequest({
+				title: "新メニュー入荷",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledTimes(1);
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledWith({
+			barId: 1,
+			articleId: 10,
+			articleTitle: "新メニュー入荷",
+		});
+	});
+
+	it("draft で作成しても通知配信は呼ばれない", async () => {
+		mockInsertChain({ data: { id: 11 }, error: null });
+
+		await POST(
+			createMockRequest({
+				title: "下書き",
+				body: "本文",
+				status: "draft",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
+	});
+});
+
+describe("PUT 記事編集時の新着記事通知", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	it("draft → published で通知配信が呼ばれる", async () => {
+		mockUpdateChain({ data: { id: 20 }, error: null }, "draft");
+
+		await PUT(
+			createMockRequest({
+				title: "公開記事",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "20" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledTimes(1);
+		expect(mockNotifyFavoriteUsers).toHaveBeenCalledWith({
+			barId: 1,
+			articleId: 20,
+			articleTitle: "公開記事",
+		});
+	});
+
+	it("published → published（再保存）では通知配信が呼ばれない", async () => {
+		mockUpdateChain({ data: { id: 21 }, error: null }, "published");
+
+		await PUT(
+			createMockRequest({
+				title: "公開記事の修正",
+				body: "本文",
+				status: "published",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "21" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
+	});
+
+	it("draft → draft では通知配信が呼ばれない", async () => {
+		mockUpdateChain({ data: { id: 22 }, error: null }, "draft");
+
+		await PUT(
+			createMockRequest({
+				title: "下書き更新",
+				body: "本文",
+				status: "draft",
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小モック
+			}) as any,
+			{ params: Promise.resolve({ barId: "1", articleId: "22" }) },
+		);
+
+		expect(mockNotifyFavoriteUsers).not.toHaveBeenCalled();
+	});
+});

--- a/apps/admin/src/__tests__/notify-favorite-users.test.ts
+++ b/apps/admin/src/__tests__/notify-favorite-users.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSupabaseFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+	},
+}));
+
+import { notifyFavoriteUsersOfNewArticle } from "@/lib/article-notification";
+
+describe("notifyFavoriteUsersOfNewArticle（配信対象解決と通知行の組み立て）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("お気に入り登録した全ユーザー分の new_article 通知行を insert する", async () => {
+		const insert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+		const barSingle = vi
+			.fn()
+			.mockResolvedValue({ data: { name: "Fuji Beer Bar" }, error: null });
+		const barEq = vi.fn().mockReturnValue({ single: barSingle });
+		const barSelect = vi.fn().mockReturnValue({ eq: barEq });
+
+		const favoriteEq = vi.fn().mockResolvedValue({
+			data: [{ user_id: "user-a" }, { user_id: "user-b" }],
+			error: null,
+		});
+		const favoriteSelect = vi.fn().mockReturnValue({ eq: favoriteEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === "bars") return { select: barSelect };
+			if (table === "favorite_bars") return { select: favoriteSelect };
+			if (table === "notifications") return { insert };
+			throw new Error(`unexpected table: ${table}`);
+		});
+
+		await notifyFavoriteUsersOfNewArticle({
+			barId: 1,
+			articleId: 99,
+			articleTitle: "限定IPA入荷",
+		});
+
+		expect(insert).toHaveBeenCalledTimes(1);
+		expect(insert).toHaveBeenCalledWith([
+			{
+				user_id: "user-a",
+				type: "new_article",
+				title: "新着記事",
+				message: "Fuji Beer Barが新しい記事「限定IPA入荷」を公開しました",
+				link_url: "/articles/99",
+				is_read: false,
+			},
+			{
+				user_id: "user-b",
+				type: "new_article",
+				title: "新着記事",
+				message: "Fuji Beer Barが新しい記事「限定IPA入荷」を公開しました",
+				link_url: "/articles/99",
+				is_read: false,
+			},
+		]);
+	});
+
+	it("お気に入り登録ユーザーが0件なら insert しない", async () => {
+		const insert = vi.fn();
+
+		const barSingle = vi
+			.fn()
+			.mockResolvedValue({ data: { name: "Fuji Beer Bar" }, error: null });
+		const barEq = vi.fn().mockReturnValue({ single: barSingle });
+		const barSelect = vi.fn().mockReturnValue({ eq: barEq });
+
+		const favoriteEq = vi.fn().mockResolvedValue({ data: [], error: null });
+		const favoriteSelect = vi.fn().mockReturnValue({ eq: favoriteEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === "bars") return { select: barSelect };
+			if (table === "favorite_bars") return { select: favoriteSelect };
+			if (table === "notifications") return { insert };
+			throw new Error(`unexpected table: ${table}`);
+		});
+
+		await notifyFavoriteUsersOfNewArticle({
+			barId: 1,
+			articleId: 99,
+			articleTitle: "限定IPA入荷",
+		});
+
+		expect(insert).not.toHaveBeenCalled();
+	});
+});

--- a/apps/admin/src/__tests__/notify-favorite-users.test.ts
+++ b/apps/admin/src/__tests__/notify-favorite-users.test.ts
@@ -90,4 +90,86 @@ describe("notifyFavoriteUsersOfNewArticle（配信対象解決と通知行の組
 
 		expect(insert).not.toHaveBeenCalled();
 	});
+
+	it("bars 取得が error なら throw する（黙って握りつぶさない）", async () => {
+		const barSingle = vi.fn().mockResolvedValue({
+			data: null,
+			error: { message: "bar fetch failed" },
+		});
+		const barEq = vi.fn().mockReturnValue({ single: barSingle });
+		const barSelect = vi.fn().mockReturnValue({ eq: barEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === "bars") return { select: barSelect };
+			throw new Error(`unexpected table: ${table}`);
+		});
+
+		await expect(
+			notifyFavoriteUsersOfNewArticle({
+				barId: 1,
+				articleId: 99,
+				articleTitle: "限定IPA入荷",
+			}),
+		).rejects.toThrow(/bar fetch failed/);
+	});
+
+	it("favorite_bars 取得が error なら throw する（黙って握りつぶさない）", async () => {
+		const barSingle = vi
+			.fn()
+			.mockResolvedValue({ data: { name: "Fuji Beer Bar" }, error: null });
+		const barEq = vi.fn().mockReturnValue({ single: barSingle });
+		const barSelect = vi.fn().mockReturnValue({ eq: barEq });
+
+		const favoriteEq = vi.fn().mockResolvedValue({
+			data: null,
+			error: { message: "favorites fetch failed" },
+		});
+		const favoriteSelect = vi.fn().mockReturnValue({ eq: favoriteEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === "bars") return { select: barSelect };
+			if (table === "favorite_bars") return { select: favoriteSelect };
+			throw new Error(`unexpected table: ${table}`);
+		});
+
+		await expect(
+			notifyFavoriteUsersOfNewArticle({
+				barId: 1,
+				articleId: 99,
+				articleTitle: "限定IPA入荷",
+			}),
+		).rejects.toThrow(/favorites fetch failed/);
+	});
+
+	it("notifications insert が error なら throw する（黙って握りつぶさない）", async () => {
+		const insert = vi
+			.fn()
+			.mockResolvedValue({ data: null, error: { message: "insert failed" } });
+
+		const barSingle = vi
+			.fn()
+			.mockResolvedValue({ data: { name: "Fuji Beer Bar" }, error: null });
+		const barEq = vi.fn().mockReturnValue({ single: barSingle });
+		const barSelect = vi.fn().mockReturnValue({ eq: barEq });
+
+		const favoriteEq = vi
+			.fn()
+			.mockResolvedValue({ data: [{ user_id: "user-a" }], error: null });
+		const favoriteSelect = vi.fn().mockReturnValue({ eq: favoriteEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === "bars") return { select: barSelect };
+			if (table === "favorite_bars") return { select: favoriteSelect };
+			if (table === "notifications") return { insert };
+			throw new Error(`unexpected table: ${table}`);
+		});
+
+		await expect(
+			notifyFavoriteUsersOfNewArticle({
+				barId: 1,
+				articleId: 99,
+				articleTitle: "限定IPA入荷",
+			}),
+		).rejects.toThrow(/insert failed/);
+	});
 });

--- a/apps/admin/src/app/api/bars/[barId]/articles/[articleId]/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/articles/[articleId]/route.ts
@@ -101,13 +101,27 @@ export async function PUT(
 		}
 
 		// 公開遷移（published 以外 → published）の判定に保存前ステータスを使うため更新前に取得する
-		const { data: previousArticle } = await supabaseAdmin
-			.from("articles")
-			.select("status")
-			.eq("id", articleId)
-			.eq("bar_id", barId)
-			.is("deleted_at", null)
-			.single();
+		const { data: previousArticle, error: previousArticleError } =
+			await supabaseAdmin
+				.from("articles")
+				.select("status")
+				.eq("id", articleId)
+				.eq("bar_id", barId)
+				.is("deleted_at", null)
+				.single();
+
+		if (previousArticleError) {
+			if (previousArticleError.code === "PGRST116") {
+				return NextResponse.json(
+					{ error: "Article not found" },
+					{ status: 404 },
+				);
+			}
+			return NextResponse.json(
+				{ error: "Failed to fetch article" },
+				{ status: 500 },
+			);
+		}
 
 		const { data, error } = await supabaseAdmin
 			.from("articles")
@@ -140,14 +154,23 @@ export async function PUT(
 		}
 
 		// 今回の保存で公開へ遷移した場合のみ通知（published のまま再保存では二重通知しない）
+		// 通知は記事保存の副次処理。失敗しても記事は保存済みのため、
+		// 外側 catch に巻き込んで 500 を返さずログ記録に留めて 200 を返す
 		if (
 			shouldNotifyNewArticle(previousArticle?.status ?? null, publishing.status)
 		) {
-			await notifyFavoriteUsersOfNewArticle({
-				barId: parseInt(barId, 10),
-				articleId: parseInt(articleId, 10),
-				articleTitle: title,
-			});
+			try {
+				await notifyFavoriteUsersOfNewArticle({
+					barId: parseInt(barId, 10),
+					articleId: parseInt(articleId, 10),
+					articleTitle: title,
+				});
+			} catch (notifyError) {
+				console.error(
+					"Failed to send new_article notifications after article update",
+					notifyError,
+				);
+			}
 		}
 
 		return NextResponse.json({ article: data });

--- a/apps/admin/src/app/api/bars/[barId]/articles/[articleId]/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/articles/[articleId]/route.ts
@@ -1,4 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
+import {
+	notifyFavoriteUsersOfNewArticle,
+	shouldNotifyNewArticle,
+} from "@/lib/article-notification";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveArticlePublishing } from "@/lib/validators";
@@ -96,6 +100,15 @@ export async function PUT(
 			return NextResponse.json({ error: publishing.error }, { status: 400 });
 		}
 
+		// 公開遷移（published 以外 → published）の判定に保存前ステータスを使うため更新前に取得する
+		const { data: previousArticle } = await supabaseAdmin
+			.from("articles")
+			.select("status")
+			.eq("id", articleId)
+			.eq("bar_id", barId)
+			.is("deleted_at", null)
+			.single();
+
 		const { data, error } = await supabaseAdmin
 			.from("articles")
 			.update({
@@ -124,6 +137,17 @@ export async function PUT(
 				{ error: "Failed to update article" },
 				{ status: 500 },
 			);
+		}
+
+		// 今回の保存で公開へ遷移した場合のみ通知（published のまま再保存では二重通知しない）
+		if (
+			shouldNotifyNewArticle(previousArticle?.status ?? null, publishing.status)
+		) {
+			await notifyFavoriteUsersOfNewArticle({
+				barId: parseInt(barId, 10),
+				articleId: parseInt(articleId, 10),
+				articleTitle: title,
+			});
 		}
 
 		return NextResponse.json({ article: data });

--- a/apps/admin/src/app/api/bars/[barId]/articles/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/articles/route.ts
@@ -1,4 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
+import {
+	notifyFavoriteUsersOfNewArticle,
+	shouldNotifyNewArticle,
+} from "@/lib/article-notification";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveArticlePublishing } from "@/lib/validators";
@@ -110,6 +114,15 @@ export async function POST(
 				{ error: "Failed to create article" },
 				{ status: 500 },
 			);
+		}
+
+		// 新規作成では保存前ステータスが存在しないため null を渡す
+		if (shouldNotifyNewArticle(null, publishing.status)) {
+			await notifyFavoriteUsersOfNewArticle({
+				barId: parseInt(barId, 10),
+				articleId: data.id,
+				articleTitle: title,
+			});
 		}
 
 		return NextResponse.json({ article: data }, { status: 201 });

--- a/apps/admin/src/app/api/bars/[barId]/articles/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/articles/route.ts
@@ -117,12 +117,21 @@ export async function POST(
 		}
 
 		// 新規作成では保存前ステータスが存在しないため null を渡す
+		// 通知は記事保存の副次処理。失敗しても記事は保存済みのため、
+		// 外側 catch に巻き込んで 500 を返さずログ記録に留めて 201 を返す
 		if (shouldNotifyNewArticle(null, publishing.status)) {
-			await notifyFavoriteUsersOfNewArticle({
-				barId: parseInt(barId, 10),
-				articleId: data.id,
-				articleTitle: title,
-			});
+			try {
+				await notifyFavoriteUsersOfNewArticle({
+					barId: parseInt(barId, 10),
+					articleId: data.id,
+					articleTitle: title,
+				});
+			} catch (notifyError) {
+				console.error(
+					"Failed to send new_article notifications after article create",
+					notifyError,
+				);
+			}
 		}
 
 		return NextResponse.json({ article: data }, { status: 201 });

--- a/apps/admin/src/lib/article-notification.ts
+++ b/apps/admin/src/lib/article-notification.ts
@@ -26,6 +26,10 @@ export function shouldNotifyNewArticle(
  *
  * web 側（prisma）ではなく admin 側の既存 DB アクセス流儀（supabaseAdmin）に合わせる。
  * notifications テーブルのカラムは snake_case。
+ *
+ * supabase 呼び出しの error は握りつぶさず throw する。
+ * 通知は記事保存の副次処理であり、呼び出し側（記事 POST/PUT）が独立した
+ * try/catch で受けてログに留め、記事保存の正常レスポンスは巻き込まないため。
  */
 export async function notifyFavoriteUsersOfNewArticle(params: {
 	barId: number;
@@ -34,18 +38,30 @@ export async function notifyFavoriteUsersOfNewArticle(params: {
 }): Promise<void> {
 	const { barId, articleId, articleTitle } = params;
 
-	const { data: bar } = await supabaseAdmin
+	const { data: bar, error: barError } = await supabaseAdmin
 		.from("bars")
 		.select("name")
 		.eq("id", barId)
 		.single();
 
+	if (barError) {
+		throw new Error(
+			`Failed to fetch bar for new_article notification: ${barError.message}`,
+		);
+	}
+
 	const barName = bar?.name ?? "";
 
-	const { data: favorites } = await supabaseAdmin
+	const { data: favorites, error: favoritesError } = await supabaseAdmin
 		.from("favorite_bars")
 		.select("user_id")
 		.eq("bar_id", barId);
+
+	if (favoritesError) {
+		throw new Error(
+			`Failed to fetch favorite_bars for new_article notification: ${favoritesError.message}`,
+		);
+	}
 
 	if (!favorites || favorites.length === 0) {
 		return;
@@ -60,5 +76,13 @@ export async function notifyFavoriteUsersOfNewArticle(params: {
 		is_read: false,
 	}));
 
-	await supabaseAdmin.from("notifications").insert(rows);
+	const { error: insertError } = await supabaseAdmin
+		.from("notifications")
+		.insert(rows);
+
+	if (insertError) {
+		throw new Error(
+			`Failed to insert new_article notifications: ${insertError.message}`,
+		);
+	}
 }

--- a/apps/admin/src/lib/article-notification.ts
+++ b/apps/admin/src/lib/article-notification.ts
@@ -1,0 +1,64 @@
+import { supabaseAdmin } from "@/lib/supabase";
+
+/**
+ * 記事の保存が「新着記事通知を出すべき公開遷移」かどうかを判定する。
+ *
+ * - 新規作成（previousStatus = null）: 保存後が published なら通知
+ * - 編集: 保存前が published 以外 かつ 保存後が published のとき（公開への遷移）のみ通知
+ *   既に published の記事を再編集して published のまま保存した場合は二重通知防止のため通知しない
+ *
+ * scheduled → published のバッチ公開は本リポジトリに存在しないため、
+ * 通知トリガーは admin で published として保存された瞬間に限定する。
+ */
+export function shouldNotifyNewArticle(
+	previousStatus: string | null,
+	nextStatus: string,
+): boolean {
+	if (nextStatus !== "published") {
+		return false;
+	}
+	return previousStatus !== "published";
+}
+
+/**
+ * 記事を公開した店舗を favorite_bars 登録している全ユーザーに
+ * type=new_article の通知を insert する。
+ *
+ * web 側（prisma）ではなく admin 側の既存 DB アクセス流儀（supabaseAdmin）に合わせる。
+ * notifications テーブルのカラムは snake_case。
+ */
+export async function notifyFavoriteUsersOfNewArticle(params: {
+	barId: number;
+	articleId: number;
+	articleTitle: string;
+}): Promise<void> {
+	const { barId, articleId, articleTitle } = params;
+
+	const { data: bar } = await supabaseAdmin
+		.from("bars")
+		.select("name")
+		.eq("id", barId)
+		.single();
+
+	const barName = bar?.name ?? "";
+
+	const { data: favorites } = await supabaseAdmin
+		.from("favorite_bars")
+		.select("user_id")
+		.eq("bar_id", barId);
+
+	if (!favorites || favorites.length === 0) {
+		return;
+	}
+
+	const rows = favorites.map((favorite) => ({
+		user_id: favorite.user_id,
+		type: "new_article",
+		title: "新着記事",
+		message: `${barName}が新しい記事「${articleTitle}」を公開しました`,
+		link_url: `/articles/${articleId}`,
+		is_read: false,
+	}));
+
+	await supabaseAdmin.from("notifications").insert(rows);
+}

--- a/apps/web/src/actions/user-notification.test.ts
+++ b/apps/web/src/actions/user-notification.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	})),
+}));
+
+const mockUserProfileFindUnique = vi.fn();
+const mockFollowRelationCreate = vi.fn();
+const mockNotificationCreate = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+	prisma: {
+		userProfile: {
+			findUnique: (...args: unknown[]) => mockUserProfileFindUnique(...args),
+		},
+		userFollowRelation: {
+			create: (...args: unknown[]) => mockFollowRelationCreate(...args),
+		},
+		notification: {
+			create: (...args: unknown[]) => mockNotificationCreate(...args),
+		},
+	},
+}));
+
+import { followUser } from "./user";
+
+describe("followUser のフォロー通知生成", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetUser.mockResolvedValue({
+			data: { user: { id: "auth-follower" } },
+			error: null,
+		});
+		mockFollowRelationCreate.mockResolvedValue({});
+		mockNotificationCreate.mockResolvedValue({});
+	});
+
+	it("follower !== followee のとき followee 宛に type=followed の通知を生成する", async () => {
+		mockUserProfileFindUnique.mockResolvedValue({
+			id: "follower-profile-id",
+			nickname: "りく",
+		});
+
+		await followUser("followee-profile-id");
+
+		expect(mockFollowRelationCreate).toHaveBeenCalledWith({
+			data: {
+				followerId: "follower-profile-id",
+				followeeId: "followee-profile-id",
+			},
+		});
+		expect(mockNotificationCreate).toHaveBeenCalledTimes(1);
+		expect(mockNotificationCreate).toHaveBeenCalledWith({
+			data: {
+				userId: "followee-profile-id",
+				type: "followed",
+				title: "フォロー",
+				message: "りくさんにフォローされました",
+				linkUrl: "/users/follower-profile-id",
+			},
+		});
+	});
+
+	it("自己フォロー（follower === followee）では通知を生成しない", async () => {
+		mockUserProfileFindUnique.mockResolvedValue({
+			id: "same-profile-id",
+			nickname: "りく",
+		});
+
+		await followUser("same-profile-id");
+
+		expect(mockFollowRelationCreate).toHaveBeenCalledTimes(1);
+		expect(mockNotificationCreate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/actions/user.ts
+++ b/apps/web/src/actions/user.ts
@@ -329,6 +329,19 @@ export async function followUser(targetUserId: string) {
 			followeeId: targetUserId,
 		},
 	});
+
+	// 自己フォローは UI 上発生しないが、post_liked が自分の投稿を除外しているのと同様に防御する
+	if (targetUserId !== userProfile.id) {
+		await prisma.notification.create({
+			data: {
+				userId: targetUserId,
+				type: "followed",
+				title: "フォロー",
+				message: `${userProfile.nickname}さんにフォローされました`,
+				linkUrl: `/users/${userProfile.id}`,
+			},
+		});
+	}
 }
 
 export async function unfollowUser(targetUserId: string) {

--- a/database.md
+++ b/database.md
@@ -605,6 +605,14 @@ UNIQUE制約: `country_id + name`
 | is_read       | boolean    | NOT NULL DEFAULT false               | 既読フラグ                                 |
 | created_at    | timestamptz| NOT NULL DEFAULT now()               | 作成日時                                   |
 
+**生成される `type` と発火タイミング**:
+
+| type          | 発火タイミング                                                                 | title      | message 例                                  | link_url 例           |
+|---------------|--------------------------------------------------------------------------------|------------|---------------------------------------------|-----------------------|
+| `post_liked`  | 自分の投稿に他ユーザーがいいねしたとき（`apps/web` の `togglePostLike`）。自分の投稿への自己いいねは除外 | いいね     | `${ニックネーム}さんがあなたの投稿にいいねしました` | `/timeline`           |
+| `followed`    | 他ユーザーにフォローされたとき（`apps/web` の `followUser`）。自己フォローは除外。フォロー解除では生成しない | フォロー   | `${ニックネーム}さんにフォローされました`        | `/users/[userId]`（フォローした側のアプリ内ユーザーID `user_profiles.id`） |
+| `new_article` | お気に入り登録した店舗が記事を公開したとき（`apps/admin` の記事 POST / PUT で status が published へ遷移した瞬間）。配信対象は `favorite_bars` 経由で解決。published のまま再保存した場合は二重通知防止のため生成しない。予約公開（scheduled→published）を実行するバッチは未実装のため、scheduled は通知対象外 | 新着記事   | `${店舗名}が新しい記事「${記事タイトル}」を公開しました` | `/articles/[articleId]` |
+
 ---
 
 ## 7. ログ関連（任意で実装）


### PR DESCRIPTION
## 概要

Closes #334

README の MVP 機能「通知」のうち、これまで `post_liked` のみが生成されており、`followed` と `new_article` は type 定義だけで発火していなかった。本 PR で 2 種類の通知生成を追加する。

## 実装内容

### A. フォロー通知（type=followed）
- `apps/web/src/actions/user.ts` の `followUser` で、`UserFollowRelation` 作成成功後に followee（フォローされた側）宛へ通知を 1 件生成する。
- 自己フォロー（follower === followee）は UI 上発生しないが、既存の `post_liked` が自己いいねを除外しているのと同様に防御し、通知を生成しない。
- フォロー解除（`unfollowUser`）では通知を生成しない。
- 通知フィールド:
  - `type`: `followed` / `title`: `フォロー`
  - `message`: `${フォローした人のニックネーム}さんにフォローされました`
  - `linkUrl`: `/users/${フォローした側の user_profiles.id}`（既存の他ユーザーページリンクと同じく `UserProfile.id` を使用）

### B. 新着記事通知（type=new_article）
- `apps/admin` の記事 API（`articles` の POST / PUT）で、記事が **published として保存された瞬間** に、その店舗を `favorite_bars` 登録している全ユーザーへ通知を生成する。
- 生成条件（二重通知防止）:
  - POST（新規作成）: 保存後 status が `published` のとき。
  - PUT（編集）: 「保存前 status が published 以外」かつ「保存後 status が published」の公開遷移時のみ。保存前 status は更新前に DB から取得して判定する。既に published の記事を published のまま再保存しても通知しない。
- 予約公開（scheduled → published）を実行するバッチ/cron は本リポジトリに存在しないため、通知トリガーは admin で `published` 保存された瞬間に限定する（Issue 未確定事項のうち環境制約から一意に確定）。
- 配信は `favorite_bars` を `bar_id` で参照して全 `user_id` を解決し、`createMany` 相当（`insert` 配列）で一括生成する。
- admin 側は既存の DB アクセス流儀（`supabaseAdmin` の `notifications` insert、カラムは snake_case）に合わせた。
- 通知フィールド:
  - `type`: `new_article` / `title`: `新着記事`
  - `message`: `${店舗名}が新しい記事「${記事タイトル}」を公開しました`
  - `link_url`: `/articles/${記事ID}`
- 通知生成ロジックは `apps/admin/src/lib/article-notification.ts` に切り出し、純粋判定関数 `shouldNotifyNewArticle` と配信関数 `notifyFavoriteUsersOfNewArticle` に分離した。

## 変更ファイル
- `apps/web/src/actions/user.ts`（フォロー通知生成）
- `apps/admin/src/lib/article-notification.ts`（新規・通知生成ロジック）
- `apps/admin/src/app/api/bars/[barId]/articles/route.ts`（POST に通知連携）
- `apps/admin/src/app/api/bars/[barId]/articles/[articleId]/route.ts`（PUT に保存前 status 取得＋通知連携）
- `database.md`（notifications の生成 type と発火タイミングを追記）

## テスト観点（UT / Vitest）
追加した UT は共有 DB に触れない純粋ロジック / モックベース。`*.integration.test.ts` は対象外。

- `apps/web/src/actions/user-notification.test.ts`
  - follower !== followee のとき followee 宛に `followed` 通知を生成する
  - 自己フォローでは通知を生成しない
- `apps/admin/src/__tests__/article-notification.test.ts`
  - `shouldNotifyNewArticle` の公開遷移判定（新規 published / draft / scheduled、draft→published、scheduled→published、published→published、published→draft）
  - POST published で通知配信が呼ばれる / draft では呼ばれない
  - PUT draft→published で呼ばれる / published→published・draft→draft では呼ばれない
- `apps/admin/src/__tests__/notify-favorite-users.test.ts`
  - お気に入り登録ユーザー全員分の `new_article` 通知行（message / link_url 含む）を組み立てて insert する
  - お気に入り 0 件なら insert しない
- 既存の `apps/admin/src/__tests__/article-api.test.ts` は通知副作用をモックで切り離し、PUT の保存前 status 取得に対応するようモックチェーンを更新（既存 10 件は引き続き green）

### 実行結果
- `pnpm --filter web exec vitest run`: 348 passed
- `pnpm --filter admin test`: 105 passed
- `pnpm format` / `pnpm lint`: クリーン
- `pnpm typecheck`: web / admin とも green

## 受入条件の検証について
受入条件（フォロー時／記事公開時に通知一覧へ表示）は上記 UT で生成ロジックを担保。実画面での E2E 検証は共有 DB を要するため、本ブランチでは実行せず司令塔側での消化を想定する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)