### PR TITLE
fix: 店舗更新APIの子データ同期（支払い方法・営業時間）をRPCで原子化

### DIFF
--- a/apps/admin/src/__tests__/bar-payment-methods-api.test.ts
+++ b/apps/admin/src/__tests__/bar-payment-methods-api.test.ts
@@ -17,19 +17,27 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 // URL バリデータは本テストの対象外なので常に valid を返すモックにし、
-// 子データ同期ロジックの検証に集中する
-vi.mock("@/lib/validators", () => ({
-	validateWebsiteUrl: () => ({ isValid: true }),
-	validateInstagramUrl: () => ({ isValid: true }),
-	validateXUrl: () => ({ isValid: true }),
-	validateFacebookUrl: () => ({ isValid: true }),
-	validateLineUrl: () => ({ isValid: true }),
-	validateCoordinates: () => ({
-		isValid: true,
-		latitude: null,
-		longitude: null,
-	}),
-}));
+// 子データ同期ロジックの検証に集中する。
+// 営業時間の要素バリデーション（validateOpeningHours）は検証対象そのものなので実装を使う。
+vi.mock("@/lib/validators", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/validators")>(
+			"@/lib/validators",
+		);
+	return {
+		validateWebsiteUrl: () => ({ isValid: true }),
+		validateInstagramUrl: () => ({ isValid: true }),
+		validateXUrl: () => ({ isValid: true }),
+		validateFacebookUrl: () => ({ isValid: true }),
+		validateLineUrl: () => ({ isValid: true }),
+		validateCoordinates: () => ({
+			isValid: true,
+			latitude: null,
+			longitude: null,
+		}),
+		validateOpeningHours: actual.validateOpeningHours,
+	};
+});
 
 import type { NextRequest } from "next/server";
 import { PUT } from "@/app/api/bars/[barId]/route";
@@ -300,6 +308,58 @@ describe("PUT /api/bars/[barId] 営業時間同期", () => {
 			createMockRequest({
 				name: "テストバー",
 				opening_hours: "invalid",
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_opening_hours",
+			expect.anything(),
+		);
+	});
+
+	it("day_of_week が範囲外（7）の場合は 400 を返し RPC を呼ばない", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 7,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_opening_hours",
+			expect.anything(),
+		);
+	});
+
+	it("時刻が不正形式（25:00）の場合は 400 を返し RPC を呼ばない", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "25:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
 			}),
 			{ params: Promise.resolve({ barId: "5" }) },
 		);

--- a/apps/admin/src/__tests__/bar-payment-methods-api.test.ts
+++ b/apps/admin/src/__tests__/bar-payment-methods-api.test.ts
@@ -8,14 +8,16 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 const mockSupabaseFrom = vi.fn();
+const mockSupabaseRpc = vi.fn();
 vi.mock("@/lib/supabase", () => ({
 	supabaseAdmin: {
 		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+		rpc: (...args: unknown[]) => mockSupabaseRpc(...args),
 	},
 }));
 
 // URL バリデータは本テストの対象外なので常に valid を返すモックにし、
