### PR TITLE
feat: 店舗のセルフサーブ登録導線を追加（admin承認制）(#370)

### DIFF
--- a/apps/admin/src/__tests__/bars-approve-api.test.ts
+++ b/apps/admin/src/__tests__/bars-approve-api.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+vi.mock("@/lib/auth", () => ({
+	getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+const mockSupabaseFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+	},
+}));
+
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/bars/[barId]/approve/route";
+
+function createMockRequest(): NextRequest {
+	// biome-ignore lint/suspicious/noExplicitAny: approve は request body を参照しないため最小モック
+	return {} as any;
+}
+
+function createParams(barId: string) {
+	return { params: Promise.resolve({ barId }) };
+}
+
+/**
+ * approve は admin_users を検索 → approval_status を approved に更新 → bars を is_active=true に更新。
+ * - adminUser: 検索結果（null なら 404）
+ * - updateAdminError / updateBarError: 各更新の失敗
+ */
+function setupSupabaseMocks(overrides?: {
+	adminUser?: unknown;
+	updateAdminError?: unknown;
+	updateBarError?: unknown;
+}) {
+	const adminUser =
+		overrides?.adminUser === undefined
+			? { id: "admin-user-1", approval_status: "pending" }
+			: overrides.adminUser;
+
+	const adminMaybeSingle = vi
+		.fn()
+		.mockResolvedValue({ data: adminUser, error: null });
+	const adminSelectEq2 = vi
+		.fn()
+		.mockReturnValue({ maybeSingle: adminMaybeSingle });
+	const adminSelectEq1 = vi.fn().mockReturnValue({ eq: adminSelectEq2 });
+	const adminSelect = vi.fn().mockReturnValue({ eq: adminSelectEq1 });
+
+	const adminUpdateEq = vi
+		.fn()
+		.mockResolvedValue({ error: overrides?.updateAdminError ?? null });
+	const adminUpdate = vi.fn().mockReturnValue({ eq: adminUpdateEq });
+
+	const barUpdateEq = vi
+		.fn()
+		.mockResolvedValue({ error: overrides?.updateBarError ?? null });
+	const barUpdate = vi.fn().mockReturnValue({ eq: barUpdateEq });
+
+	mockSupabaseFrom.mockImplementation((table: string) => {
+		if (table === "admin_users")
+			return { select: adminSelect, update: adminUpdate };
+		if (table === "bars") return { update: barUpdate };
+		throw new Error(`unexpected table: ${table}`);
+	});
+
+	return { adminUpdate, barUpdate };
+}
+
+describe("POST /api/bars/[barId]/approve", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("admin が承認すると 200 を返し、admin_users を approved・bars を is_active=true に更新する", async () => {
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+		const { adminUpdate, barUpdate } = setupSupabaseMocks();
+
+		const response = await POST(createMockRequest(), createParams("42"));
+		const json = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(json.approvalStatus).toBe("approved");
+		expect(adminUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ approval_status: "approved" }),
+		);
+		expect(barUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ is_active: true }),
+		);
+	});
+
+	it("未認証の場合は 401 を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+		setupSupabaseMocks();
+
+		const response = await POST(createMockRequest(), createParams("42"));
+		expect(response.status).toBe(401);
+	});
+
+	it("bar_owner の場合は 403 を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "owner-1",
+			role: "bar_owner",
+			barId: 42,
+		});
+		setupSupabaseMocks();
+
+		const response = await POST(createMockRequest(), createParams("42"));
+		expect(response.status).toBe(403);
+	});
+
+	it("barId が不正な場合は 400 を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+		setupSupabaseMocks();
+
+		const response = await POST(createMockRequest(), createParams("abc"));
+		expect(response.status).toBe(400);
+	});
+
+	it("承認対象の店舗アカウントが存在しない場合は 404 を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+		setupSupabaseMocks({ adminUser: null });
+
+		const response = await POST(createMockRequest(), createParams("42"));
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/admin/src/__tests__/bars-approve-api.test.ts
+++ b/apps/admin/src/__tests__/bars-approve-api.test.ts
@@ -125,4 +125,32 @@ describe("POST /api/bars/[barId]/approve", () => {
 		const response = await POST(createMockRequest(), createParams("42"));
 		expect(response.status).toBe(404);
 	});
+
+	it("既に承認済み（approved）の場合は冪等に 200 を返し、更新は行わない", async () => {
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+		const { adminUpdate, barUpdate } = setupSupabaseMocks({
+			adminUser: { id: "admin-user-1", approval_status: "approved" },
+		});
+
+		const response = await POST(createMockRequest(), createParams("42"));
+		const json = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(json.approvalStatus).toBe("approved");
+		expect(adminUpdate).not.toHaveBeenCalled();
+		expect(barUpdate).not.toHaveBeenCalled();
+	});
+
+	it("却下済み（rejected）の場合は 409 を返し、更新は行わない", async () => {
+		mockGetCurrentUser.mockResolvedValue({ id: "admin-1", role: "admin" });
+		const { adminUpdate, barUpdate } = setupSupabaseMocks({
+			adminUser: { id: "admin-user-1", approval_status: "rejected" },
+		});
+
+		const response = await POST(createMockRequest(), createParams("42"));
+
+		expect(response.status).toBe(409);
+		expect(adminUpdate).not.toHaveBeenCalled();
+		expect(barUpdate).not.toHaveBeenCalled();
+	});
 });

