### PR TITLE
feat: Claude Code Actions で @pr-review メンションによるPRレビューを追加 (#369)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -9,6 +9,11 @@
 # 二重起動を回避する。理解チェック用の claude.yml と、設計レビュー特化の本ファイルを
 # 権限・トリガーごと分離し、片方の変更が他方を壊さないようにする。
 #
+# 運用注意（逆方向の二重起動）: 1つのコメントに `@claude` と `@pr-review` を両方書くと、
+# claude.yml（`@claude` 一致）と本ファイル（`@pr-review` 一致）が両方起動し Actions 枠を
+# 二重消費する。claude.yml を無改変に保つため除外条件は入れていない（Issue #369 の
+# 「既存WFに差分がない」を満たすため）。両メンションの同時記載は避ける運用とする。
+#
 # Why-not: 認証は ANTHROPIC_API_KEY（従量課金）ではなく CLAUDE_CODE_OAUTH_TOKEN（サブスク連携）。
 # 既存 claude.yml / claude-code-review.yml と同じ登録済みトークンに揃え、Secrets を増やさない。
 name: Claude PR Review
@@ -53,9 +58,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Claude が PR の CI 結果を読めるようにする（pr-review のテスト観点で参照）
-          additional_permissions: |
-            actions: read
+          # Why-not: additional_permissions で actions: read を再指定しない。上の permissions
+          # ブロック（actions: read）で Claude は既に CI 結果を読めるため、additional_permissions
+          # 側の指定は冗長。二重指定を避けて権限の意図を1箇所に集約する。
 
           # ローカルの /pr-review スキルをそのまま起動する。PR番号はトリガー元イベントから解決する。
           prompt: '/pr-review ${{ github.event.issue.number || github.event.pull_request.number }}'

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,70 @@
+# ローカル自作の /pr-review スキル（system-architect による設計md整合特化のPRレビュー）を
+# GitHub Actions 上でも起動できるようにする。PR/コメントに `@pr-review` と書くと、
+# claude-code-action が `.claude/skills/pr-review` を実行し、レビュー結果をPRコメントに投稿する。
+#
+# Why-not: 既存 claude.yml（`@claude` 汎用メンション用）に相乗りさせない。claude.yml 冒頭の
+# 設計判断どおり「同一 `@claude` トリガーの二重起動」を避けるのが目的だが、本ファイルは
+# トリガー語を `@claude` を部分文字列として含まない `@pr-review` にすることで、
+# claude.yml の `contains(body, '@claude')` に一切マッチさせず、claude.yml を無改変のまま
+# 二重起動を回避する。理解チェック用の claude.yml と、設計レビュー特化の本ファイルを
+# 権限・トリガーごと分離し、片方の変更が他方を壊さないようにする。
+#
+# Why-not: 認証は ANTHROPIC_API_KEY（従量課金）ではなく CLAUDE_CODE_OAUTH_TOKEN（サブスク連携）。
+# 既存 claude.yml / claude-code-review.yml と同じ登録済みトークンに揃え、Secrets を増やさない。
+name: Claude PR Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-pr-review:
+    # Why-not: `@claude` ではなく `@pr-review` で判定する。`@claude` は claude.yml が拾うため、
+    # 二重起動を避ける。また issue_comment はPRにもIssueにもPRにも発火するが、PR以外の
+    # Issue コメントでは pr-review（PR番号前提）が成立しないため、`issue.pull_request` の
+    # 存在でPRコメントに限定する。
+    if: |
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@pr-review')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@pr-review'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Why-not: pull-requests は read ではなく write。/pr-review は `gh pr comment` で
+      # レビュー結果をPRに投稿するため書き込みが要る。ただしコード変更・マージはしないため
+      # contents は read に留める（Action からの push を発生させない）。
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Review
+        id: claude-pr-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Claude が PR の CI 結果を読めるようにする（pr-review のテスト観点で参照）
+          additional_permissions: |
+            actions: read
+
+          # ローカルの /pr-review スキルをそのまま起動する。PR番号はトリガー元イベントから解決する。
+          prompt: '/pr-review ${{ github.event.issue.number || github.event.pull_request.number }}'
+
+          # Why-not: --max-turns は未指定（デフォルト）にせず明示する。pr-review は
+          # 「gh pr view / gh pr diff で情報取得 → レビュー生成 → gh pr comment で投稿」の
+          # 数ターンで完結するレビュー専用フロー（実装のような多ターンは不要）。
+          # 15 で余裕を持たせつつ暴走を抑える。初回実機検証のログで過不足があれば調整する。
+          # allowed-tools は pr-review が使う gh コマンド群に限定し、コード改変系を渡さない。
+          claude_args: |
+            --max-turns 15
+            --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Read,Glob,Grep"


### PR DESCRIPTION
## 概要

ローカルで自作している `/pr-review` スキル（system-architect による設計md整合特化のPRレビュー）を、GitHub Actions 上でも起動できるようにする。PR / PRコメントに `@pr-review` と書くと、`claude-code-action@v1` が `.claude/skills/pr-review` を実行し、レビュー結果をPRコメントに投稿する。

`Closes #369`

## 実装内容

- **新規 `.github/workflows/claude-pr-review.yml` を1本追加**（既存WF・`.claude/` 配下・`CLAUDE.md` は一切改変していない）。
- トリガー: `issue_comment` / `pull_request_review_comment` で本文に **`@pr-review`** を含む場合のみ起動。`issue_comment` は `issue.pull_request != null` でPRコメントに限定（Issueコメントでは pr-review が成立しないため）。
- `prompt: '/pr-review <PR番号>'` でローカルスキルを直渡し。PR番号はトリガー元イベントから解決。
- 認証は登録済みの `CLAUDE_CODE_OAUTH_TOKEN` を流用（`ANTHROPIC_API_KEY` の新規登録は不要）。
- `permissions`: `pull-requests: write`（`gh pr comment` 用）のみ書き込み付与。`contents: read` に留め、Action からの push を発生させない。
- `claude_args`: `--max-turns 15` と `--allowed-tools`（gh の view/diff/comment ＋ Read/Glob/Grep）を明示。コード改変系ツールは渡さない。

## Issue前提との差分（重要）

Issue #369 は「`claude.yml` を新規1本追加のみ」を前提としていたが、**`claude.yml` は #279 で既に追加済み**（`@claude` 汎用メンション用）。そのまま追加すると衝突するため、方針を以下に確定してユーザー承認済み:

- **方針A**: 既存 `claude.yml` は無改変。PRレビュー専用の `claude-pr-review.yml` を新規追加。
- **トリガー語**: `@pr-review`。`@claude-review` 案は文字列として `@claude` を含み、既存 `claude.yml` の `contains(body, '@claude')` に部分一致して二重起動するため不採用。`@pr-review` なら `@claude` を含まず、既存 `claude.yml` を無改変のまま二重起動を回避できる。
- **認証**: 既存の `CLAUDE_CODE_OAUTH_TOKEN` に統一。

## トリガー衝突の突き合わせ

| WF | トリガー | 本PRとの衝突 |
|---|---|---|
| `claude.yml` | `@claude` メンション | なし（`@pr-review` は `@claude` を部分文字列に含まない） |
| `claude-code-review.yml` | `workflow_dispatch`（手動） | なし |
| `claude-pr-review.yml`（本PR） | `@pr-review` メンション | — |

## テスト方針

- YAMLはロジックを持たないため **Vitest（UT）対象外**。Biome（format/lint）もTS/JS/JSON対象でYAML対象外。Playwright（E2E）もブラウザ操作を伴わないため該当なし。
- 受入条件の実体は **Actions 実機での動作確認**。マージ後にテストPRで以下を検証する:
  - `@pr-review` メンションで Action 起動 → レビューコメント投稿
  - メンション無しでは起動しない
  - `@claude` メンション時に本WFが起動しない（＝二重起動しない）
  - ローカル `/pr-review` の回帰なし
  - `--max-turns 15` の過不足を実行ログから確認・調整

## 破壊的変更

なし（CI/CDインフラのYAML追加のみ。DB・API・環境変数・パッケージ変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)