-// 支払い方法同期ロジックの検証に集中する
+// 子データ同期ロジックの検証に集中する
 vi.mock("@/lib/validators", () => ({
 	validateWebsiteUrl: () => ({ isValid: true }),
 	validateInstagramUrl: () => ({ isValid: true }),
@@ -40,10 +42,10 @@ function createMockRequest(body: unknown): NextRequest {
 }
 
 /**
- * bars PUT は複数テーブルへ順番に .from() を呼ぶ。
- * テーブル名ごとにモックチェーンを差し替え、支払い方法の delete / insert 呼び出しを観測する。
+ * bars PUT は bars テーブルを update した後、子データ（支払い方法・営業時間）を
+ * sync RPC で原子的に同期する。RPC はテーブル名ではなく関数名で観測する。
  */
-function setupSupabaseMocks(overrides?: { paymentInsertError?: unknown }) {
+function setupSupabaseMocks(overrides?: { rpcError?: unknown }) {
 	const barSingle = vi
 		.fn()
 		.mockResolvedValue({ data: { id: 1, name: "テストバー" }, error: null });
@@ -51,30 +53,12 @@ function setupSupabaseMocks(overrides?: { paymentInsertError?: unknown }) {
 	const barEq = vi.fn().mockReturnValue({ select: barSelect });
 	const barUpdate = vi.fn().mockReturnValue({ eq: barEq });
 
-	const paymentDeleteEq = vi.fn().mockResolvedValue({ error: null });
-	const paymentDelete = vi.fn().mockReturnValue({ eq: paymentDeleteEq });
-	const paymentInsert = vi
-		.fn()
-		.mockResolvedValue({ error: overrides?.paymentInsertError ?? null });
-
-	const openingDeleteEq = vi.fn().mockResolvedValue({ error: null });
-	const openingDelete = vi.fn().mockReturnValue({ eq: openingDeleteEq });
-	const openingInsert = vi.fn().mockResolvedValue({ error: null });
-
 	mockSupabaseFrom.mockImplementation((table: string) => {
 		if (table === "bars") return { update: barUpdate };
-		if (table === "bar_payment_methods")
-			return { delete: paymentDelete, insert: paymentInsert };
-		if (table === "bar_opening_hours")
-			return { delete: openingDelete, insert: openingInsert };
 		throw new Error(`unexpected table: ${table}`);
 	});
 
-	return {
-		paymentDelete,
-		paymentDeleteEq,
-		paymentInsert,
-	};
+	mockSupabaseRpc.mockResolvedValue({ error: overrides?.rpcError ?? null });
 }
 
 describe("PUT /api/bars/[barId] 支払い方法同期", () => {
@@ -88,9 +72,8 @@ describe("PUT /api/bars/[barId] 支払い方法同期", () => {
 		mockCanAccessBar.mockReturnValue(true);
 	});
 
-	it("選択した支払い方法を bar_id で全削除してから再登録する", async () => {
-		const { paymentDelete, paymentDeleteEq, paymentInsert } =
-			setupSupabaseMocks();
+	it("選択した支払い方法を sync RPC に委譲する（DELETE→INSERT を原子化）", async () => {
+		setupSupabaseMocks();
 
 		const response = await PUT(
 			createMockRequest({
@@ -101,19 +84,34 @@ describe("PUT /api/bars/[barId] 支払い方法同期", () => {
 		);
 
 		expect(response.status).toBe(200);
-		// 既存分を bar_id で全削除
-		expect(paymentDelete).toHaveBeenCalledTimes(1);
-		expect(paymentDeleteEq).toHaveBeenCalledWith("bar_id", "5");
-		// 選択分を再 INSERT（重複なし・UNIQUE制約 bar_id+payment_method_id を守る形）
-		expect(paymentInsert).toHaveBeenCalledWith([
-			{ bar_id: 5, payment_method_id: 1 },
-			{ bar_id: 5, payment_method_id: 3 },
-		]);
+		// DELETE 単独クエリ（.from("bar_payment_methods")）は発行せず、RPC に一本化する
+		expect(mockSupabaseFrom).not.toHaveBeenCalledWith("bar_payment_methods");
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_payment_methods", {
+			p_bar_id: 5,
+			p_payment_method_ids: [1, 3],
+		});
 	});
 
-	it("空配列を渡すと全削除のみ行い INSERT しない", async () => {
-		const { paymentDelete, paymentDeleteEq, paymentInsert } =
-			setupSupabaseMocks();
+	it("重複した payment_method_id を除去して RPC に渡す", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				payment_method_ids: [1, 1, 3],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_payment_methods", {
+			p_bar_id: 5,
+			p_payment_method_ids: [1, 3],
+		});
+	});
+
+	it("空配列を渡すと RPC には空配列を渡す（全削除のみ）", async () => {
+		setupSupabaseMocks();
 
 		const response = await PUT(
 			createMockRequest({
@@ -124,30 +122,210 @@ describe("PUT /api/bars/[barId] 支払い方法同期", () => {
 		);
 
 		expect(response.status).toBe(200);
-		expect(paymentDelete).toHaveBeenCalledTimes(1);
-		expect(paymentDeleteEq).toHaveBeenCalledWith("bar_id", "5");
-		expect(paymentInsert).not.toHaveBeenCalled();
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_payment_methods", {
+			p_bar_id: 5,
+			p_payment_method_ids: [],
+		});
 	});
 
-	it("payment_method_ids を送らない場合は削除も INSERT も行わない", async () => {
-		const { paymentDelete, paymentInsert } = setupSupabaseMocks();
+	it("payment_method_ids を送らない場合は RPC を呼ばない", async () => {
+		setupSupabaseMocks();
 
 		const response = await PUT(createMockRequest({ name: "テストバー" }), {
 			params: Promise.resolve({ barId: "5" }),
 		});
 
 		expect(response.status).toBe(200);
-		expect(paymentDelete).not.toHaveBeenCalled();
-		expect(paymentInsert).not.toHaveBeenCalled();
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_payment_methods",
+			expect.anything(),
+		);
 	});
 
-	it("INSERT が失敗した場合は500を返す", async () => {
-		setupSupabaseMocks({ paymentInsertError: { message: "insert failed" } });
+	it("整数でない値を含む場合は 400 を返し RPC を呼ばない（既存データに触れない）", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				payment_method_ids: [1, "abc"],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_payment_methods",
+			expect.anything(),
+		);
+	});
+
+	it("配列でない値を渡すと 400 を返し RPC を呼ばない", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				payment_method_ids: "1,2,3",
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_payment_methods",
+			expect.anything(),
+		);
+	});
+
+	it("sync RPC が失敗した場合は 500 を返す", async () => {
+		setupSupabaseMocks({ rpcError: { message: "sync failed" } });
 
 		const response = await PUT(
 			createMockRequest({
 				name: "テストバー",
 				payment_method_ids: [2],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(500);
+	});
+});
+
+describe("PUT /api/bars/[barId] 営業時間同期", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	it("整形済み営業時間を sync RPC に委譲する（HH:MM:SS 付与・定休日反映）", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+					{
+						day_of_week: 1,
+						open_time: "",
+						close_time: "",
+						sort_order: 0,
+						is_closed: true,
+					},
+				],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockSupabaseFrom).not.toHaveBeenCalledWith("bar_opening_hours");
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_opening_hours", {
+			p_bar_id: 5,
+			p_opening_hours: [
+				{
+					day_of_week: 0,
+					open_time: "17:00:00",
+					close_time: "23:00:00",
+					sort_order: 0,
+					is_closed: false,
+				},
+				{
+					day_of_week: 1,
+					open_time: "00:00:00",
+					close_time: "00:00:00",
+					sort_order: 0,
+					is_closed: true,
+				},
+			],
+		});
+	});
+
+	it("時刻未入力かつ非定休日の行は除外して RPC に渡す", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "",
+						close_time: "",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_opening_hours", {
+			p_bar_id: 5,
+			p_opening_hours: [],
+		});
+	});
+
+	it("opening_hours を送らない場合は RPC を呼ばない", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(createMockRequest({ name: "テストバー" }), {
+			params: Promise.resolve({ barId: "5" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_opening_hours",
+			expect.anything(),
+		);
+	});
+
+	it("配列でない値を渡すと 400 を返し RPC を呼ばない", async () => {
+		setupSupabaseMocks();
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: "invalid",
+			}),
+			{ params: Promise.resolve({ barId: "5" }) },
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseRpc).not.toHaveBeenCalledWith(
+			"sync_bar_opening_hours",
+			expect.anything(),
+		);
+	});
+
+	it("sync RPC が失敗した場合は 500 を返す", async () => {
+		setupSupabaseMocks({ rpcError: { message: "sync failed" } });
+
+		const response = await PUT(
+			createMockRequest({
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
 			}),
 			{ params: Promise.resolve({ barId: "5" }) },
 		);

--- a/apps/admin/src/__tests__/bars-api-post.test.ts
+++ b/apps/admin/src/__tests__/bars-api-post.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+vi.mock("@/lib/auth", () => ({
+	getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+	hashPassword: () => Promise.resolve("hashed-password"),
+}));
+
+const mockSupabaseFrom = vi.fn();
+const mockSupabaseRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+		rpc: (...args: unknown[]) => mockSupabaseRpc(...args),
+	},
+}));
+
+// URL バリデータは本テストの対象外なので常に valid を返すモックにする。
+// 営業時間の要素バリデーション（validateOpeningHours）は検証対象そのものなので実装を使う。
+vi.mock("@/lib/validators", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/validators")>(
+			"@/lib/validators",
+		);
+	return {
+		validateWebsiteUrl: () => ({ isValid: true }),
+		validateInstagramUrl: () => ({ isValid: true }),
+		validateXUrl: () => ({ isValid: true }),
+		validateFacebookUrl: () => ({ isValid: true }),
+		validateLineUrl: () => ({ isValid: true }),
+		validateCoordinates: () => ({
+			isValid: true,
+			latitude: null,
+			longitude: null,
+		}),
+		validateOpeningHours: actual.validateOpeningHours,
+	};
+});
+
+vi.mock("@/lib/shizuoka-cities", () => ({
+	SHIZUOKA_PREFECTURE: "静岡県",
+}));
+
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/bars/route";
+
+function createMockRequest(body: unknown): NextRequest {
+	return {
+		json: () => Promise.resolve(body),
+		// biome-ignore lint/suspicious/noExplicitAny: POST が参照する json のみを持つ最小モック
+	} as any;
+}
+
+/**
+ * POST /api/bars は bars を作成し、admin_users を作成した後、
+ * 営業時間を sync RPC で登録する。
+ * - barInsert: bars テーブルへの insert（作成された bar を返す）
+ * - adminUsersInsert: admin_users への insert
+ * - bar_manage_id 重複チェック: admin_users.select().eq().maybeSingle()
+ */
+function setupSupabaseMocks(overrides?: {
+	rpcError?: unknown;
+	barInsertError?: unknown;
+}) {
+	const barSingle = vi.fn().mockResolvedValue({
+		data: overrides?.barInsertError ? null : { id: 42, name: "テストバー" },
+		error: overrides?.barInsertError ?? null,
+	});
+	const barSelect = vi.fn().mockReturnValue({ single: barSingle });
+	const barInsert = vi.fn().mockReturnValue({ select: barSelect });
+
+	const adminMaybeSingle = vi
+		.fn()
+		.mockResolvedValue({ data: null, error: null });
+	const adminEq = vi.fn().mockReturnValue({ maybeSingle: adminMaybeSingle });
+	const adminSelect = vi.fn().mockReturnValue({ eq: adminEq });
+	const adminInsert = vi.fn().mockResolvedValue({ error: null });
+
+	mockSupabaseFrom.mockImplementation((table: string) => {
+		if (table === "bars") return { insert: barInsert };
+		if (table === "admin_users")
+			return { select: adminSelect, insert: adminInsert };
+		throw new Error(`unexpected table: ${table}`);
+	});
+
+	mockSupabaseRpc.mockResolvedValue({ error: overrides?.rpcError ?? null });
+
+	return { barInsert, adminInsert };
+}
+
+const validPhase1 = {
+	bar_manage_id: "test-bar",
+	password: "password123",
+	contact_email: "owner@example.com",
+	contact_phone: "09012345678",
+};
+
+describe("POST /api/bars 営業時間同期", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+	});
+
+	it("営業時間 RPC が error を返した場合は 500 を返し、レスポンスに barId を含む", async () => {
+		setupSupabaseMocks({ rpcError: { message: "sync failed" } });
+
+		const response = await POST(
+			createMockRequest({
+				...validPhase1,
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+		);
+
+		expect(response.status).toBe(500);
+		const json = await response.json();
+		expect(json.barId).toBe(42);
+	});
+
+	it("営業時間が不正（day_of_week 範囲外）な場合は 400 を返し、bars の insert すら呼ばれない", async () => {
+		const { barInsert } = setupSupabaseMocks();
+
+		const response = await POST(
+			createMockRequest({
+				...validPhase1,
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 7,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockSupabaseFrom).not.toHaveBeenCalledWith("bars");
+		expect(barInsert).not.toHaveBeenCalled();
+		expect(mockSupabaseRpc).not.toHaveBeenCalled();
+	});
+
+	it("時刻が不正形式（25:00）な場合は 400 を返し、bars の insert すら呼ばれない", async () => {
+		const { barInsert } = setupSupabaseMocks();
+
+		const response = await POST(
+			createMockRequest({
+				...validPhase1,
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "25:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(barInsert).not.toHaveBeenCalled();
+		expect(mockSupabaseRpc).not.toHaveBeenCalled();
+	});
+
+	it("営業時間が正常な場合は 201 を返し、整形済みデータを RPC に委譲する", async () => {
+		setupSupabaseMocks();
+
+		const response = await POST(
+			createMockRequest({
+				...validPhase1,
+				name: "テストバー",
+				opening_hours: [
+					{
+						day_of_week: 0,
+						open_time: "17:00",
+						close_time: "23:00",
+						sort_order: 0,
+						is_closed: false,
+					},
+				],
+			}),
+		);
+
+		expect(response.status).toBe(201);
+		expect(mockSupabaseRpc).toHaveBeenCalledWith("sync_bar_opening_hours", {
+			p_bar_id: 42,
+			p_opening_hours: [
+				{
+					day_of_week: 0,
+					open_time: "17:00:00",
+					close_time: "23:00:00",
+					sort_order: 0,
+					is_closed: false,
+				},
+			],
+		});
+	});
+});

--- a/apps/admin/src/__tests__/validators.test.ts
+++ b/apps/admin/src/__tests__/validators.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { validateCoordinates, validateLineUrl } from "@/lib/validators";
+import {
+	validateCoordinates,
+	validateLineUrl,
+	validateOpeningHours,
+} from "@/lib/validators";
 
 describe("validateLineUrl", () => {
 	it("空文字列の場合はバリデーションを通過する", () => {
@@ -195,5 +199,141 @@ describe("validateCoordinates", () => {
 			expect(result.error).toContain("経度");
 			expect(result.error).toContain("数値");
 		}
+	});
+});
+
+describe("validateOpeningHours", () => {
+	it("正常な非定休日の行を通過する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 0,
+					open_time: "17:00",
+					close_time: "23:00",
+					sort_order: 0,
+					is_closed: false,
+				},
+			]),
+		).toEqual({ isValid: true });
+	});
+
+	it("定休日の行は時刻検証をスキップして通過する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 1,
+					open_time: "",
+					close_time: "",
+					sort_order: 0,
+					is_closed: true,
+				},
+			]),
+		).toEqual({ isValid: true });
+	});
+
+	it("時刻未入力かつ非定休日の行は時刻検証の対象外で通過する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 2,
+					open_time: "",
+					close_time: "",
+					sort_order: 0,
+					is_closed: false,
+				},
+			]),
+		).toEqual({ isValid: true });
+	});
+
+	it("day_of_week が範囲外（7）の場合は失敗する", () => {
+		const result = validateOpeningHours([
+			{
+				day_of_week: 7,
+				open_time: "17:00",
+				close_time: "23:00",
+				sort_order: 0,
+				is_closed: false,
+			},
+		]);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toBe("営業時間の指定が正しくありません");
+	});
+
+	it("day_of_week が整数でない場合は失敗する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 1.5,
+					open_time: "17:00",
+					close_time: "23:00",
+					sort_order: 0,
+					is_closed: false,
+				},
+			]).isValid,
+		).toBe(false);
+	});
+
+	it("sort_order が整数でない場合は失敗する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 0,
+					open_time: "17:00",
+					close_time: "23:00",
+					sort_order: 1.5,
+					is_closed: false,
+				},
+			]).isValid,
+		).toBe(false);
+	});
+
+	it("is_closed が boolean でない場合は失敗する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 0,
+					open_time: "17:00",
+					close_time: "23:00",
+					sort_order: 0,
+					is_closed: "false",
+				},
+			]).isValid,
+		).toBe(false);
+	});
+
+	it("open_time が不正形式（25:00）の場合は失敗する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 0,
+					open_time: "25:00",
+					close_time: "23:00",
+					sort_order: 0,
+					is_closed: false,
+				},
+			]).isValid,
+		).toBe(false);
+	});
+
+	it("close_time が不正形式（23:99）の場合は失敗する", () => {
+		expect(
+			validateOpeningHours([
+				{
+					day_of_week: 0,
+					open_time: "17:00",
+					close_time: "23:99",
+					sort_order: 0,
+					is_closed: false,
+				},
+			]).isValid,
+		).toBe(false);
+	});
+
+	it("要素がオブジェクトでない場合は失敗する", () => {
+		expect(validateOpeningHours(["invalid"]).isValid).toBe(false);
+	});
+
+	it("空配列は通過する", () => {
+		expect(validateOpeningHours([])).toEqual({ isValid: true });
 	});
 });