--- a/apps/admin/src/__tests__/bars-register-api.test.ts
+++ b/apps/admin/src/__tests__/bars-register-api.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+	hashPassword: () => Promise.resolve("hashed-password"),
+}));
+
+const mockSupabaseFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockSupabaseFrom(...args),
+	},
+}));
+
+vi.mock("@/lib/shizuoka-cities", () => ({
+	SHIZUOKA_PREFECTURE: "静岡県",
+}));
+
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/bars/register/route";
+
+function createMockRequest(body: unknown): NextRequest {
+	return {
+		json: () => Promise.resolve(body),
+		// biome-ignore lint/suspicious/noExplicitAny: POST が参照する json のみを持つ最小モック
+	} as any;
+}
+
+/**
+ * register は admin_users の重複チェック → bars insert（is_active=false）→ admin_users insert（pending）。
+ * - existingUser: bar_manage_id 重複チェックの結果
+ * - barInsertError / adminInsertError: それぞれの insert 失敗をシミュレート
+ */
+function setupSupabaseMocks(overrides?: {
+	existingUser?: unknown;
+	barInsertError?: unknown;
+	adminInsertError?: unknown;
+}) {
+	const adminMaybeSingle = vi
+		.fn()
+		.mockResolvedValue({ data: overrides?.existingUser ?? null, error: null });
+	const adminEq = vi.fn().mockReturnValue({ maybeSingle: adminMaybeSingle });
+	const adminSelect = vi.fn().mockReturnValue({ eq: adminEq });
+	const adminInsert = vi
+		.fn()
+		.mockResolvedValue({ error: overrides?.adminInsertError ?? null });
+
+	const barSingle = vi.fn().mockResolvedValue({
+		data: overrides?.barInsertError ? null : { id: 42, name: "test-bar" },
+		error: overrides?.barInsertError ?? null,
+	});
+	const barSelect = vi.fn().mockReturnValue({ single: barSingle });
+	const barInsert = vi.fn().mockReturnValue({ select: barSelect });
+	const barUpdateEq = vi.fn().mockResolvedValue({ error: null });
+	const barUpdate = vi.fn().mockReturnValue({ eq: barUpdateEq });
+
+	mockSupabaseFrom.mockImplementation((table: string) => {
+		if (table === "bars") return { insert: barInsert, update: barUpdate };
+		if (table === "admin_users")
+			return { select: adminSelect, insert: adminInsert };
+		throw new Error(`unexpected table: ${table}`);
+	});
+
+	return { barInsert, adminInsert, barUpdate };
+}
+
+const validBody = {
+	bar_manage_id: "test-bar",
+	password: "password123",
+	contact_email: "owner@example.com",
+	contact_phone: "09012345678",
+};
+
+describe("POST /api/bars/register", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("正常な入力で 201 を返し、admin_users を pending・bars を is_active=false で作成する", async () => {
+		const { barInsert, adminInsert } = setupSupabaseMocks();
+
+		const response = await POST(createMockRequest(validBody));
+		const json = await response.json();
+
+		expect(response.status).toBe(201);
+		expect(json.approvalStatus).toBe("pending");
+		expect(json.barManageId).toBe("test-bar");
+
+		expect(barInsert).toHaveBeenCalledWith(
+			expect.objectContaining({ is_active: false }),
+		);
+		expect(adminInsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				approval_status: "pending",
+				role: "bar_owner",
+				bar_id: 42,
+			}),
+		);
+	});
+
+	it("bar_manage_id が空の場合は 400 を返す", async () => {
+		setupSupabaseMocks();
+		const response = await POST(
+			createMockRequest({ ...validBody, bar_manage_id: "" }),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("bar_manage_id がスラッグ形式でない場合は 400 を返す", async () => {
+		setupSupabaseMocks();
+		const response = await POST(
+			createMockRequest({ ...validBody, bar_manage_id: "Fuji Beer" }),
+		);
+		const json = await response.json();
+		expect(response.status).toBe(400);
+		expect(json.error).toContain("半角英数字");
+	});
+
+	it("パスワードが8文字未満の場合は 400 を返す", async () => {
+		setupSupabaseMocks();
+		const response = await POST(
+			createMockRequest({ ...validBody, password: "short" }),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("メールアドレスが空の場合は 400 を返す", async () => {
+		setupSupabaseMocks();
+		const response = await POST(
+			createMockRequest({ ...validBody, contact_email: "" }),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("電話番号が空の場合は 400 を返す", async () => {
+		setupSupabaseMocks();
+		const response = await POST(
+			createMockRequest({ ...validBody, contact_phone: "" }),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("bar_manage_id が既存と重複する場合は 400 を返し、bars を作成しない", async () => {
+		const { barInsert } = setupSupabaseMocks({
+			existingUser: { id: "existing-1" },
+		});
+
+		const response = await POST(createMockRequest(validBody));
+		const json = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(json.error).toContain("既に使用されています");
+		expect(barInsert).not.toHaveBeenCalled();
+	});
+
+	it("admin_users の作成に失敗した場合は 500 を返し、作成済みの bars をロールバックする", async () => {
+		const { barUpdate } = setupSupabaseMocks({
+			adminInsertError: { message: "insert failed" },
+		});
+
+		const response = await POST(createMockRequest(validBody));
+
+		expect(response.status).toBe(500);
+		expect(barUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ is_active: false }),
+		);
+	});
+});

--- a/apps/admin/src/__tests__/bars-register-api.test.ts
+++ b/apps/admin/src/__tests__/bars-register-api.test.ts
@@ -50,17 +50,17 @@ function setupSupabaseMocks(overrides?: {
 	});
 	const barSelect = vi.fn().mockReturnValue({ single: barSingle });
 	const barInsert = vi.fn().mockReturnValue({ select: barSelect });
-	const barUpdateEq = vi.fn().mockResolvedValue({ error: null });
-	const barUpdate = vi.fn().mockReturnValue({ eq: barUpdateEq });
+	const barDeleteEq = vi.fn().mockResolvedValue({ error: null });
+	const barDelete = vi.fn().mockReturnValue({ eq: barDeleteEq });
 
 	mockSupabaseFrom.mockImplementation((table: string) => {
-		if (table === "bars") return { insert: barInsert, update: barUpdate };
+		if (table === "bars") return { insert: barInsert, delete: barDelete };
 		if (table === "admin_users")
 			return { select: adminSelect, insert: adminInsert };
 		throw new Error(`unexpected table: ${table}`);
 	});
 
-	return { barInsert, adminInsert, barUpdate };
+	return { barInsert, adminInsert, barDelete };
 }
 
 const validBody = {
@@ -152,16 +152,28 @@ describe("POST /api/bars/register", () => {
 		expect(barInsert).not.toHaveBeenCalled();
 	});
 
-	it("admin_users の作成に失敗した場合は 500 を返し、作成済みの bars をロールバックする", async () => {
-		const { barUpdate } = setupSupabaseMocks({
+	it("admin_users の作成に失敗した場合は 500 を返し、作成済みの bars を物理削除でロールバックする", async () => {
+		const { barDelete } = setupSupabaseMocks({
 			adminInsertError: { message: "insert failed" },
 		});
 
 		const response = await POST(createMockRequest(validBody));
 
 		expect(response.status).toBe(500);
-		expect(barUpdate).toHaveBeenCalledWith(
-			expect.objectContaining({ is_active: false }),
-		);
+		// is_active=false の bars を残さず物理削除する（孤児行を作らない）
+		expect(barDelete).toHaveBeenCalled();
+	});
+
+	it("並行登録で admin_users insert が UNIQUE 違反（23505）の場合は 400 に変換し、bars をロールバックする", async () => {
+		const { barDelete } = setupSupabaseMocks({
+			adminInsertError: { code: "23505", message: "duplicate key" },
+		});
+
+		const response = await POST(createMockRequest(validBody));
+		const json = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(json.error).toContain("既に使用されています");
+		expect(barDelete).toHaveBeenCalled();
 	});
 });

--- a/apps/admin/src/__tests__/middleware.test.ts
+++ b/apps/admin/src/__tests__/middleware.test.ts
@@ -99,3 +99,41 @@ describe("middleware: /login redirect for authenticated users", () => {
 		expect(response.headers.get("location")).toBeNull();
 	});
 });
+
+describe("middleware: セルフサーブ登録の公開パス", () => {
+	it("未ログインで /bars/register にアクセスした場合、そのまま表示される（/login へ飛ばされない）", async () => {
+		const request = createMockRequest("/bars/register");
+		const response = await middleware(request);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("location")).toBeNull();
+	});
+
+	it("ログイン済み admin が /bars/register にアクセスした場合、/bars へリダイレクトされる", async () => {
+		mockVerifyToken.mockResolvedValue({ role: "admin", barId: null });
+
+		const request = createMockRequest("/bars/register", {
+			"admin-token": "valid-admin-token",
+		});
+		const response = await middleware(request);
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toContain("/bars");
+	});
+
+	it("未ログインで /api/bars/register にアクセスした場合、/login へリダイレクトされない（公開API）", async () => {
+		const request = createMockRequest("/api/bars/register", {}, "POST");
+		const response = await middleware(request);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("location")).toBeNull();
+	});
+
+	it("未ログインで /api/bars（一般API）にアクセスした場合、/login へリダイレクトされる", async () => {
+		const request = createMockRequest("/api/bars");
+		const response = await middleware(request);
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toContain("/login");
+	});
+});

--- a/apps/admin/src/app/api/auth/login/route.test.ts
+++ b/apps/admin/src/app/api/auth/login/route.test.ts
@@ -101,6 +101,60 @@ describe("POST /api/auth/login", () => {
 		expect(body.error).toBe("店舗IDまたはパスワードが正しくありません");
 	});
 
+	it("承認待ち（approval_status=pending）の場合 403 を返し、setAuthCookie は呼ばれない", async () => {
+		mockSupabaseSingle({
+			data: {
+				id: "user-1",
+				bar_manage_id: "pending-bar",
+				password_hash: "hashed-password",
+				name: "審査中オーナー",
+				role: "bar_owner",
+				bar_id: 1,
+				approval_status: "pending",
+			},
+			error: null,
+		});
+		mockVerifyPassword.mockResolvedValue(true);
+
+		const response = await POST(
+			createMockRequest({
+				barManageId: "pending-bar",
+				password: "Test1234!@#",
+			}),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(body.error).toContain("審査中");
+		expect(mockSetAuthCookie).not.toHaveBeenCalled();
+	});
+
+	it("却下済み（approval_status=rejected）の場合 403 を返す", async () => {
+		mockSupabaseSingle({
+			data: {
+				id: "user-1",
+				bar_manage_id: "rejected-bar",
+				password_hash: "hashed-password",
+				name: "却下オーナー",
+				role: "bar_owner",
+				bar_id: 1,
+				approval_status: "rejected",
+			},
+			error: null,
+		});
+		mockVerifyPassword.mockResolvedValue(true);
+
+		const response = await POST(
+			createMockRequest({
+				barManageId: "rejected-bar",
+				password: "Test1234!@#",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(mockSetAuthCookie).not.toHaveBeenCalled();
+	});
+
 	it("正しい認証情報の場合 200 と user 情報を返し、setAuthCookie が呼ばれる", async () => {
 		mockSupabaseSingle({
 			data: {
@@ -110,6 +164,7 @@ describe("POST /api/auth/login", () => {
 				name: "テストオーナー",
 				role: "bar_owner",
 				bar_id: 1,
+				approval_status: "approved",
 			},
 			error: null,
 		});

--- a/apps/admin/src/app/api/auth/login/route.ts
+++ b/apps/admin/src/app/api/auth/login/route.ts
@@ -33,6 +33,22 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
+		// セルフサーブ登録直後（承認前）はログインさせない。パスワード検証後に判定することで、
+		// 存在しない ID との区別（列挙）を避けつつ、承認待ちであることだけを本人に伝える。
+		if (user.approval_status === "pending") {
+			return NextResponse.json(
+				{ error: "アカウントは審査中です。承認までお待ちください。" },
+				{ status: 403 },
+			);
+		}
+
+		if (user.approval_status === "rejected") {
+			return NextResponse.json(
+				{ error: "このアカウントは登録が承認されませんでした。" },
+				{ status: 403 },
+			);
+		}
+
 		const token = await createToken(user);
 
 		await setAuthCookie(token);

--- a/apps/admin/src/app/api/bars/[barId]/approve/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/approve/route.ts
@@ -42,6 +42,19 @@ export async function POST(
 			);
 		}
 
+		// 既に承認済みなら冪等に成功扱い（二重承認や再クリックで状態を壊さない）。
+		if (adminUser.approval_status === "approved") {
+			return NextResponse.json({ barId: barIdNum, approvalStatus: "approved" });
+		}
+
+		// 却下済みアカウントの承認は本フローの対象外（別途の却下解除は未実装）。
+		if (adminUser.approval_status !== "pending") {
+			return NextResponse.json(
+				{ error: "このアカウントは承認できる状態ではありません" },
+				{ status: 409 },
+			);
+		}
+
 		const { error: updateAdminError } = await supabaseAdmin
 			.from("admin_users")
 			.update({

--- a/apps/admin/src/app/api/bars/[barId]/approve/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/approve/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+// POST /api/bars/[barId]/approve - セルフサーブ登録された店舗を admin が承認する
+// 承認で admin_users.approval_status を 'approved' にし（ログイン可能化）、bars.is_active を true にする（公開化）。
+export async function POST(
+	_request: NextRequest,
+	{ params }: { params: Promise<{ barId: string }> },
+) {
+	try {
+		const user = await getCurrentUser();
+
+		if (!user) {
+			return NextResponse.json(
+				{ error: "認証されていません" },
+				{ status: 401 },
+			);
+		}
+
+		if (user.role !== "admin") {
+			return NextResponse.json({ error: "権限がありません" }, { status: 403 });
+		}
+
+		const { barId } = await params;
+		const barIdNum = Number(barId);
+		if (!Number.isInteger(barIdNum) || barIdNum <= 0) {
+			return NextResponse.json({ error: "店舗IDが不正です" }, { status: 400 });
+		}
+
+		const { data: adminUser, error: adminUserError } = await supabaseAdmin
+			.from("admin_users")
+			.select("id, approval_status")
+			.eq("bar_id", barIdNum)
+			.eq("role", "bar_owner")
+			.maybeSingle();
+
+		if (adminUserError || !adminUser) {
+			return NextResponse.json(
+				{ error: "承認対象の店舗アカウントが見つかりません" },
+				{ status: 404 },
+			);
+		}
+
+		const { error: updateAdminError } = await supabaseAdmin
+			.from("admin_users")
+			.update({
+				approval_status: "approved",
+				updated_at: new Date().toISOString(),
+			})
+			.eq("id", adminUser.id);
+
+		if (updateAdminError) {
+			return NextResponse.json(
+				{ error: "承認に失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		const { error: updateBarError } = await supabaseAdmin
+			.from("bars")
+			.update({ is_active: true, updated_at: new Date().toISOString() })
+			.eq("id", barIdNum);
+
+		if (updateBarError) {
+			return NextResponse.json(
+				{ error: "店舗の公開に失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		return NextResponse.json({ barId: barIdNum, approvalStatus: "approved" });
+	} catch (_error) {
+		return NextResponse.json({ error: "承認に失敗しました" }, { status: 500 });
+	}
+}

--- a/apps/admin/src/app/api/bars/pending/route.ts
+++ b/apps/admin/src/app/api/bars/pending/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+// GET /api/bars/pending - セルフサーブ登録の審査中店舗一覧（admin 専用）
+// 通常の GET /api/bars は is_active=true で公開店舗だけを返すため、承認前（is_active=false）の
+// 審査中店舗はこの専用エンドポイントで取得する。
+export async function GET() {
+	try {
+		const user = await getCurrentUser();
+
+		if (!user) {
+			return NextResponse.json(
+				{ error: "認証されていません" },
+				{ status: 401 },
+			);
+		}
+
+		if (user.role !== "admin") {
+			return NextResponse.json({ error: "権限がありません" }, { status: 403 });
+		}
+
+		const { data: pendingUsers, error } = await supabaseAdmin
+			.from("admin_users")
+			.select("bar_id, bar_manage_id, contact_email, contact_phone, created_at")
+			.eq("approval_status", "pending")
+			.eq("role", "bar_owner")
+			.not("bar_id", "is", null)
+			.order("created_at", { ascending: false });
+
+		if (error) {
+			return NextResponse.json(
+				{ error: "審査中店舗の取得に失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		return NextResponse.json(pendingUsers ?? []);
+	} catch (_error) {
+		return NextResponse.json(
+			{ error: "審査中店舗の取得に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/admin/src/app/api/bars/register/route.ts
+++ b/apps/admin/src/app/api/bars/register/route.ts
@@ -1,0 +1,128 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { hashPassword } from "@/lib/auth";
+import { SHIZUOKA_PREFECTURE } from "@/lib/shizuoka-cities";
+import { supabaseAdmin } from "@/lib/supabase";
+import type { Bar } from "@/types/database";
+
+// POST /api/bars/register - 店舗オーナーによるセルフサーブ登録（未認証で叩ける公開エンドポイント）
+// Why not 既存 POST /api/bars の 403 ガードを緩める: admin 手動作成フロー（Phase 2 含む）と認可ロジックが同居して
+// 複雑化するため、Phase 1 項目のみ受け付ける専用の公開エンドポイントとして分離する。
+// 作成される店舗は承認まで公開しない（bars.is_active=false / admin_users.approval_status='pending'）。
+export async function POST(request: NextRequest) {
+	try {
+		const body = await request.json();
+		const { bar_manage_id, password, contact_email, contact_phone } = body;
+
+		if (!bar_manage_id || typeof bar_manage_id !== "string") {
+			return NextResponse.json(
+				{ error: "店舗IDを入力してください" },
+				{ status: 400 },
+			);
+		}
+
+		const slugPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+		if (!slugPattern.test(bar_manage_id)) {
+			return NextResponse.json(
+				{
+					error:
+						"店舗IDは半角英数字とハイフンのみ使用できます（例: fuji-beer-bar）",
+				},
+				{ status: 400 },
+			);
+		}
+
+		if (!password || typeof password !== "string" || password.length < 8) {
+			return NextResponse.json(
+				{ error: "パスワードは8文字以上で入力してください" },
+				{ status: 400 },
+			);
+		}
+
+		if (!contact_email) {
+			return NextResponse.json(
+				{ error: "メールアドレスを入力してください" },
+				{ status: 400 },
+			);
+		}
+
+		if (!contact_phone) {
+			return NextResponse.json(
+				{ error: "電話番号を入力してください" },
+				{ status: 400 },
+			);
+		}
+
+		// bar_manage_id の重複チェック（UX フィードバック用の事前チェック。最終的な一意性は UNIQUE 制約が担保する）
+		const { data: existingUser } = await supabaseAdmin
+			.from("admin_users")
+			.select("id")
+			.eq("bar_manage_id", bar_manage_id)
+			.maybeSingle();
+
+		if (existingUser) {
+			return NextResponse.json(
+				{ error: "この店舗IDは既に使用されています" },
+				{ status: 400 },
+			);
+		}
+
+		// 承認まで公開しないため is_active=false で作成する。承認時に true へ更新する。
+		const now = new Date().toISOString();
+		const { data: bar, error: barError } = await supabaseAdmin
+			.from("bars")
+			.insert({
+				name: bar_manage_id,
+				prefecture: SHIZUOKA_PREFECTURE,
+				city: "",
+				address_line1: "",
+				is_active: false,
+				updated_at: now,
+			})
+			.select()
+			.single<Bar>();
+
+		if (barError || !bar) {
+			return NextResponse.json(
+				{ error: "店舗の登録に失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		const passwordHash = await hashPassword(password);
+		const { error: adminUserError } = await supabaseAdmin
+			.from("admin_users")
+			.insert({
+				bar_manage_id,
+				password_hash: passwordHash,
+				name: bar_manage_id,
+				role: "bar_owner",
+				bar_id: bar.id,
+				contact_email,
+				contact_phone,
+				approval_status: "pending",
+			});
+
+		if (adminUserError) {
+			// admin_users 作成失敗時は店舗もロールバック（論理削除）。既存 POST /api/bars と対称。
+			await supabaseAdmin
+				.from("bars")
+				.update({ is_active: false })
+				.eq("id", bar.id);
+
+			return NextResponse.json(
+				{ error: "店舗アカウントの作成に失敗しました" },
+				{ status: 500 },
+			);
+		}
+
+		return NextResponse.json(
+			{ barManageId: bar_manage_id, approvalStatus: "pending" },
+			{ status: 201 },
+		);
+	} catch (_error) {
+		return NextResponse.json(
+			{ error: "店舗の登録に失敗しました" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/admin/src/app/api/bars/register/route.ts
+++ b/apps/admin/src/app/api/bars/register/route.ts
@@ -103,11 +103,18 @@ export async function POST(request: NextRequest) {
 			});
 
 		if (adminUserError) {
-			// admin_users 作成失敗時は店舗もロールバック（論理削除）。既存 POST /api/bars と対称。
-			await supabaseAdmin
-				.from("bars")
-				.update({ is_active: false })
-				.eq("id", bar.id);
+			// Why not is_active=false へのロールバック: bars は既に is_active=false で作成しているため
+			// 状態が変わらず孤児行が残る。作成直後で参照も無いため物理 delete で確実に取り消す。
+			await supabaseAdmin.from("bars").delete().eq("id", bar.id);
+
+			// 事前チェックをすり抜けた並行登録（TOCTOU）は UNIQUE 制約違反で弾かれる。
+			// これを 500 ではなく「既に使用されています」の 400 に変換して最終的に1件へ収束させる。
+			if (adminUserError.code === "23505") {
+				return NextResponse.json(
+					{ error: "この店舗IDは既に使用されています" },
+					{ status: 400 },
+				);
+			}
 
 			return NextResponse.json(
 				{ error: "店舗アカウントの作成に失敗しました" },

--- a/apps/admin/src/app/bars/BarList.tsx
+++ b/apps/admin/src/app/bars/BarList.tsx
@@ -6,17 +6,32 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import type { Bar } from "@/types/database";
 
+type PendingBar = {
+	bar_id: number;
+	bar_manage_id: string;
+	contact_email: string | null;
+	contact_phone: string | null;
+	created_at: string;
+};
+
 export default function BarList() {
 	const [bars, setBars] = useState<Bar[]>([]);
+	const [pendingBars, setPendingBars] = useState<PendingBar[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [approvingId, setApprovingId] = useState<number | null>(null);
 	const router = useRouter();
 
 	const fetchBars = useCallback(async () => {
 		try {
-			const response = await fetch("/api/bars");
-			if (response.ok) {
-				const data = await response.json();
-				setBars(data);
+			const [barsRes, pendingRes] = await Promise.all([
+				fetch("/api/bars"),
+				fetch("/api/bars/pending"),
+			]);
+			if (barsRes.ok) {
+				setBars(await barsRes.json());
+			}
+			if (pendingRes.ok) {
+				setPendingBars(await pendingRes.json());
 			}
 		} catch (_error) {
 		} finally {
@@ -27,6 +42,21 @@ export default function BarList() {
 	useEffect(() => {
 		fetchBars();
 	}, [fetchBars]);
+
+	const handleApprove = async (barId: number) => {
+		setApprovingId(barId);
+		try {
+			const response = await fetch(`/api/bars/${barId}/approve`, {
+				method: "POST",
+			});
+			if (response.ok) {
+				await fetchBars();
+			}
+		} catch (_error) {
+		} finally {
+			setApprovingId(null);
+		}
+	};
 
 	if (loading) {
 		return (
@@ -52,6 +82,40 @@ export default function BarList() {
 					店舗を登録する
 				</button>
 			</div>
+
+			{pendingBars.length > 0 && (
+				<div className="mb-8">
+					<h2 className="text-lg font-bold text-gray-900 mb-3">
+						審査中の店舗（{pendingBars.length}）
+					</h2>
+					<div className="space-y-3">
+						{pendingBars.map((pending) => (
+							<div
+								key={pending.bar_id}
+								className="border border-amber-200 bg-amber-50 rounded-lg p-4 flex items-center justify-between gap-4"
+							>
+								<div className="min-w-0">
+									<p className="text-base font-bold text-gray-900 truncate">
+										{pending.bar_manage_id}
+									</p>
+									<p className="text-sm text-gray-600 truncate">
+										{pending.contact_email ?? "-"} /{" "}
+										{pending.contact_phone ?? "-"}
+									</p>
+								</div>
+								<button
+									type="button"
+									onClick={() => handleApprove(pending.bar_id)}
+									disabled={approvingId === pending.bar_id}
+									className="shrink-0 px-4 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-600 disabled:opacity-50 disabled:cursor-not-allowed"
+								>
+									{approvingId === pending.bar_id ? "承認中..." : "承認する"}
+								</button>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
 
 			{bars.length === 0 ? (
 				<div className="border border-gray-200 rounded-lg p-12 text-center">

--- a/apps/admin/src/app/bars/register/BarRegisterForm.tsx
+++ b/apps/admin/src/app/bars/register/BarRegisterForm.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import Link from "next/link";
+import { type FormEvent, useState } from "react";
+
+export default function BarRegisterForm() {
+	const [barManageId, setBarManageId] = useState("");
+	const [password, setPassword] = useState("");
+	const [contactEmail, setContactEmail] = useState("");
+	const [contactPhone, setContactPhone] = useState("");
+	const [error, setError] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [submitted, setSubmitted] = useState(false);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError("");
+
+		if (!barManageId || !password || !contactEmail || !contactPhone) {
+			setError("すべての項目を入力してください");
+			return;
+		}
+
+		if (password.length < 8) {
+			setError("パスワードは8文字以上で入力してください");
+			return;
+		}
+
+		setLoading(true);
+
+		try {
+			const response = await fetch("/api/bars/register", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					bar_manage_id: barManageId,
+					password,
+					contact_email: contactEmail,
+					contact_phone: contactPhone,
+				}),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				setError(data.error || "登録に失敗しました");
+				return;
+			}
+
+			setSubmitted(true);
+		} catch (_err) {
+			setError("登録に失敗しました");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	if (submitted) {
+		return (
+			<div className="min-h-screen flex items-center justify-center bg-gray-50">
+				<div className="max-w-md w-full bg-white shadow-lg rounded-lg p-8 space-y-6 text-center">
+					<h1 className="text-2xl font-bold text-gray-900">
+						お申し込みを受け付けました
+					</h1>
+					<p className="text-sm text-gray-600">
+						ご登録内容を審査中です。承認され次第、ご登録の店舗IDとパスワードでログインできるようになります。
+					</p>
+					<Link
+						href="/login"
+						className="inline-block w-full py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-gray-900 hover:bg-gray-800"
+					>
+						ログイン画面へ
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen flex items-center justify-center bg-gray-50">
+			<div className="max-w-md w-full bg-white shadow-lg rounded-lg p-8 space-y-6">
+				<div>
+					<h1 className="text-center text-2xl font-bold text-gray-900">
+						Beer Salon Admin
+					</h1>
+					<p className="mt-2 text-center text-sm text-gray-600">
+						店舗登録の申し込み
+					</p>
+				</div>
+
+				<form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+					<div className="rounded-md shadow-sm space-y-4">
+						<div>
+							<label
+								htmlFor="barManageId"
+								className="block text-sm font-medium text-gray-700"
+							>
+								店舗ID
+							</label>
+							<input
+								id="barManageId"
+								name="barManageId"
+								type="text"
+								autoComplete="username"
+								required
+								value={barManageId}
+								onChange={(e) => setBarManageId(e.target.value)}
+								className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-gray-500 focus:border-gray-500 focus:z-10 sm:text-sm"
+								placeholder="fuji-beer-bar"
+							/>
+							<p className="mt-1 text-xs text-gray-500">
+								半角英数字とハイフンのみ使用できます（例: fuji-beer-bar）
+							</p>
+						</div>
+
+						<div>
+							<label
+								htmlFor="password"
+								className="block text-sm font-medium text-gray-700"
+							>
+								パスワード
+							</label>
+							<input
+								id="password"
+								name="password"
+								type="password"
+								autoComplete="new-password"
+								required
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-gray-500 focus:border-gray-500 focus:z-10 sm:text-sm"
+								placeholder="8文字以上"
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="contactEmail"
+								className="block text-sm font-medium text-gray-700"
+							>
+								管理者メールアドレス
+							</label>
+							<input
+								id="contactEmail"
+								name="contactEmail"
+								type="email"
+								autoComplete="email"
+								required
+								value={contactEmail}
+								onChange={(e) => setContactEmail(e.target.value)}
+								className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-gray-500 focus:border-gray-500 focus:z-10 sm:text-sm"
+							/>
+						</div>
+
+						<div>
+							<label
+								htmlFor="contactPhone"
+								className="block text-sm font-medium text-gray-700"
+							>
+								管理者電話番号
+							</label>
+							<input
+								id="contactPhone"
+								name="contactPhone"
+								type="tel"
+								autoComplete="tel"
+								required
+								value={contactPhone}
+								onChange={(e) => setContactPhone(e.target.value)}
+								className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-gray-500 focus:border-gray-500 focus:z-10 sm:text-sm"
+							/>
+						</div>
+					</div>
+
+					{error && (
+						<div className="rounded-md bg-red-50 p-4">
+							<p className="text-sm text-red-800">{error}</p>
+						</div>
+					)}
+
+					<div>
+						<button
+							type="submit"
+							disabled={loading}
+							className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							{loading ? "送信中..." : "登録を申し込む"}
+						</button>
+					</div>
+				</form>
+
+				<div className="text-center">
+					<Link href="/login" className="text-sm text-gray-600 hover:underline">
+						ログインに戻る
+					</Link>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/admin/src/app/bars/register/page.tsx
+++ b/apps/admin/src/app/bars/register/page.tsx
@@ -1,0 +1,6 @@
+import BarRegisterForm from "./BarRegisterForm";
+
+// 未ログインの店舗オーナーが申し込む公開ページのため、DashboardLayout（ログイン後レイアウト）は使わない。
+export default function BarRegisterPage() {
+	return <BarRegisterForm />;
+}

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useState } from "react";
 
@@ -121,6 +122,15 @@ export default function LoginPage() {
 						</button>
 					</div>
 				</form>
+
+				<div className="text-center">
+					<Link
+						href="/bars/register"
+						className="text-sm text-gray-600 hover:underline"
+					>
+						店舗登録はこちら
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/admin/src/lib/auth.test.ts
+++ b/apps/admin/src/lib/auth.test.ts
@@ -44,6 +44,7 @@ describe("createToken / verifyToken", () => {
 		password_hash: "irrelevant-for-token",
 		contact_email: null,
 		contact_phone: null,
+		approval_status: "approved" as const,
 		is_active: true,
 		created_at: "2024-01-01T00:00:00Z",
 		updated_at: "2024-01-01T00:00:00Z",

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -3,7 +3,10 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { verifyToken } from "@/lib/auth";
 
-const publicPaths = ["/login"];
+// /bars/register は未ログインの店舗オーナーがセルフサーブ登録するための公開ページ。
+// /bars/[barId] や /bars/new（いずれもログイン必須）より前に startsWith で判定するため、
+// より具体的なプレフィックスとして publicPaths に含める。
+const publicPaths = ["/login", "/bars/register"];
 
 const MUTATION_METHODS = ["POST", "PUT", "DELETE", "PATCH"];
 
@@ -13,7 +16,11 @@ export async function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
 	if (publicPaths.some((path) => pathname.startsWith(path))) {
-		if (pathname.startsWith("/login")) {
+		// /login と /bars/register はどちらもログイン済みなら本来のホームへ戻す（誤ってフォームを見せない）。
+		if (
+			pathname.startsWith("/login") ||
+			pathname.startsWith("/bars/register")
+		) {
 			const token = request.cookies.get("admin-token")?.value;
 			if (token) {
 				const payload = await verifyToken(token);
@@ -38,6 +45,10 @@ export async function middleware(request: NextRequest) {
 
 	if (pathname.startsWith("/api/")) {
 		if (pathname.startsWith("/api/auth/")) {
+			return NextResponse.next();
+		}
+		// セルフサーブ登録は未認証で叩ける公開エンドポイント。
+		if (pathname === "/api/bars/register") {
 			return NextResponse.next();
 		}
 		if (pathname === "/api/payment-methods") {

--- a/apps/admin/src/types/database.ts
+++ b/apps/admin/src/types/database.ts
@@ -7,6 +7,7 @@ export interface AdminUser {
 	bar_id: number | null;
 	contact_email: string | null;
 	contact_phone: string | null;
+	approval_status: "pending" | "approved" | "rejected";
 	is_active: boolean;
 	created_at: string;
 	updated_at: string;

--- a/apps/admin/tests/bar-register.spec.ts
+++ b/apps/admin/tests/bar-register.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+// セルフサーブ登録（未ログインの店舗オーナーが申し込む公開フロー）の受入条件を検証する。
+test.describe("店舗セルフサーブ登録", () => {
+	test("ログイン画面から登録画面へ遷移でき、フォーム項目が表示される", async ({
+		page,
+	}) => {
+		await page.goto("/login");
+
+		await page.getByRole("link", { name: "店舗登録はこちら" }).click();
+
+		await expect(page).toHaveURL(/\/bars\/register$/);
+		await expect(
+			page.getByRole("heading", { name: "Beer Salon Admin" }),
+		).toBeVisible();
+		await expect(page.getByText("店舗登録の申し込み")).toBeVisible();
+
+		await expect(page.getByLabel("店舗ID")).toBeVisible();
+		await expect(page.getByLabel("パスワード")).toBeVisible();
+		await expect(page.getByLabel("管理者メールアドレス")).toBeVisible();
+		await expect(page.getByLabel("管理者電話番号")).toBeVisible();
+	});
+
+	test("申し込むと審査中の完了画面が表示される", async ({ page }) => {
+		// 再実行で bar_manage_id が衝突しないよう、テスト実行ごとに一意なスラッグを使う。
+		const uniqueId = `e2e-selfserve-${Date.now()}`;
+
+		await page.goto("/bars/register");
+
+		await page.getByLabel("店舗ID").fill(uniqueId);
+		await page.getByLabel("パスワード").fill("password123");
+		await page.getByLabel("管理者メールアドレス").fill("owner@example.com");
+		await page.getByLabel("管理者電話番号").fill("09012345678");
+
+		await page.getByRole("button", { name: "登録を申し込む" }).click();
+
+		await expect(
+			page.getByRole("heading", { name: "お申し込みを受け付けました" }),
+		).toBeVisible();
+		await expect(page.getByText("審査中")).toBeVisible();
+		await expect(
+			page.getByRole("link", { name: "ログイン画面へ" }),
+		).toBeVisible();
+	});
+});
+
+// 受入条件の中核（登録された ID/PW で「承認後に」ログインできる／承認前はログインできない）を、
+// 登録 → 承認前ログイン拒否 → admin 承認 → ログイン成功、の一巡で検証する。
+// 申込側（未認証 page）と admin 側は別コンテキストにする。同一 page を admin でログインさせると
+// middleware が /bars/register を /bars へリダイレクトし、登録フォームに到達できないため。
+test.describe("店舗セルフサーブ登録: 承認フロー", () => {
+	test("登録直後はログインできず、admin 承認後にログインできる", async ({
+		page,
+		browser,
+	}) => {
+		const uniqueId = `e2e-approval-${Date.now()}`;
+		const password = "password123";
+
+		// 1. 未ログインの店舗オーナーが申し込む
+		await page.goto("/bars/register");
+		await page.getByLabel("店舗ID").fill(uniqueId);
+		await page.getByLabel("パスワード").fill(password);
+		await page.getByLabel("管理者メールアドレス").fill("owner@example.com");
+		await page.getByLabel("管理者電話番号").fill("09012345678");
+		await page.getByRole("button", { name: "登録を申し込む" }).click();
+		await expect(
+			page.getByRole("heading", { name: "お申し込みを受け付けました" }),
+		).toBeVisible();
+
+		// 2. 承認前は作成した ID/PW でログインできない（審査中エラー）
+		await page.goto("/login");
+		await page.getByLabel("店舗ID").fill(uniqueId);
+		await page.getByLabel("パスワード").fill(password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page.getByText("審査中")).toBeVisible();
+		await expect(page).toHaveURL(/\/login$/);
+
+		// 3. admin が別コンテキストで /bars の審査中セクションから承認する
+		const adminContext = await browser.newContext();
+		const adminPage = await adminContext.newPage();
+		await loginAsAdmin(adminPage);
+		await adminPage.goto("/bars");
+		// 過去実行で審査中店舗が複数残っていても取り違えないよう、この店舗IDを表示する要素を
+		// 起点に、同じ行（直近の bg-amber-50 コンテナ）内の承認ボタンだけを対象にする。
+		const pendingRow = adminPage
+			.locator("div.bg-amber-50")
+			.filter({ hasText: uniqueId });
+		await expect(pendingRow).toBeVisible();
+		await pendingRow.getByRole("button", { name: "承認する" }).click();
+		// 承認が反映され、この行が審査中リストから外れる
+		await expect(pendingRow).toHaveCount(0, { timeout: 10000 });
+		await adminContext.close();
+
+		// 4. 承認後は作成した ID/PW でログインできる（自店舗ページへ遷移）
+		await page.goto("/login");
+		await page.getByLabel("店舗ID").fill(uniqueId);
+		await page.getByLabel("パスワード").fill(password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page).toHaveURL(/\/bars\/\d+$/);
+	});
+});

--- a/database.md
+++ b/database.md
@@ -675,6 +675,7 @@ BeerSalonAdmin（管理画面）専用のテーブル。ユーザー向けアプ
 | bar_id          | bigint     | NULLABLE, FK → bars(id)         | 紐づく店舗ID（bar_ownerは必須、adminはNULL）|
 | contact_email   | text       | NULLABLE                         | 店舗管理者メールアドレス（請求書送付用）|
 | contact_phone   | text       | NULLABLE                         | 店舗管理者電話番号（トラブル時連絡用）|
+| approval_status | text       | NOT NULL DEFAULT 'approved' CHECK (in 'pending'/'approved'/'rejected') | セルフサーブ登録の承認状態 |
 | is_active       | boolean    | NOT NULL DEFAULT true            | アカウント有効フラグ        |
 | created_at      | timestamptz| NOT NULL DEFAULT now()           | 作成日時                    |
 | updated_at      | timestamptz| NOT NULL DEFAULT now()           | 更新日時                    |
@@ -686,6 +687,15 @@ BeerSalonAdmin（管理画面）専用のテーブル。ユーザー向けアプ
 **運用ルール**:
 - 1店舗 = 1アカウント（店舗スタッフ全員で `bar_manage_id` とパスワードを共有してログイン）
 - 店舗登録時に `admin_users` レコードも自動作成される
+
+**承認ステータス（`approval_status`）**:
+- 店舗登録の経路により初期値が異なる:
+  - admin 手動作成（`POST /api/bars` / `/bars/new`）: 従来どおり承認不要。列は `DEFAULT 'approved'` で作成される
+  - 店舗セルフサーブ登録（`POST /api/bars/register` / `/bars/register`）: `'pending'`（審査中）で作成し、あわせて `bars.is_active=false` にして承認まで非公開にする
+- ログイン API（`POST /api/auth/login`）は `approval_status='pending'`/`'rejected'` のアカウントを 403 で弾く（`'approved'` のみログイン可能）
+- admin が承認（`POST /api/bars/[barId]/approve`）すると `approval_status='approved'`・`bars.is_active=true` に更新され、ログイン可能・ユーザー画面に公開される
+- 既存レコードは `DEFAULT 'approved'` により後方互換（既存 admin/bar_owner のログインに影響しない）
+- `'rejected'`（却下）値は予約済みだが、却下操作の UI は本スコープ外（別 Issue）
 
 **権限**:
 - `bar_owner`: 自店舗（`bar_id` で紐づく店舗）の全データを編集可能

--- a/routing.md
+++ b/routing.md
@@ -423,7 +423,7 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
 ### 3-0. 共通ルール
 
 - ドメイン: `https://admin.beersalon.com`（想定）
-- 未ログインでアクセス可能なページ: `/login` のみ
+- 未ログインでアクセス可能なページ: `/login` と `/bars/register`（店舗セルフサーブ登録）
 - それ以外はすべてログイン必須（未ログイン時は `/login` へリダイレクト）
 - 認証方式: カスタムJWT認証（jose + bcryptjs）。Supabase Auth は不使用
 - ログイン後の共通レイアウト:
@@ -442,9 +442,38 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
   - 店舗ID（テキストボックス）
   - パスワード（テキストボックス、8文字以上）
   - ログインボタン
+  - 「店舗登録はこちら」リンク → `/bars/register`
 - ログイン後遷移先:
   - `admin` → `/bars`（店舗管理ページ）
   - `bar_owner` → `/bars/[barId]`（自店舗の詳細ページ）
+- 振る舞い:
+  - 承認待ち（`admin_users.approval_status='pending'`）のアカウントはログイン不可。パスワード検証後に「アカウントは審査中です。承認までお待ちください。」を表示する（403）
+  - 却下（`rejected`）のアカウントも同様にログイン不可
+
+#### 3-1-2. 店舗セルフサーブ登録ページ
+
+- Path: `/bars/register`
+- 認証: 不要（未ログインの店舗オーナーが申し込む公開ページ）
+  - ログイン済みでアクセスした場合は権限に応じたページ（`admin` → `/bars`、`bar_owner` → `/bars/[barId]`）へリダイレクト
+- 役割:
+  - 店舗オーナー自身が店舗登録を申し込む（admin の手動作成 `/bars/new` に依存しないセルフサーブ導線）
+  - 申し込みで `bars`（`is_active=false`）と `admin_users`（`role='bar_owner'`, `approval_status='pending'`）を作成する
+  - 悪用・冷やかし対策として admin 承認制（半セルフサーブ）。承認まではログイン不可・ユーザー画面非表示
+- UI 要素（Phase 1 相当のみ。店舗名・住所・営業時間などの Phase 2 項目は承認後に本人が `/bars/[barId]/edit` で入力する）:
+  - 店舗ID（テキストボックス、スラッグ形式。重複時はエラー）
+  - パスワード（テキストボックス、8文字以上）
+  - 管理者メールアドレス
+  - 管理者電話番号
+  - 「登録を申し込む」ボタン
+  - 「ログインに戻る」リンク → `/login`
+- 振る舞い:
+  - 送信成功時: 「お申し込みを受け付けました（審査中）」の完了画面を表示し、`/login` への導線を出す（自動ログインはしない）
+  - `bar_manage_id` が既存と重複する場合はエラーを表示して作成しない
+  - API: `POST /api/bars/register`（未認証で叩ける公開エンドポイント）。既存の `POST /api/bars`（admin 専用・Phase 2 含む）とは分離
+- 承認フロー:
+  - admin が `/bars`（店舗管理ページ）の「審査中の店舗」セクションから「承認する」を押すと、`admin_users.approval_status='approved'`・`bars.is_active=true` に更新され、当該オーナーがログイン可能・ユーザー画面に公開される
+  - API: `POST /api/bars/[barId]/approve`（admin 専用）
+  - ※却下（rejected）UI・承認通知メール・登録直後の課金（#335 Stripe Checkout）連携は本スコープ外（別 Issue）
 
 ### 3-2. 店舗管理（admin専用）
 
@@ -457,6 +486,9 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
   - 新規店舗登録への導線
 - UI 要素:
   - 店舗登録ボタン → `/bars/new`
+  - 「審査中の店舗」セクション（セルフサーブ登録された未承認店舗が存在する場合のみ表示）
+    - 各行に店舗ID・連絡先を表示し、「承認する」ボタンで承認（`POST /api/bars/[barId]/approve`）
+    - 取得元: `GET /api/bars/pending`（admin 専用。承認前は `is_active=false` のため通常の `GET /api/bars` には出ない）
   - 店舗カード一覧（店舗名、プレビュー画像）
   - 各カード → `/bars/[barId]`
 

--- a/supabase/migrations/20260703000001_add_admin_users_approval_status.sql
+++ b/supabase/migrations/20260703000001_add_admin_users_approval_status.sql
@@ -1,0 +1,12 @@
+-- admin_users にセルフサーブ登録の承認ステータスを追加する。
+-- Why not DEFAULT 'pending': 既存の admin / bar_owner を審査待ちに巻き込むとログイン不能になるため、
+-- 既存レコードは承認済みとみなす DEFAULT 'approved' とし、セルフサーブ登録 API 側で明示的に 'pending' を入れる。
+ALTER TABLE "admin_users"
+  ADD COLUMN "approval_status" TEXT NOT NULL DEFAULT 'approved';
+
+ALTER TABLE "admin_users"
+  ADD CONSTRAINT "admin_users_approval_status_check"
+  CHECK ("approval_status" IN ('pending', 'approved', 'rejected'));
+
+-- 審査中一覧の絞り込み用。
+CREATE INDEX "idx_admin_users_approval_status" ON "admin_users"("approval_status");


### PR DESCRIPTION
## 概要

未ログインの店舗オーナーが自分で店舗登録を申し込めるセルフサーブ導線を追加する（Issue #370）。
店舗数の拡大が admin の手作業（`/bars/new`）に律速される状態を解消する。

悪用・冷やかし登録が即座に本番 `bars`（ユーザー画面に出る店舗）になるのを防ぐため、**admin 承認を挟む半セルフサーブ**とした。承認まではログイン不可・ユーザー画面非表示。

## 確定した仕様（事前の /plan で合意）

| 論点 | 決定 |
|---|---|
| 承認モデル | admin 承認制（半セルフサーブ） |
| 登録エンドポイント | 新設 `POST /api/bars/register`（公開）。既存の admin 専用 `POST /api/bars` は温存 |
| 登録ページ | `/bars/register`（公開） |
| 登録後遷移 | 「審査中」完了画面 → ログイン誘導（自動ログインしない） |
| 承認ステータス | `admin_users.approval_status`（列追加） |
| admin 承認 UI | 今回スコープに含める（`/bars` の審査中セクション＋承認ボタン） |
| 課金連携(#335) | スコープ外（別 Issue） |

## 変更内容

### DB / 型
- マイグレーション `20260703000001`: `admin_users.approval_status`（`pending`/`approved`/`rejected`、`DEFAULT 'approved'` + CHECK 制約 + index）を追加。既存レコードは `approved` で後方互換
- `AdminUser` 型に `approval_status` を追加

### API
- `POST /api/bars/register`（公開）: Phase1項目のみ受付。`bars`（`is_active=false`）＋`admin_users`（`pending`）を作成。`admin_users` 作成失敗時は `bars` をロールバック
- `POST /api/bars/[barId]/approve`（admin専用）: `approval_status='approved'`・`bars.is_active=true` に更新
- `GET /api/bars/pending`（admin専用）: 審査中店舗一覧
- `POST /api/auth/login`: `pending`/`rejected` を 403 で弾く承認ブロックを追加

### 画面
- `/bars/register`（公開）: 登録フォーム＋審査中の完了画面
- ログイン画面: 「店舗登録はこちら」導線を追加
- `/bars` 店舗管理: 審査中セクション＋「承認する」ボタン

### middleware
- `/bars/register`・`/api/bars/register` を公開。ログイン済みで `/bars/register` に来たら本来のホームへリダイレクト

### ドキュメント
- `routing.md`: `/bars/register`・承認フロー・審査中セクション・ログイン承認ブロックを追記
- `database.md`: `admin_users.approval_status` 列と承認フローの運用ルールを追記

## テスト

### UT（Vitest）174本 pass
- `bars-register-api.test.ts`: 正常作成（pending/is_active=false）・各種バリデーション400・重複400・ロールバック
- `bars-approve-api.test.ts`: admin成功・未認証401・bar_owner403・不正barId400・404
- `login/route.test.ts`: `pending`/`rejected` で403・setAuthCookie未呼び出し
- `middleware.test.ts`: `/bars/register`・`/api/bars/register` の公開通過

### E2E（Playwright）3本 pass
- ログイン画面 → 登録画面遷移・フォーム項目表示
- 申込 → 審査中の完了画面
- 登録 → 承認前ログイン不可（審査中） → admin承認 → ログイン成功（受入条件の中核）

## 受入条件

- [x] 未ログインの店舗オーナーが登録フォームから申し込むと `admin_users`（bar_owner）と `bars` が作成される
- [x] 作成された `bar_manage_id` とパスワードで（承認後に）ログインできる
- [x] `bar_manage_id` が既存と重複する場合はエラーが表示され作成されない
- [x] UT / E2E を追加

## スコープ外（別 Issue 化予定）

- #335 Stripe Checkout 連携（登録直後の課金導線）
- 却下（rejected）フローの UI・却下理由通知
- 承認/却下時のオーナーへのメール通知
- Phase2項目（店舗名・住所・営業時間等）のセルフサーブ入力

## 破壊的変更

- **DBスキーマ変更あり**: `admin_users.approval_status` 列を追加。`develop` push で `migrate.yml` が dev Supabase に自動適用する。`DEFAULT 'approved'` のため既存アカウントのログインには影響しない

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)