### PR TITLE
ci: preview/production の Supabase プロジェクトを分岐適用する (#342)

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -33,17 +33,32 @@ jobs:
       # Secret を必ず両方参照でき、未登録でも空文字で素通りして link が分かりにくい形で失敗する。ここで ref_name に応じて
       # 適用先（main=prod / develop=dev）を1組だけ選び、選んだ Secret の有無を検査して原因が一目で分かる形で fail させる。
       # preview/production は別 Supabase プロジェクトに分離済み（README「DB マイグレーションの自動適用」参照）。
+      #
+      # Why not シークレットを run 本文へ ${{ secrets... }} で直接展開: DB パスワードは記号・改行等の特殊文字を含み得るため、
+      # 本文展開だと (a) スクリプトが構文破壊で異常終了し、(b) その行に ::add-mask:: 実行前の生値が露出する恐れがある
+      # （add-mask は同ステップ内でも当該行より後に効くため後追いになる）。シークレットは env 経由で環境変数へ渡し、
+      # 本文では "$VAR" 参照に限定して展開を避ける。
       - name: Resolve target project by branch
         id: target
+        env:
+          PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+          PROD_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          DEV_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID_DEV }}
+          DEV_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_DEV }}
         run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            project_id="${{ secrets.SUPABASE_PROJECT_ID }}"
-            db_password="${{ secrets.SUPABASE_DB_PASSWORD }}"
+          # Why not else を dev 扱い: 「main 以外は全部 dev」だと将来トリガーブランチが増えたとき暗黙で dev に流れて事故る。
+          # develop を明示し、想定外ブランチは fail させて意図を固定する。
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            project_id="$PROD_PROJECT_ID"
+            db_password="$PROD_DB_PASSWORD"
             missing_names="SUPABASE_PROJECT_ID / SUPABASE_DB_PASSWORD"
-          else
-            project_id="${{ secrets.SUPABASE_PROJECT_ID_DEV }}"
-            db_password="${{ secrets.SUPABASE_DB_PASSWORD_DEV }}"
+          elif [ "$GITHUB_REF_NAME" = "develop" ]; then
+            project_id="$DEV_PROJECT_ID"
+            db_password="$DEV_DB_PASSWORD"
             missing_names="SUPABASE_PROJECT_ID_DEV / SUPABASE_DB_PASSWORD_DEV"
+          else
+            echo "::error::Unsupported branch '$GITHUB_REF_NAME': this workflow applies migrations only for 'main' (prod) or 'develop' (dev)"
+            exit 1
           fi
 
           missing=0
@@ -52,7 +67,7 @@ jobs:
             missing=1
           fi
           if [ -z "$project_id" ] || [ -z "$db_password" ]; then
-            echo "::error::Required secret(s) not set for branch '${{ github.ref_name }}': $missing_names"
+            echo "::error::Required secret(s) not set for branch '$GITHUB_REF_NAME': $missing_names"
             missing=1
           fi
           [ "$missing" -eq 0 ]

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -26,24 +26,40 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
-      # Why not link 時に空文字で進める: Secret 未登録だと link が分かりにくい形で失敗するため、
-      # 先に必須 Secret の有無を検査して原因が一目で分かる形で fail させる。
-      - name: Check required secrets
+      # Why not project_ref / db_password を GitHub Actions 式で直接分岐: 式で分岐すると develop/main いずれかの
+      # Secret を必ず両方参照でき、未登録でも空文字で素通りして link が分かりにくい形で失敗する。ここで ref_name に応じて
+      # 適用先（main=prod / develop=dev）を1組だけ選び、選んだ Secret の有無を検査して原因が一目で分かる形で fail させる。
+      # preview/production は別 Supabase プロジェクトに分離済み（README「DB マイグレーションの自動適用」参照）。
+      - name: Resolve target project by branch
+        id: target
         run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            project_id="${{ secrets.SUPABASE_PROJECT_ID }}"
+            db_password="${{ secrets.SUPABASE_DB_PASSWORD }}"
+            missing_names="SUPABASE_PROJECT_ID / SUPABASE_DB_PASSWORD"
+          else
+            project_id="${{ secrets.SUPABASE_PROJECT_ID_DEV }}"
+            db_password="${{ secrets.SUPABASE_DB_PASSWORD_DEV }}"
+            missing_names="SUPABASE_PROJECT_ID_DEV / SUPABASE_DB_PASSWORD_DEV"
+          fi
+
           missing=0