--- a/apps/admin/src/app/api/bars/[barId]/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/route.ts
@@ -258,79 +258,86 @@ export async function PUT(
 		}
 
 		if (payment_method_ids !== undefined) {
-			const { error: deleteError } = await supabaseAdmin
-				.from("bar_payment_methods")
-				.delete()
-				.eq("bar_id", barId);
-
-			if (deleteError) {
+			if (!Array.isArray(payment_method_ids)) {
+				return NextResponse.json(
+					{ error: "支払い方法の指定が正しくありません" },
+					{ status: 400 },
+				);
 			}
 
-			if (Array.isArray(payment_method_ids) && payment_method_ids.length > 0) {
-				const paymentMethodsData = payment_method_ids.map((pmId: string) => ({
-					bar_id: parseInt(barId, 10),
-					payment_method_id: parseInt(pmId, 10),
-				}));
-
-				const { error: insertError } = await supabaseAdmin
-					.from("bar_payment_methods")
-					.insert(paymentMethodsData);
-
-				if (insertError) {
+			const normalizedIds: number[] = [];
+			for (const pmId of payment_method_ids) {
+				const id = Number(pmId);
+				if (!Number.isInteger(id)) {
 					return NextResponse.json(
-						{ error: "支払い方法の更新に失敗しました" },
-						{ status: 500 },
+						{ error: "支払い方法の指定が正しくありません" },
+						{ status: 400 },
 					);
 				}
+				if (!normalizedIds.includes(id)) {
+					normalizedIds.push(id);
+				}
+			}
+
+			// DELETE→INSERT を1トランザクションで実行する RPC に委譲し、
+			// INSERT 失敗時に既存データが消えたまま残る事故を防ぐ
+			const { error: syncError } = await supabaseAdmin.rpc(
+				"sync_bar_payment_methods",
+				{
+					p_bar_id: parseInt(barId, 10),
+					p_payment_method_ids: normalizedIds,
+				},
+			);
+
+			if (syncError) {
+				return NextResponse.json(
+					{ error: "支払い方法の更新に失敗しました" },
+					{ status: 500 },
+				);
 			}
 		}
 
 		if (opening_hours !== undefined) {
-			const { error: deleteError } = await supabaseAdmin
-				.from("bar_opening_hours")
-				.delete()
-				.eq("bar_id", barId);
-
-			if (deleteError) {
+			if (!Array.isArray(opening_hours)) {
+				return NextResponse.json(
+					{ error: "営業時間の指定が正しくありません" },
+					{ status: 400 },
+				);
 			}
 
-			if (Array.isArray(opening_hours) && opening_hours.length > 0) {
-				const now = new Date().toISOString();
-				interface OpeningHourInput {
-					day_of_week: number;
-					open_time: string;
-					close_time: string;
-					sort_order: number;
-					is_closed: boolean;
-				}
-				const openingHoursData = opening_hours
-					.filter(
-						(oh: OpeningHourInput) =>
-							oh.is_closed || (oh.open_time && oh.close_time),
-					)
-					.map((oh: OpeningHourInput) => ({
-						bar_id: parseInt(barId, 10),
-						day_of_week: oh.day_of_week,
-						open_time: oh.is_closed ? "00:00:00" : `${oh.open_time}:00`,
-						close_time: oh.is_closed ? "00:00:00" : `${oh.close_time}:00`,
-						sort_order: oh.sort_order,
-						is_closed: oh.is_closed,
-						created_at: now,
-						updated_at: now,
-					}));
+			interface OpeningHourInput {
+				day_of_week: number;
+				open_time: string;
+				close_time: string;
+				sort_order: number;
+				is_closed: boolean;
+			}
+			const openingHoursData = opening_hours
+				.filter(
+					(oh: OpeningHourInput) =>
+						oh.is_closed || (oh.open_time && oh.close_time),
+				)
+				.map((oh: OpeningHourInput) => ({
+					day_of_week: oh.day_of_week,
+					open_time: oh.is_closed ? "00:00:00" : `${oh.open_time}:00`,
+					close_time: oh.is_closed ? "00:00:00" : `${oh.close_time}:00`,
+					sort_order: oh.sort_order,
+					is_closed: oh.is_closed,
+				}));
 
-				if (openingHoursData.length > 0) {
-					const { error: insertError } = await supabaseAdmin
-						.from("bar_opening_hours")
-						.insert(openingHoursData);
+			const { error: syncError } = await supabaseAdmin.rpc(
+				"sync_bar_opening_hours",
+				{
+					p_bar_id: parseInt(barId, 10),
+					p_opening_hours: openingHoursData,
+				},
+			);
 
-					if (insertError) {
-						return NextResponse.json(
-							{ error: "営業時間の更新に失敗しました" },
-							{ status: 500 },
-						);
-					}
-				}
+			if (syncError) {
+				return NextResponse.json(
+					{ error: "営業時間の更新に失敗しました" },
+					{ status: 500 },
+				);
 			}
 		}
 

--- a/apps/admin/src/app/api/bars/[barId]/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/route.ts
@@ -7,6 +7,7 @@ import {
 	validateFacebookUrl,
 	validateInstagramUrl,
 	validateLineUrl,
+	validateOpeningHours,
 	validateWebsiteUrl,
 	validateXUrl,
 } from "@/lib/validators";
@@ -301,6 +302,15 @@ export async function PUT(
 			if (!Array.isArray(opening_hours)) {
 				return NextResponse.json(
 					{ error: "営業時間の指定が正しくありません" },
+					{ status: 400 },
+				);
+			}
+
+			// 不正値のまま sync RPC を呼んで既存データを消す事故を防ぐため、整形前に要素を検証する
+			const openingHoursValidation = validateOpeningHours(opening_hours);
+			if (!openingHoursValidation.isValid) {
+				return NextResponse.json(
+					{ error: openingHoursValidation.error },
 					{ status: 400 },
 				);
 			}

--- a/apps/admin/src/app/api/bars/route.ts
+++ b/apps/admin/src/app/api/bars/route.ts
@@ -271,7 +271,7 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
-		// 営業時間を登録
+		// 営業時間を登録（PUT と同じ sync RPC に寄せ、書き込み口を一本化する）
 		if (Array.isArray(opening_hours) && opening_hours.length > 0) {
 			const openingHoursData = opening_hours
 				.filter(
@@ -286,19 +286,19 @@ export async function POST(request: NextRequest) {
 						sort_order: number;
 						is_closed: boolean;
 					}) => ({
-						bar_id: bar.id,
 						day_of_week: oh.day_of_week,
 						open_time: oh.is_closed ? "00:00:00" : `${oh.open_time}:00`,
 						close_time: oh.is_closed ? "00:00:00" : `${oh.close_time}:00`,
 						sort_order: oh.sort_order,
 						is_closed: oh.is_closed,
-						created_at: now,
-						updated_at: now,
 					}),
 				);
 
 			if (openingHoursData.length > 0) {
-				await supabaseAdmin.from("bar_opening_hours").insert(openingHoursData);
+				await supabaseAdmin.rpc("sync_bar_opening_hours", {
+					p_bar_id: bar.id,
+					p_opening_hours: openingHoursData,
+				});
 			}
 		}
 

--- a/apps/admin/src/app/api/bars/route.ts
+++ b/apps/admin/src/app/api/bars/route.ts
@@ -7,6 +7,7 @@ import {
 	validateFacebookUrl,
 	validateInstagramUrl,
 	validateLineUrl,
+	validateOpeningHours,
 	validateWebsiteUrl,
 	validateXUrl,
 } from "@/lib/validators";
@@ -212,6 +213,24 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
+		// 営業時間は店舗（bars）を作る前に検証する。作成後に 400 を返すと店舗だけ残るため。
+		if (opening_hours !== undefined) {
+			if (!Array.isArray(opening_hours)) {
+				return NextResponse.json(
+					{ error: "営業時間の指定が正しくありません" },
+					{ status: 400 },
+				);
+			}
+
+			const openingHoursValidation = validateOpeningHours(opening_hours);
+			if (!openingHoursValidation.isValid) {
+				return NextResponse.json(
+					{ error: openingHoursValidation.error },
+					{ status: 400 },
+				);
+			}
+		}
+
 		// バー作成
 		const now = new Date().toISOString();
 		const { data: bar, error: barError } = await supabaseAdmin
@@ -295,10 +314,28 @@ export async function POST(request: NextRequest) {
 				);
 
 			if (openingHoursData.length > 0) {
-				await supabaseAdmin.rpc("sync_bar_opening_hours", {
-					p_bar_id: bar.id,
-					p_opening_hours: openingHoursData,
-				});
+				// PUT 側と対称に RPC の error を拾う。握り潰すと営業時間の登録失敗が呼び出し側に伝わらないため。
+				// Why not「POST 全体の RPC 化（店舗作成含めた全体トランザクション化）」: 本 PR スコープ（子データ同期の原子化）外のため採らず、
+				// 既存データ消失防止に必要な RPC エラーの拾い上げのみ行う。
+				const { error: syncError } = await supabaseAdmin.rpc(
+					"sync_bar_opening_hours",
+					{
+						p_bar_id: bar.id,
+						p_opening_hours: openingHoursData,
+					},
+				);
+
+				if (syncError) {
+					// 店舗（bars）と admin_users は既に作成済み。作成済みの barId を返し、
+					// 「店舗は作成されたが営業時間の登録に失敗した」ことを呼び出し側へ伝える。
+					return NextResponse.json(
+						{
+							error: "店舗は作成されましたが営業時間の登録に失敗しました",
+							barId: bar.id,
+						},
+						{ status: 500 },
+					);
+				}
 			}
 		}
 

--- a/apps/admin/src/lib/validators.ts
+++ b/apps/admin/src/lib/validators.ts
@@ -149,6 +149,75 @@ export function resolveArticlePublishing(
 	return { isValid: true, status, published_at: scheduledAt.toISOString() };
 }
 
+const OPENING_HOUR_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * 営業時間配列（RPC 整形前の生入力）の各要素を検証する。
+ *
+ * `payment_method_ids` と同水準の入力バリデーションを営業時間にも設け、
+ * 不正値のまま sync RPC を呼んで既存データを消してしまう事故を防ぐ。
+ * 検証内容:
+ * - day_of_week: 0〜6 の整数
+ * - sort_order: 整数
+ * - is_closed: boolean
+ * - 時刻整形の対象となる行（非定休日かつ open_time/close_time が入っている行）は HH:MM 形式
+ *   Why not「全行の時刻を必須検証」: 定休日行や時刻未入力で除外される行は整形対象外（既存 filter と整合）のため、時刻検証もしない。
+ */
+export function validateOpeningHours(openingHours: unknown[]): {
+	isValid: boolean;
+	error?: string;
+} {
+	const error = "営業時間の指定が正しくありません";
+
+	for (const oh of openingHours) {
+		if (typeof oh !== "object" || oh === null) {
+			return { isValid: false, error };
+		}
+
+		const row = oh as {
+			day_of_week?: unknown;
+			open_time?: unknown;
+			close_time?: unknown;
+			sort_order?: unknown;
+			is_closed?: unknown;
+		};
+
+		if (typeof row.is_closed !== "boolean") {
+			return { isValid: false, error };
+		}
+
+		if (
+			typeof row.day_of_week !== "number" ||
+			!Number.isInteger(row.day_of_week) ||
+			row.day_of_week < 0 ||
+			row.day_of_week > 6
+		) {
+			return { isValid: false, error };
+		}
+
+		if (
+			typeof row.sort_order !== "number" ||
+			!Number.isInteger(row.sort_order)
+		) {
+			return { isValid: false, error };
+		}
+
+		// 時刻整形の対象となる行（非定休日かつ open_time/close_time が入っている行）のみ HH:MM 形式を検証する
+		if (row.is_closed !== true && row.open_time && row.close_time) {
+			if (
+				typeof row.open_time !== "string" ||
+				typeof row.close_time !== "string" ||
+				!OPENING_HOUR_TIME_PATTERN.test(row.open_time) ||
+				!OPENING_HOUR_TIME_PATTERN.test(row.close_time)
+			) {
+				return { isValid: false, error };
+			}
+		}
+	}
+
+	return { isValid: true };
+}
+
 export function validateWebsiteUrl(url: string | null | undefined): {
 	isValid: boolean;
 	error?: string;

--- a/database.md
+++ b/database.md
@@ -124,6 +124,8 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 
 **CASCADE削除**: 店舗削除時に関連する営業時間レコードも削除
 
+**書き込み（管理画面）**: 店舗登録（POST）・店舗更新（PUT）の営業時間は「当該 `bar_id` を全削除→整形済みレコードを再登録」で同期する。PostgREST（`supabaseAdmin`）は複数文を1トランザクションにまとめられないため、DELETE 成功後に INSERT が失敗すると営業時間が全消失したまま復元されない。これを防ぐため、DELETE+INSERT を単一トランザクション化する RPC `sync_bar_opening_hours(p_bar_id bigint, p_opening_hours jsonb)` に書き込みを一本化している（`open_time`/`close_time` への `:00` 付与・`is_closed` 反映などの整形は API 側で行い、整形済み jsonb 配列を RPC に渡す）。
+
 **使用例**:
 - 複数時間帯: 昼営業（11:00-14:00）+ 夜営業（17:00-23:00）を2レコードで表現
 - 定休日: `is_closed=true` のレコードで表現
@@ -568,6 +570,8 @@ UNIQUE制約: `country_id + name`
 **UNIQUE制約**: `bar_id + payment_method_id`
 
 **CASCADE削除**: 店舗削除時に関連する `bar_payment_methods` も削除される
+
+**書き込み（管理画面）**: 店舗編集（PUT）の支払い方法は「当該 `bar_id` を全削除→選択分を再登録」で同期する。営業時間と同様に PostgREST では DELETE+INSERT を1トランザクションにできないため、原子化した RPC `sync_bar_payment_methods(p_bar_id bigint, p_payment_method_ids bigint[])` に一本化している。INSERT 失敗時は DELETE ごとロールバックされ、既存の支払い方法が保持される。API 側で `payment_method_ids` の整数検証・重複除去を行い、RPC 内でも `DISTINCT` で UNIQUE 制約 `bar_id + payment_method_id` 違反を二重防御する。
 
 ---
 

--- a/supabase/migrations/20260702000000_bar_children_sync_rpc.sql
+++ b/supabase/migrations/20260702000000_bar_children_sync_rpc.sql
@@ -1,0 +1,64 @@
+-- 店舗の子データ（支払い方法・営業時間）を「全削除→再登録」で同期する RPC。
+-- PostgREST の複数文はトランザクション境界を持たないため、DELETE 成功後に INSERT が
+-- 失敗すると子データが全消失したまま復元されない。PL/pgSQL 関数は単一トランザクションで
+-- 実行され例外時に自動ロールバックされるため、DELETE と INSERT を関数内に閉じ込めて原子化する。
+
+-- 支払い方法の同期
+-- p_payment_method_ids は API 側で重複除去・整数検証済みを前提とするが、
+-- UNIQUE 制約 bar_id+payment_method_id 違反を関数内でも防ぐため DISTINCT で二重防御する。
+CREATE OR REPLACE FUNCTION sync_bar_payment_methods(
+  p_bar_id BIGINT,
+  p_payment_method_ids BIGINT[]
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  DELETE FROM bar_payment_methods WHERE bar_id = p_bar_id;
+
+  IF p_payment_method_ids IS NOT NULL AND array_length(p_payment_method_ids, 1) > 0 THEN
+    INSERT INTO bar_payment_methods (bar_id, payment_method_id)
+    SELECT p_bar_id, ids.payment_method_id
+    FROM (SELECT DISTINCT unnest(p_payment_method_ids) AS payment_method_id) AS ids;
+  END IF;
+END;
+$$;
+
+-- 営業時間の同期
+-- p_opening_hours は整形済み（open_time/close_time は HH:MM:SS、is_closed 反映済み）の
+-- jsonb 配列を前提とする。整形ロジックは API 側に残し、関数は書き込みの原子化のみを担う。
+CREATE OR REPLACE FUNCTION sync_bar_opening_hours(
+  p_bar_id BIGINT,
+  p_opening_hours JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  DELETE FROM bar_opening_hours WHERE bar_id = p_bar_id;
+
+  IF p_opening_hours IS NOT NULL AND jsonb_array_length(p_opening_hours) > 0 THEN
+    INSERT INTO bar_opening_hours (
+      bar_id, day_of_week, open_time, close_time, sort_order, is_closed
+    )
+    SELECT
+      p_bar_id,
+      (elem->>'day_of_week')::INTEGER,
+      (elem->>'open_time')::TIME,
+      (elem->>'close_time')::TIME,
+      (elem->>'sort_order')::INTEGER,
+      (elem->>'is_closed')::BOOLEAN
+    FROM jsonb_array_elements(p_opening_hours) AS elem;
+  END IF;
+END;
+$$;
+
+-- service_role には既存マイグレーション（20260419000001）の
+-- ALTER DEFAULT PRIVILEGES ... GRANT EXECUTE ON FUNCTIONS で自動付与されるが、
+-- 適用順序に依存せず明示的に付与しておく。
+GRANT EXECUTE ON FUNCTION sync_bar_payment_methods(BIGINT, BIGINT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION sync_bar_opening_hours(BIGINT, JSONB) TO service_role;


### PR DESCRIPTION
Closes #363

## 問題
管理画面の店舗更新API `PUT /api/bars/[barId]` で、`bar_payment_methods`（支払い方法）と `bar_opening_hours`（営業時間）の同期を「全 DELETE → 再 INSERT」で行っているが、PostgREST（`supabaseAdmin`）は複数文を1トランザクションにまとめられない。

- DELETE 成功後に INSERT が失敗すると子データが**全消失したまま復元されず** 500 が返る（データ消失）
- `if (deleteError) {}` の空ブロックで DELETE エラーを握り潰していた
- `payment_method_ids` の入力検証が無く、重複値で UNIQUE 制約違反・不正値で FK 違反を誘発しうる

## 修正方針
PostgREST では複数文トランザクションを張れないため、**Supabase RPC（PL/pgSQL 関数）で DELETE+INSERT を1トランザクション化**する正攻法を採用（差分同期案は原子性そのものを担保できないため不採用）。

## 変更内容
- **Migration** `20260702000000_bar_children_sync_rpc.sql`
  - `sync_bar_payment_methods(p_bar_id bigint, p_payment_method_ids bigint[])`
  - `sync_bar_opening_hours(p_bar_id bigint, p_opening_hours jsonb)`
  - いずれも関数内で `DELETE → INSERT` を実行。単一トランザクションのため INSERT 失敗時は DELETE ごと自動ロールバック
  - 支払い方法は `DISTINCT` で UNIQUE 制約 `bar_id + payment_method_id` を二重防御
- **API** `bars/[barId]/route.ts` PUT
  - 支払い方法・営業時間の DELETE/INSERT ブロックを RPC 呼び出しに置換（`deleteError` の握り潰しを解消）
  - `payment_method_ids` の整数配列検証・重複除去を追加（配列でない/非整数を含む場合は 400 を返し RPC を呼ばない＝既存データに触れない）
  - 営業時間の整形（`:00` 付与・`is_closed` 反映）は API 側に残し、整形済み配列を RPC に渡す
- **API** `bars/route.ts` POST — 営業時間 INSERT も同じ `sync_bar_opening_hours` RPC に寄せ、書き込み口を一本化
- **UT** `bar-payment-methods-api.test.ts` を RPC ベースに刷新（原子性・重複除去・バリデーション・営業時間同期を検証）
- **Docs** `database.md` の `bar_payment_methods` / `bar_opening_hours` に RPC 同期方針を追記

## 受入条件
- [x] `bar_payment_methods` の同期が原子的に行われ、INSERT 失敗時に既存データがロールバック（保持）される
- [x] `bar_opening_hours` の同期も同様に原子的に行われる
- [x] DELETE エラーを握り潰さず、失敗時は 500 で早期 return する（DELETE を RPC 内に移し、RPC エラーとして一括ハンドリング）
- [x] 存在しない `payment_method_id` / 重複値を PUT した場合に、既存データが消えないことを UT で検証
- [x] 入力バリデーション（整数配列検証・重複除去）を追加
- [x] 既存の店舗更新（正常系）が従来どおり動作する

## テスト
- **UT**: `pnpm --filter @beersalon/admin test` → 16 files / 138 tests 全パス（本 Issue 分は 12 tests）
- **DB 直検証**（ローカル Supabase で RPC を直接実行して確認）:
  - 正常同期 / 重複除去（`[3,3,4]`→`[3,4]`）/ 空配列で全削除
  - FK 違反（存在しない payment_method_id）時に既存 `[3,4]` が消えずロールバック
  - CHECK 違反（day_of_week=7）時に既存営業時間 2 件が消えずロールバック
- **E2E**: テストピラミッド原則により、原子性・ロールバックは DB 直検証＋UT で担保済みのため E2E コードは追加せず（正常系 UI ロジックも UT でカバー）

## 破壊的変更
- **DB マイグレーション追加**（RPC 関数 2 本）。`develop` push 時に `migrate.yml` が dev プロジェクトへ自動適用する。`deploy.yml` と並列実行のため、マイグレーション適用前にデプロイが先行すると RPC 未定義で 500 になり得る点に注意（本 PR 単独マージなら問題なし）
- ローカルで動作確認する場合は `supabase db push` 相当（本 PR のマイグレーションファイル）を適用してから admin devサーバーで検証すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)