### PR TITLE
feat: 記事ページで複数画像（image_url_2/3）を最大3枚表示する

### DIFF
--- a/apps/web/src/app/articles/[articleId]/article-images.test.ts
+++ b/apps/web/src/app/articles/[articleId]/article-images.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { getArticleImageUrls } from "./article-images";
+
+describe("getArticleImageUrls", () => {
+	describe("正常系", () => {
+		it("3枚すべて設定されている場合、3件を順序通り返す", () => {
+			const result = getArticleImageUrls({
+				imageUrl: "https://example.com/1.jpg",
+				imageUrl2: "https://example.com/2.jpg",
+				imageUrl3: "https://example.com/3.jpg",
+			});
+			expect(result).toEqual([
+				"https://example.com/1.jpg",
+				"https://example.com/2.jpg",
+				"https://example.com/3.jpg",
+			]);
+		});
+
+		it("1枚目のみ設定されている場合、1件を返す", () => {
+			const result = getArticleImageUrls({
+				imageUrl: "https://example.com/1.jpg",
+				imageUrl2: null,
+				imageUrl3: null,
+			});
+			expect(result).toEqual(["https://example.com/1.jpg"]);
+		});
+	});
+
+	describe("null を含む境界・異常系", () => {
+		it("2枚目のみ null の場合、imageUrl と imageUrl3 の2件を順序通り返す", () => {
+			const result = getArticleImageUrls({
+				imageUrl: "https://example.com/1.jpg",
+				imageUrl2: null,
+				imageUrl3: "https://example.com/3.jpg",
+			});
+			expect(result).toEqual([
+				"https://example.com/1.jpg",
+				"https://example.com/3.jpg",
+			]);
+		});
+
+		it("1枚目が null で 2・3枚目のみ設定の場合、2件を返す", () => {
+			const result = getArticleImageUrls({
+				imageUrl: null,
+				imageUrl2: "https://example.com/2.jpg",
+				imageUrl3: "https://example.com/3.jpg",
+			});
+			expect(result).toEqual([
+				"https://example.com/2.jpg",
+				"https://example.com/3.jpg",
+			]);
+		});
+
+		it("すべて null の場合、空配列を返す", () => {
+			const result = getArticleImageUrls({
+				imageUrl: null,
+				imageUrl2: null,
+				imageUrl3: null,
+			});
+			expect(result).toEqual([]);
+		});
+
+		it("空文字列は表示対象から除外する", () => {
+			const result = getArticleImageUrls({
+				imageUrl: "",
+				imageUrl2: "https://example.com/2.jpg",
+				imageUrl3: "",
+			});
+			expect(result).toEqual(["https://example.com/2.jpg"]);
+		});
+	});
+});

--- a/apps/web/src/app/articles/[articleId]/article-images.ts
+++ b/apps/web/src/app/articles/[articleId]/article-images.ts
@@ -1,0 +1,9 @@
+export function getArticleImageUrls(article: {
+	imageUrl: string | null;
+	imageUrl2: string | null;
+	imageUrl3: string | null;
+}): string[] {
+	return [article.imageUrl, article.imageUrl2, article.imageUrl3]
+		.filter((url): url is string => Boolean(url))
+		.slice(0, 3);
+}

--- a/apps/web/src/app/articles/[articleId]/page.tsx
+++ b/apps/web/src/app/articles/[articleId]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getArticleDetail } from "@/actions/article";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { getArticleImageUrls } from "./article-images";
 
 export default async function ArticlePage({
 	params,
@@ -22,6 +23,8 @@ export default async function ArticlePage({
 		const d = new Date(date);
 		return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
 	};
+
+	const imageUrls = getArticleImageUrls(article);
 
 	return (
 		<AuthenticatedLayout>
@@ -45,16 +48,19 @@ export default async function ArticlePage({
 							</p>
 						)}
 
-						{article.imageUrl && (
-							<div className="relative w-full h-96 mb-6 rounded-xl overflow-hidden bg-muted/30">
+						{imageUrls.map((url) => (
+							<div
+								key={url}
+								className="relative w-full h-96 mb-6 rounded-xl overflow-hidden bg-muted/30"
+							>
 								<Image
-									src={article.imageUrl}
+									src={url}
 									alt={article.title}
 									fill
 									className="object-cover"
 								/>
 							</div>
-						)}
+						))}
 
 						<div className="prose prose-lg max-w-none">
 							<p className="text-card-foreground whitespace-pre-wrap tracking-wide leading-relaxed">


### PR DESCRIPTION
## 概要
Closes #337

記事ページ（`/articles/[articleId]`）が `image_url` のみを表示していたため、登録済みの `image_url_2` / `image_url_3` が表示されない差分を解消する。最大3枚まで表示する。

## 変更内容
- `apps/web/src/app/articles/[articleId]/page.tsx`
  - 単枚表示を、表示対象 URL 配列を `.map()` する形に変更（1枚目の見た目は既存スタイルを踏襲し縦積み）
- `apps/web/src/app/articles/[articleId]/article-images.ts`（新規）
  - `getArticleImageUrls()`: `image_url` / `image_url_2` / `image_url_3` から falsy を除外し最大3枚に絞る純粋関数
- `apps/web/src/app/articles/[articleId]/article-images.test.ts`（新規・UT）

※ `getArticleDetail` は既に `imageUrl2` / `imageUrl3` を返却しており、アクション側の改修は不要。スキーマ変更なし。

## 受入条件
- [x] image_url_2/3 が設定された記事で2〜3枚目の画像が表示される
- [x] 未設定の画像枠は表示されない

## テスト
- UT 追加（6ケース・境界/異常系）：3枚すべて / 1枚のみ / 2枚目null / 1枚目null / 全null / 空文字除外
- `pnpm test`: web 全 354 passed
- 表示のみ・DB非依存のため IT は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)