-          for name in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_ID; do
-            if [ -z "${!name}" ]; then
-              echo "::error::Required secret '$name' is not set"
-              missing=1
-            fi
-          done
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::Required secret 'SUPABASE_ACCESS_TOKEN' is not set"
+            missing=1
+          fi
+          if [ -z "$project_id" ] || [ -z "$db_password" ]; then
+            echo "::error::Required secret(s) not set for branch '${{ github.ref_name }}': $missing_names"
+            missing=1
+          fi
           [ "$missing" -eq 0 ]
-        env:
-          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
+          echo "project_id=$project_id" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$db_password"
+          echo "db_password=$db_password" >> "$GITHUB_OUTPUT"
 
       # Why not version: latest: リモート本番DBへの DDL 適用は CLI 仕様変更で
       # 非対話実行の挙動が壊れると事故に直結するため、ローカルで db push 実績のある版に固定する。
@@ -52,12 +68,14 @@ jobs:
         with:
           version: 2.65.5
 
-      # Why not develop/main で適用先を分ける: 現状 preview/production は同一 Supabase プロジェクトを共用するため
-      # 適用先は1つ。将来プロジェクトを分離する場合は、ここの project-ref を環境別 Secret に切り替える。
       - name: Link to remote project
-        run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_ID }}"
+        run: supabase link --project-ref "${{ steps.target.outputs.project_id }}"
+        env:
+          SUPABASE_DB_PASSWORD: ${{ steps.target.outputs.db_password }}
 
       # Why not --dry-run: dry-run では適用されない。CLI が schema_migrations を見て
       # 未適用分のみ適用するため冪等。失敗時は非ゼロ終了でジョブが fail する。
       - name: Push migrations to remote
         run: supabase db push
+        env:
+          SUPABASE_DB_PASSWORD: ${{ steps.target.outputs.db_password }}

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 | Secret 名 | 用途 |
 |-----------|------|
-| `SUPABASE_ACCESS_TOKEN` | Supabase CLI のアクセストークン（`supabase link` 用）。ダッシュボード → Account → Access Tokens で発行。dev / prod 共通（同一組織なら1つで足りる） |
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI のアクセストークン（`supabase link` 用）。ダッシュボード → Account → Access Tokens で発行。dev / prod 共通で1つ。**ただしトークンは組織スコープのため、dev プロジェクトは prod と同一 Supabase 組織に作成すること**（別組織に作るとこの1トークンでは dev を link できず、組織ごとに別トークンが必要になる） |
 | `SUPABASE_PROJECT_ID` | **prod（main 用）** プロジェクトの ref（`supabase link --project-ref` に渡す） |
 | `SUPABASE_DB_PASSWORD` | **prod（main 用）** リモート DB のパスワード（`supabase db push` 用） |
 | `SUPABASE_PROJECT_ID_DEV` | **dev（develop 用）** プロジェクトの ref |

--- a/README.md
+++ b/README.md
@@ -138,19 +138,25 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 `develop` / `main` に push され、`supabase/migrations/**` に変更が含まれる場合、GitHub Actions（`.github/workflows/migrate.yml`）が `supabase db push` でリモート Supabase へ未適用のマイグレーションを自動適用する。
 
-- preview / production は同一 Supabase プロジェクトを共用しているため、適用先は1つ（develop / main どちらの push でも同じプロジェクトに適用される）。
+- **preview（develop）と production（main）は別々の Supabase プロジェクトに分離している**。`migrate.yml` は `github.ref_name` に応じて適用先を切り替える（`develop` → dev プロジェクト、`main` → prod プロジェクト）。これにより、`develop` への破壊的マイグレーションが本番 DB に直撃する事故と、preview のテストデータ・テストユーザー（`auth.users`）が本番に混入する事故を防ぐ。
 - `supabase db push` は `supabase_migrations.schema_migrations` を見て未適用分のみを適用するため冪等。マイグレーション変更が無い push ではワークフロー自体が起動しない（paths フィルタ）。
 - 適用に失敗するとジョブが fail する。
