### PR TITLE
refactor: トップページのマップで geolocation を一本化する (#355)

### DIFF
--- a/apps/web/src/components/map/google-map.tsx
+++ b/apps/web/src/components/map/google-map.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import type { BarSummary } from "@/components/bar/bar-summary";
 import { CITY_COORDINATES } from "@/lib/constants/city-coordinates";
 import { type BarPin, toBarPins } from "@/lib/map/bar-pins";
+import { type LatLng, requestUserLocation } from "@/lib/map/user-location";
 
 interface GoogleMapProps {
 	city?: string;
@@ -18,31 +19,14 @@ interface GoogleMapProps {
 	defaultZoom?: number;
 }
 
-function MapContent({ pins }: { pins: BarPin[] }) {
+function MapContent({
+	pins,
+	userLocation,
+}: {
+	pins: BarPin[];
+	userLocation: LatLng | null;
+}) {
 	const [selectedPinId, setSelectedPinId] = useState<string | null>(null);
-	const [userLocation, setUserLocation] = useState<{
-		lat: number;
-		lng: number;
-	} | null>(null);
-	const hasSetUserLocation = useRef(false);
-
-	useEffect(() => {
-		if (!hasSetUserLocation.current && navigator.geolocation) {
-			navigator.geolocation.getCurrentPosition(
-				(position) => {
-					setUserLocation({
-						lat: position.coords.latitude,
-						lng: position.coords.longitude,
-					});
-					hasSetUserLocation.current = true;
-				},
-				(error) => {
-					console.warn("位置情報の取得に失敗しました:", error);
-					hasSetUserLocation.current = true;
-				},
-			);
-		}
-	}, []);
 
 	const selectedPin = pins.find((pin) => pin.id === selectedPinId) ?? null;
 
@@ -87,32 +71,24 @@ export function GoogleMap({ city, bars, defaultZoom = 12 }: GoogleMapProps) {
 		lat: 34.9756,
 		lng: 138.3833,
 	});
-	const [userLocation, setUserLocation] = useState<{
-		lat: number;
-		lng: number;
-	} | null>(null);
+	const [userLocation, setUserLocation] = useState<LatLng | null>(null);
 	const hasSetUserLocation = useRef(false);
 
 	useEffect(() => {
-		if (!hasSetUserLocation.current && navigator.geolocation) {
-			navigator.geolocation.getCurrentPosition(
-				(position) => {
-					const newCenter = {
-						lat: position.coords.latitude,
-						lng: position.coords.longitude,
-					};
-					setUserLocation(newCenter);
-					if (!city) {
-						setCenter(newCenter);
-					}
-					hasSetUserLocation.current = true;
-				},
-				(error) => {
-					console.warn("位置情報の取得に失敗しました:", error);
-					hasSetUserLocation.current = true;
-				},
-			);
-		}
+		if (hasSetUserLocation.current) return;
+		requestUserLocation(
+			navigator.geolocation,
+			(location) => {
+				setUserLocation(location);
+				if (!city) {
+					setCenter(location);
+				}
+				hasSetUserLocation.current = true;
+			},
+			() => {
+				hasSetUserLocation.current = true;
+			},
+		);
 	}, [city]);
 
 	useEffect(() => {
@@ -153,7 +129,7 @@ export function GoogleMap({ city, bars, defaultZoom = 12 }: GoogleMapProps) {
 					gestureHandling="greedy"
 					disableDefaultUI={false}
 				>
-					<MapContent pins={pins} />
+					<MapContent pins={pins} userLocation={userLocation} />
 				</GoogleMapComponent>
 			</APIProvider>
 		</div>

--- a/apps/web/src/lib/map/user-location.test.ts
+++ b/apps/web/src/lib/map/user-location.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { requestUserLocation } from "./user-location";
+
+function makeGeolocation(
+	behavior: (success: PositionCallback, error: PositionErrorCallback) => void,
+): Geolocation {
+	return {
+		getCurrentPosition: vi.fn(behavior),
+		watchPosition: vi.fn(),
+		clearWatch: vi.fn(),
+	} as unknown as Geolocation;
+}
+
+describe("requestUserLocation", () => {
+	it("geolocation が undefined のときは何もしない（getCurrentPosition を呼ばない）", () => {
+		const onSuccess = vi.fn();
+		const onError = vi.fn();
+
+		requestUserLocation(undefined, onSuccess, onError);
+
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("getCurrentPosition を1回だけ呼び、取得座標を onSuccess に渡す", () => {
+		const geolocation = makeGeolocation((success) => {
+			success({
+				coords: { latitude: 35.6812, longitude: 139.7671 },
+			} as GeolocationPosition);
+		});
+		const onSuccess = vi.fn();
+
+		requestUserLocation(geolocation, onSuccess);
+
+		expect(geolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+		expect(onSuccess).toHaveBeenCalledWith({ lat: 35.6812, lng: 139.7671 });
+	});
+
+	it("取得失敗時は onError を呼び、onSuccess は呼ばない", () => {
+		const geolocationError = {
+			code: 1,
+			message: "denied",
+		} as GeolocationPositionError;
+		const geolocation = makeGeolocation((_success, error) => {
+			error(geolocationError);
+		});
+		const onSuccess = vi.fn();
+		const onError = vi.fn();
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		requestUserLocation(geolocation, onSuccess, onError);
+
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onError).toHaveBeenCalledWith(geolocationError);
+		warnSpy.mockRestore();
+	});
+
+	it("onError 省略時でも取得失敗でクラッシュしない", () => {
+		const geolocation = makeGeolocation((_success, error) => {
+			error({ code: 1, message: "denied" } as GeolocationPositionError);
+		});
+		const onSuccess = vi.fn();
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		expect(() => requestUserLocation(geolocation, onSuccess)).not.toThrow();
+		expect(onSuccess).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+});

--- a/apps/web/src/lib/map/user-location.ts
+++ b/apps/web/src/lib/map/user-location.ts
@@ -1,0 +1,27 @@
+export interface LatLng {
+	lat: number;
+	lng: number;
+}
+
+// Why not: GoogleMap（親）と MapContent（子）で navigator.geolocation を二重取得していたため、
+// 取得ロジックをこの純粋関数に集約し、親から1度だけ呼ぶ。UT で「1回だけ呼ばれる」ことを
+// 検証できるよう、React に依存しない形（geolocation を引数で受け取る）で切り出す。
+export function requestUserLocation(
+	geolocation: Geolocation | undefined,
+	onSuccess: (location: LatLng) => void,
+	onError?: (error: GeolocationPositionError) => void,
+): void {
+	if (!geolocation) return;
+	geolocation.getCurrentPosition(
+		(position) => {
+			onSuccess({
+				lat: position.coords.latitude,
+				lng: position.coords.longitude,
+			});
+		},
+		(error) => {
+			console.warn("位置情報の取得に失敗しました:", error);
+			onError?.(error);
+		},
+	);
+}


### PR DESCRIPTION
## 概要

Closes #355

トップページのマップコンポーネント `apps/web/src/components/map/google-map.tsx` で、外側の `GoogleMap`（親）と内側の `MapContent`（子）が**それぞれ独立に** `navigator.geolocation.getCurrentPosition` を呼んでおり、位置情報を常に2回取得しに行く構造になっていた。これを親 `GoogleMap` の1箇所に一本化する。挙動は変えない純粋なリファクタリング。

## 変更内容

- 位置情報取得ロジックを `apps/web/src/lib/map/user-location.ts` の純粋関数 `requestUserLocation(geolocation, onSuccess, onError)` に切り出した。
  - `navigator` に直接依存せず `Geolocation` を引数で受け取る形にし、UT で「1回だけ呼ばれる／座標が渡る」を検証できるようにした。
- 親 `GoogleMap` で `requestUserLocation` を1回だけ呼び、取得した現在地を `userLocation` state に保持。`MapContent` には `userLocation` を **props で渡す**。
- 子 `MapContent` から自前の `userLocation` state・`hasSetUserLocation` ref・geolocation 取得の `useEffect` を削除し、渡された `userLocation` で現在地マーカーを描画するだけにした。

### getCurrentPosition の集約（before → after）

- **before**: 2箇所（`MapContent` と `GoogleMap` がそれぞれ呼ぶ）
- **after**: 1箇所（`user-location.ts` 内の `requestUserLocation` のみ。呼び出し元は親 `GoogleMap` の1回）

## 挙動を維持するために工夫した点

- 現在地マーカーの表示条件（`userLocation` が非 null のとき）は不変。従来子側の state で持っていた現在地を、親が解決して props で降ろす形に移すだけにした。
- マップ中心の初期化（現在地取得時、`city` 未選択なら現在地へ寄せる）・`city` 選択時の `CITY_COORDINATES` への中心移動・`hasSetUserLocation` による2回目以降の上書きガードは、親側にそのまま残した（もともと親が担っていた責務のため副作用の移動はしていない）。
- 親は元々マウント時に geolocation を呼んでおり、子は「マップ描画後」に呼んでいた。一本化後は親の1回のみだが、現在地は state 更新→再レンダリングで `MapContent` に反映されるため、現在地マーカーの見え方は従来どおり。

## テスト

### UT（追加）

- `apps/web/src/lib/map/user-location.test.ts` を追加。geolocation はブラウザ API のため `vi.fn` でモックし、以下を検証:
  - `getCurrentPosition` が **1回だけ** 呼ばれ、取得座標が `onSuccess` に渡る
  - `geolocation` が undefined のとき何もしない
  - 取得失敗時に `onError` を呼び `onSuccess` を呼ばない／`onError` 省略時もクラッシュしない
- `pnpm exec vitest run`（web）: **34 files / 365 tests passed**。

> @vis.gl/react-google-maps のコンポーネント自体は jsdom で描画が難しいため、現在地取得ロジックを純粋関数に切り出してそれを UT で担保する方針にした（既存の `bar-pins.test.ts` と同じ純粋ロジックテストの流儀）。

### E2E について

本プロジェクトは `docs/e2e.md` の方針で E2E をスモーク7本（web5/admin2）に限定しているため、**新しい E2E spec は追加しない**。受入条件「既存の E2E（bar-search）が緑のまま」は、既存の `apps/web/e2e/bar-search.spec.ts` が壊れないことで担保される（内部リファクタで画面挙動は不変）。

## 品質チェック

- format（Biome）: OK
- lint（Biome）: OK（No fixes applied）
- typecheck（tsc --noEmit）: OK

## 設計ドキュメント

内部リファクタで画面挙動・ルーティング・DB は変わらないため、`routing.md` / `wireframe.md` / `database.md` / `README.md` の更新は不要。

## スコープ外（厳守）

- マップのピン表示ロジック（#344）の変更なし
- fitBounds 等の再センタリング（#356）は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)