-- **`supabase/config.toml`（認証メールテンプレート・`enable_confirmations` 等）は `supabase db push` の対象外**。このワークフローでは反映されないため、config.toml を変更した場合は別途リモートへ反映する必要がある（誤って「自動反映される」と誤認しないよう、トリガーの paths からも `config.toml` を除外している）。
+- **`supabase/config.toml`（認証メールテンプレート・`enable_confirmations` 等）は `supabase db push` の対象外**。このワークフローでは反映されないため、config.toml を変更した場合は別途リモートへ反映する必要がある（誤って「自動反映される」と誤認しないよう、トリガーの paths からも `config.toml` を除外している）。プロジェクトを分離しているため、dev / prod の**両プロジェクト**へ手動反映が必要になる点に注意。
 - **`deploy.yml`（Vercel デプロイ）と `migrate.yml` は実行順序が保証されず並列で走る**。スキーマ追加に依存するアプリ変更を同一 push に含めると、マイグレーション適用前にデプロイが先行して実行時エラーになり得る。スキーマ変更とそれに依存するアプリ変更は、マイグレーションを先行 push してから（または別 PR で先にマージしてから）アプリ変更を入れるのが安全。
 
 **必要な GitHub Secrets**（事前に登録すること。未登録だと自動適用が動かない）:
 
 | Secret 名 | 用途 |
 |-----------|------|
-| `SUPABASE_ACCESS_TOKEN` | Supabase CLI のアクセストークン（`supabase link` 用）。ダッシュボード → Account → Access Tokens で発行 |
-| `SUPABASE_DB_PASSWORD` | リモート DB のパスワード（`supabase db push` 用） |
-| `SUPABASE_PROJECT_ID` | リモートプロジェクトの ref（`supabase link --project-ref` に渡す） |
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI のアクセストークン（`supabase link` 用）。ダッシュボード → Account → Access Tokens で発行。dev / prod 共通（同一組織なら1つで足りる） |
+| `SUPABASE_PROJECT_ID` | **prod（main 用）** プロジェクトの ref（`supabase link --project-ref` に渡す） |
+| `SUPABASE_DB_PASSWORD` | **prod（main 用）** リモート DB のパスワード（`supabase db push` 用） |
+| `SUPABASE_PROJECT_ID_DEV` | **dev（develop 用）** プロジェクトの ref |
+| `SUPABASE_DB_PASSWORD_DEV` | **dev（develop 用）** リモート DB のパスワード |
+
+> `develop` push 時は `*_DEV` Secret、`main` push 時は無印（prod 用）Secret が参照される。push したブランチ側の Secret が未登録だと、`Resolve target project by branch` ステップで「どの Secret が足りないか」を明示して fail する。
+
+> **接続文字列の注意**: dev プロジェクトの `DATABASE_URL` / `DIRECT_URL` は Session pooler を使う（過去に Pooler ホストが `aws-0` → 正しくは `aws-1` のズレで `tenant not found` が起きた経緯がある）。
 
 > 過去に、この自動適用が存在せずリモート DB へマイグレーションが一切適用されていなかったため、プロフィール画像アップロード時にバケットが無く「画像のアップロードに失敗しました」が発生した経緯がある（Issue #313）。この仕組みはその再発防止のためのもの。
 
@@ -191,8 +197,9 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 1. **Supabase ダッシュボード → Authentication → Providers → Email**
    - "Confirm email" が ON になっていること（OFF だと確認メールが送られない）。
 2. **Supabase ダッシュボード → Authentication → URL Configuration → Redirect URLs**
-   - local / preview / production の各オリジンの `/auth/callback` が許可されていること。
-   - Vercel Preview はワイルドカード（例: `https://*.vercel.app/auth/callback`）で登録する。
+   - **preview（develop）と production（main）は別 Supabase プロジェクトに分離しているため、登録先プロジェクトを取り違えないこと**。preview のオリジンは dev プロジェクト、production のオリジンは prod プロジェクトに登録する。
+   - dev プロジェクト: preview オリジン（Vercel Preview はワイルドカード `https://*.vercel.app/auth/callback`。固定 URL の `https://beer-salon-develop.vercel.app/auth/callback` 等）＋ローカル（`http://127.0.0.1:3000/auth/callback` 等）の `/auth/callback` を許可する。
+   - prod プロジェクト: production オリジン（`https://beer-salon.vercel.app/auth/callback` 等）の `/auth/callback` を許可する。
    - 許可外オリジンへのリダイレクトはブロックされ、メール内リンクが無効化される。
 3. **Supabase ダッシュボード → Project Settings → Authentication → SMTP**
    - 無料枠のデフォルト SMTP は送信レート・到達率が低い。独自 SMTP（SendGrid 等）の設定を推奨。


### PR DESCRIPTION
## 概要

preview（`develop`）と production（`main`）が同一 Supabase プロジェクトを共用していた構造を、**別プロジェクトへ分離**するための CI 側の対応（案B）。`migrate.yml` が `github.ref_name` に応じて適用先を切り替えるようにした。

Closes #342

## 背景（なぜ必要か）

共用構成には運用ルールで塞げない構造リスクがあった。

- **破壊的マイグレーションが本番直撃**: `develop` への DDL push を `migrate.yml` が本番 DB にも適用していた。
- **認証ユーザー混在（最重要）**: preview でサインアップしたテストユーザー（`auth.users`）が本番実ユーザーと同居。管理画面のテストアカウントで本番店舗データを操作できてしまう。

## 変更内容

### `.github/workflows/migrate.yml`
- `Resolve target project by branch` ステップを新設。`github.ref_name` に応じて適用先を選択する。
  - `main` → prod（`SUPABASE_PROJECT_ID` / `SUPABASE_DB_PASSWORD`）
  - `develop` → dev（`SUPABASE_PROJECT_ID_DEV` / `SUPABASE_DB_PASSWORD_DEV`）
- push したブランチ側の Secret が未登録の場合、どの Secret が足りないかを明示して fail させる（従来の `Check required secrets` を分岐対応に置き換え）。
- `db_password` は `::add-mask::` でログマスクした上で後続ステップに渡す。
- `link` / `db push` は選択した project_ref / password を使う。冪等性（`schema_migrations` 参照）は不変。

### `README.md`
- 「DB マイグレーションの自動適用」を分離構成に更新。
- 必要 GitHub Secrets 表に `_DEV` 系を追記。
- Redirect URLs は preview→dev / production→prod に登録先が分かれる旨を明記。
- dev の接続文字列は Session pooler（`aws-1` ホスト）を使う注意書きを追加。

## Secrets 命名方針（確認済み）

prod は現状名（`SUPABASE_PROJECT_ID` / `SUPABASE_DB_PASSWORD`）を維持し、dev 用に `_DEV` サフィックスを追加する方式。既存 Secret のリネームは不要。

## このPRに含まれない外部作業（ユーザー実施）

コードで完結しない以下はリポジトリ外の手動作業のため本PRに含まない。**このワークフローが正しく動くには、マージ前に少なくとも `SUPABASE_PROJECT_ID_DEV` / `SUPABASE_DB_PASSWORD_DEV` の登録が必要**。

- [ ] dev 用 Supabase プロジェクト新設 + 既存マイグレーション全適用 + seed/マスタ投入 + Auth 設定（Redirect URLs・メールテンプレ）の手動反映
- [ ] Vercel の Preview スコープ環境変数を dev プロジェクトの値へ差し替え（web / admin 両方）
- [ ] GitHub Secrets に `SUPABASE_PROJECT_ID_DEV` / `SUPABASE_DB_PASSWORD_DEV` を登録

## 別Issueに切り出す作業（確認済み）

- 本番 prod のクリーンアップ（共用期間に混入したテストデータ・テスト `auth.users` の削除）は破壊的・不可逆でリスクプロファイルが異なるため、別 Issue に切り出す。

## テストについて

本変更は GitHub Actions のワークフロー YAML と README のみで、アプリのソースコード（`src/`）・スキーマ・ロジックに変更が無い。UT / E2E で検証できる対象を持たないため追加していない（testing.md の「機能追加・バグ修正時に UT/E2E 追加」はアプリ機能を対象としており、CI 設定変更は対象外）。

- YAML 構文は `js-yaml` でパース検証済み（ステップ構成が意図通りであることを確認）。
- 変更2ファイルは Biome の対象外（`Checked 0 files`）で format/lint に影響しない。
- 実挙動の最終検証は、Secrets 登録後に `develop` / `main` それぞれへ migration を push し、GitHub Actions ログと両プロジェクトの `schema_migrations` 差分で確認する（受入条件どおり）。
