### PR TITLE
配色をテーマとして差し替え可能にする基盤整備（ハードコード色のトークン化＋テーマ切替の仕組み） (#389)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ claude --plugin-dir ./plugins/bs-workflow
 
 ---
 
+## 🎨 配色テーマの切替（ユーザー画面 / apps/web）
+
+ユーザー画面の配色を「テーマ」単位で差し替えられる（方式③: ビルド時・開発者切替。実行時のユーザー向けトグルは対象外）。目的は、デザインを変えても**容易に前へ戻せる**こと。
+
+```bash
+# 現行（ライトなアンバー・クリーム基調 = 巻き戻し先）に戻す
+pnpm --filter @beersalon/web theme current
+
+# #383 案A（ダークブラウン × アンバーゴールド）に切り替える
+pnpm --filter @beersalon/web theme amber-dark
+```
+
+- テーマ本体は `apps/web/src/styles/themes/<name>.css`（各ファイルが `:root { ... }` を1つ持つ）。
+- `pnpm theme <name>` は `apps/web/src/app/globals.css` 内の `/* THEME:START */` 〜 `/* THEME:END */` で囲まれた `:root` ブロックを、指定テーマの内容へ差し替える。反映は `pnpm dev` の再ビルド / ブラウザリロードで行われる。
+- 切替が一貫して追従するのは、共通ヘッダー / フッターの帯・検索フォームのカード・入力欄・チップ・アイコン背景で使う `--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）の2トークン。以前はこれらが `#f0e68c` / `#ffffff` / `bg-white` としてハードコードされ、テーマ切替から取り残されていた（#388 で「戻せない」と判明した直接原因）。
+- **新しいテーマを足すときは `themes/` に CSS を1つ追加するだけ**でよい（`current.css` を複製して値を変える）。手で `globals.css` の `:root` を直接編集した場合は、巻き戻し先である `themes/current.css` も同じ内容に揃えること（UT `apply-theme.test.ts` が両者の一致を検査する）。
+- **既知の制約（本 Issue #389 のスコープ外）**: `globals.css` の既存 HSL トークン（`--background` / `--primary` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` などは現状レンダリング上は無色（透明）で機能していない。そのため `amber-dark` でも「帯・操作面（`--surface-*`）」以外の面はダーク化しない。全画面のダークテーマ化・実行時テーマトグル（next-themes 等）は別 Issue で扱う。本 Issue のトークン化がその前提基盤になる。
+
+---
+
 ## 🌐 プレビュー環境（develop 追従）
 
 `develop` ブランチに push されると、GitHub Actions が Vercel に自動デプロイし、以下の固定 URL を最新ビルドに付け替える。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
 		"build": "pnpm db:generate && next build",
 		"db:generate": "prisma generate --schema=../../prisma/schema.prisma",
 		"start": "next start",
+		"theme": "tsx scripts/apply-theme.ts",
 		"typecheck": "tsc --noEmit",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",

--- a/apps/web/scripts/apply-theme.test.ts
+++ b/apps/web/scripts/apply-theme.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { extractRootBlock, listThemes, replaceThemeBlock } from "./apply-theme";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(scriptDir, "..");
+const themesDir = join(webRoot, "src", "styles", "themes");
+const globalsPath = join(webRoot, "src", "app", "globals.css");
+
+describe("extractRootBlock", () => {
+	it(":root ブロックのみを抜き出す（前後のコメント・他セレクタは含めない）", () => {
+		const css = `/* comment */\n:root {\n  --a: 1;\n  --b: #fff;\n}\n.other { color: red; }`;
+		expect(extractRootBlock(css)).toBe(":root {\n  --a: 1;\n  --b: #fff;\n}");
+	});
+
+	it(":root が無い CSS はエラーになる", () => {
+		expect(() => extractRootBlock(".foo { color: red; }")).toThrow(
+			/:root ブロックが見つかりません/,
+		);
+	});
+});
+
+describe("replaceThemeBlock", () => {
+	const base = [
+		"header",
+		"/* THEME:START */",
+		":root {",
+		"  --old: 1;",
+		"}",
+		"/* THEME:END */",
+		"footer",
+	].join("\n");
+
+	it("マーカー間を新しい :root ブロックに差し替え、マーカー自体は残す", () => {
+		const result = replaceThemeBlock(base, ":root {\n  --new: 2;\n}");
+		expect(result).toBe(
+			[
+				"header",
+				"/* THEME:START */",
+				":root {",
+				"  --new: 2;",
+				"}",
+				"/* THEME:END */",
+				"footer",
+			].join("\n"),
+		);
+	});
+
+	it("繰り返し適用しても冪等（同じテーマを2回当てても結果が変わらない）", () => {
+		const once = replaceThemeBlock(base, ":root {\n  --new: 2;\n}");
+		const twice = replaceThemeBlock(once, ":root {\n  --new: 2;\n}");
+		expect(twice).toBe(once);
+	});
+
+	it("current → amber-dark → current で元の内容に戻る", () => {
+		const currentBlock = ":root {\n  --surface-panel: #f0e68c;\n}";
+		const darkBlock = ":root {\n  --surface-panel: #2a1c0e;\n}";
+		const toDark = replaceThemeBlock(base, darkBlock);
+		const backToCurrent = replaceThemeBlock(toDark, currentBlock);
+		expect(replaceThemeBlock(base, currentBlock)).toBe(backToCurrent);
+	});
+
+	it("開始マーカーが無いとエラーになる", () => {
+		expect(() => replaceThemeBlock("no markers here", ":root {}")).toThrow(
+			/開始マーカー/,
+		);
+	});
+
+	it("終了マーカーが無いとエラーになる", () => {
+		expect(() =>
+			replaceThemeBlock("/* THEME:START */\n:root {}", ":root {}"),
+		).toThrow(/終了マーカー/);
+	});
+});
+
+describe("テーマファイルと globals.css の整合", () => {
+	it("current テーマの :root ブロックが globals.css の現在のブロックと一致する（デグレ検出）", () => {
+		const globalsCss = readFileSync(globalsPath, "utf8");
+		const currentCss = readFileSync(join(themesDir, "current.css"), "utf8");
+		const currentBlock = extractRootBlock(currentCss);
+		const reapplied = replaceThemeBlock(globalsCss, currentBlock);
+		// current を適用しても globals.css が変わらない = 現在 globals.css は current テーマそのもの
+		expect(reapplied).toBe(globalsCss);
+	});
+
+	it("amber-dark 適用で --surface-panel / --surface-control がダーク値に切り替わる", () => {
+		const globalsCss = readFileSync(globalsPath, "utf8");
+		const darkCss = readFileSync(join(themesDir, "amber-dark.css"), "utf8");
+		const darkBlock = extractRootBlock(darkCss);
+		const applied = replaceThemeBlock(globalsCss, darkBlock);
+		expect(applied).toContain("--surface-panel: #2a1c0e;");
+		expect(applied).toContain("--surface-control: #3d2b17;");
+		// current 固有の白帯・白操作面は消えている
+		expect(applied).not.toContain("--surface-panel: #f0e68c;");
+		expect(applied).not.toContain("--surface-control: #ffffff;");
+	});
+
+	it("listThemes が current と amber-dark を返す", () => {
+		const themes = listThemes(themesDir);
+		expect(themes).toContain("current");
+		expect(themes).toContain("amber-dark");
+	});
+});

--- a/apps/web/scripts/apply-theme.ts
+++ b/apps/web/scripts/apply-theme.ts
@@ -1,0 +1,113 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const THEME_START = "/* THEME:START";
+const THEME_END = "/* THEME:END */";
+
+/**
+ * globals.css の THEME:START 〜 THEME:END の間（開始マーカー行の直後〜終了マーカー行の直前）を
+ * 指定テーマの `:root { ... }` ブロックへ差し替える。
+ * マーカー行自体は残す（次回以降の差し替え対象を維持するため）。
+ */
+export function replaceThemeBlock(
+	globalsCss: string,
+	themeRootBlock: string,
+): string {
+	const startLineIdx = globalsCss.indexOf(THEME_START);
+	if (startLineIdx === -1) {
+		throw new Error(
+			`globals.css に開始マーカー "${THEME_START}" が見つかりません。`,
+		);
+	}
+	// 開始マーカーはコメント行なので、その行末（改行）までを前置きとして保持する
+	const startLineEnd = globalsCss.indexOf("\n", startLineIdx);
+	if (startLineEnd === -1) {
+		throw new Error("開始マーカー行の改行が見つかりません。");
+	}
+
+	const endIdx = globalsCss.indexOf(THEME_END, startLineEnd);
+	if (endIdx === -1) {
+		throw new Error(
+			`globals.css に終了マーカー "${THEME_END}" が見つかりません。`,
+		);
+	}
+
+	const head = globalsCss.slice(0, startLineEnd + 1);
+	const tail = globalsCss.slice(endIdx);
+	const block = `${themeRootBlock.trimEnd()}\n`;
+	return `${head}${block}${tail}`;
+}
+
+/**
+ * テーマ CSS（`:root { ... }` を含む）から `:root { ... }` ブロックだけを抜き出す。
+ * テーマファイルにコメント等の付随行があっても、差し替えるのは :root ブロックに限定する。
+ */
+export function extractRootBlock(themeCss: string): string {
+	const rootIdx = themeCss.indexOf(":root");
+	if (rootIdx === -1) {
+		throw new Error("テーマ CSS に :root ブロックが見つかりません。");
+	}
+	const openBrace = themeCss.indexOf("{", rootIdx);
+	if (openBrace === -1) {
+		throw new Error("テーマ CSS の :root に { が見つかりません。");
+	}
+	// ネストしない前提（:root 直下のフラットな宣言のみ）で対応する } を探す
+	const closeBrace = themeCss.indexOf("}", openBrace);
+	if (closeBrace === -1) {
+		throw new Error("テーマ CSS の :root に } が見つかりません。");
+	}
+	return themeCss.slice(rootIdx, closeBrace + 1);
+}
+
+function resolveDirs() {
+	const scriptDir = dirname(fileURLToPath(import.meta.url));
+	const webRoot = join(scriptDir, "..");
+	return {
+		themesDir: join(webRoot, "src", "styles", "themes"),
+		globalsPath: join(webRoot, "src", "app", "globals.css"),
+	};
+}
+
+export function listThemes(themesDir: string): string[] {
+	return readdirSync(themesDir)
+		.filter((f) => f.endsWith(".css"))
+		.map((f) => f.replace(/\.css$/, ""))
+		.sort();
+}
+
+function main() {
+	const themeName = process.argv[2];
+	const { themesDir, globalsPath } = resolveDirs();
+	const available = listThemes(themesDir);
+
+	if (!themeName) {
+		console.error(
+			`テーマ名を指定してください。\n利用可能なテーマ: ${available.join(", ")}\n例: pnpm --filter @beersalon/web theme current`,
+		);
+		process.exit(1);
+	}
+
+	if (!available.includes(themeName)) {
+		console.error(
+			`テーマ "${themeName}" は存在しません。\n利用可能なテーマ: ${available.join(", ")}`,
+		);
+		process.exit(1);
+	}
+
+	const themeCss = readFileSync(join(themesDir, `${themeName}.css`), "utf8");
+	const rootBlock = extractRootBlock(themeCss);
+	const globalsCss = readFileSync(globalsPath, "utf8");
+	const next = replaceThemeBlock(globalsCss, rootBlock);
+	writeFileSync(globalsPath, next);
+
+	console.log(
+		`テーマ "${themeName}" を globals.css に適用しました。pnpm dev で反映されます。`,
+	);
+}
+
+// Why not import 時に副作用を走らせない: UT から純関数のみを import できるよう、
+// 直接実行時（このファイルがエントリポイント）だけ main() を呼ぶ。
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main();
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -37,12 +37,15 @@
 	--color-popover: var(--popover);
 	--color-card-foreground: var(--card-foreground);
 	--color-card: var(--card);
+	--color-surface-panel: var(--surface-panel);
+	--color-surface-control: var(--surface-control);
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
 }
 
+/* THEME:START (このブロックは pnpm theme <name> で src/styles/themes/<name>.css の内容に差し替わる。手編集する場合は themes/current.css も揃えること) */
 :root {
 	--radius: 1rem;
 	--background: 35 25% 92%;
@@ -76,7 +79,10 @@
 	--sidebar-accent-foreground: 30 15% 20%;
 	--sidebar-border: 35 15% 82%;
 	--sidebar-ring: 30 75% 45%;
+	--surface-panel: #f0e68c;
+	--surface-control: #ffffff;
 }
+/* THEME:END */
 
 .dark {
 	--background: oklch(0.145 0 0);

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -10,10 +10,7 @@ export function Footer() {
 	const isActive = (path: string) => pathname === path;
 
 	return (
-		<footer
-			className="fixed bottom-0 left-0 right-0 backdrop-blur-xl border-t border-border/20 z-50 modern-shadow"
-			style={{ backgroundColor: "#f0e68c" }}
-		>
+		<footer className="fixed bottom-0 left-0 right-0 bg-surface-panel backdrop-blur-xl border-t border-border/20 z-50 modern-shadow">
 			<div className="max-w-7xl mx-auto px-4">
 				<nav className="flex items-center justify-around h-16">
 					<Link
@@ -23,8 +20,8 @@ export function Footer() {
 						<div
 							className={`p-2 rounded-full transition-all duration-300 ${
 								isActive("/favorites/bars")
-									? "bg-white scale-110"
-									: "bg-white/80 hover:bg-white hover:scale-105"
+									? "bg-surface-control scale-110"
+									: "bg-surface-control/80 hover:bg-surface-control hover:scale-105"
 							}`}
 						>
 							<Star
@@ -43,8 +40,8 @@ export function Footer() {
 						<div
 							className={`p-2 rounded-full transition-all duration-300 ${
 								isActive("/timeline")
-									? "bg-white scale-110"
-									: "bg-white/80 hover:bg-white hover:scale-105"
+									? "bg-surface-control scale-110"
+									: "bg-surface-control/80 hover:bg-surface-control hover:scale-105"
 							}`}
 						>
 							<FileText
@@ -63,8 +60,8 @@ export function Footer() {
 						<div
 							className={`p-2 rounded-full transition-all duration-300 ${
 								isActive("/posts/new")
-									? "bg-white scale-110"
-									: "bg-white/80 hover:bg-white hover:scale-105"
+									? "bg-surface-control scale-110"
+									: "bg-surface-control/80 hover:bg-surface-control hover:scale-105"
 							}`}
 						>
 							<PlusCircle
@@ -83,8 +80,8 @@ export function Footer() {
 						<div
 							className={`p-2 rounded-full transition-all duration-300 ${
 								isActive("/history/bars")
-									? "bg-white scale-110"
-									: "bg-white/80 hover:bg-white hover:scale-105"
+									? "bg-surface-control scale-110"
+									: "bg-surface-control/80 hover:bg-surface-control hover:scale-105"
 							}`}
 						>
 							<Clock

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -8,10 +8,7 @@ export async function Header() {
 	const unreadCount = await getUnreadNotificationCount();
 
 	return (
-		<header
-			className="fixed top-0 left-0 right-0 backdrop-blur-xl border-b border-border/20 z-50 modern-shadow"
-			style={{ backgroundColor: "#f0e68c" }}
-		>
+		<header className="fixed top-0 left-0 right-0 bg-surface-panel backdrop-blur-xl border-b border-border/20 z-50 modern-shadow">
 			<div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
 				<Link
 					href="/"
@@ -30,7 +27,7 @@ export async function Header() {
 				<div className="flex items-center gap-2">
 					<Link
 						href="/notifications"
-						className="p-2.5 text-foreground bg-white hover:bg-white/80 rounded-full transition-all duration-300 relative"
+						className="p-2.5 text-foreground bg-surface-control hover:bg-surface-control/80 rounded-full transition-all duration-300 relative"
 						aria-label="通知"
 						data-testid="notification-icon"
 					>
@@ -47,7 +44,7 @@ export async function Header() {
 
 					<Link
 						href="/mypage"
-						className="p-2.5 text-foreground bg-white hover:bg-white/80 rounded-full transition-all duration-300"
+						className="p-2.5 text-foreground bg-surface-control hover:bg-surface-control/80 rounded-full transition-all duration-300"
 						aria-label="マイページ"
 					>
 						<User className="w-5 h-5" />
@@ -56,7 +53,7 @@ export async function Header() {
 					<form action={logout}>
 						<button
 							type="submit"
-							className="p-2.5 text-foreground bg-white hover:bg-white/80 rounded-full transition-all duration-300"
+							className="p-2.5 text-foreground bg-surface-control hover:bg-surface-control/80 rounded-full transition-all duration-300"
 							aria-label="ログアウト"
 						>
 							<LogOut className="w-5 h-5" />

--- a/apps/web/src/components/search/search-form.tsx
+++ b/apps/web/src/components/search/search-form.tsx
@@ -89,10 +89,7 @@ export function SearchForm({ initialValues, onSearch }: SearchFormProps) {
 	};
 
 	return (
-		<div
-			className="p-6 md:p-8 rounded-2xl modern-shadow animate-fade-in"
-			style={{ backgroundColor: "#f0e68c" }}
-		>
+		<div className="p-6 md:p-8 rounded-2xl modern-shadow animate-fade-in bg-surface-panel">
 			<div className="mb-4">
 				<label
 					htmlFor="search-keyword"
@@ -111,8 +108,7 @@ export function SearchForm({ initialValues, onSearch }: SearchFormProps) {
 								handleKeywordSearch();
 							}
 						}}
-						className="glass-input flex-1 px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
-						style={{ backgroundColor: "#ffffff" }}
+						className="flex-1 px-4 py-3 rounded-xl bg-surface-control backdrop-blur-sm border border-border/30 text-card-foreground focus:outline-none focus:border-primary/50 focus:ring-2 focus:ring-primary/20 transition-all duration-300"
 					/>
 					<button
 						type="button"
@@ -137,8 +133,7 @@ export function SearchForm({ initialValues, onSearch }: SearchFormProps) {
 						id="city"
 						value={selectedCity}
 						onChange={(e) => handleCityChange(e.target.value)}
-						className="glass-input w-full px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
-						style={{ backgroundColor: "#ffffff" }}
+						className="w-full px-4 py-3 rounded-xl bg-surface-control backdrop-blur-sm border border-border/30 text-card-foreground focus:outline-none focus:border-primary/50 focus:ring-2 focus:ring-primary/20 transition-all duration-300"
 					>
 						<option value="">全て</option>
 						{SHIZUOKA_CITIES.map((city) => (
@@ -165,7 +160,7 @@ export function SearchForm({ initialValues, onSearch }: SearchFormProps) {
 									className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
 										isSelected
 											? "bg-primary text-primary-foreground"
-											: "bg-white text-card-foreground hover:opacity-80"
+											: "bg-surface-control text-card-foreground hover:opacity-80"
 									}`}
 								>
 									{isSelected ? `✓ ${category}` : category}
@@ -186,8 +181,7 @@ export function SearchForm({ initialValues, onSearch }: SearchFormProps) {
 						id="origin"
 						value={selectedOrigin}
 						onChange={(e) => handleOriginChange(e.target.value)}
-						className="glass-input w-full px-4 py-3 rounded-xl text-card-foreground focus:outline-none transition-all duration-300"
-						style={{ backgroundColor: "#ffffff" }}
+						className="w-full px-4 py-3 rounded-xl bg-surface-control backdrop-blur-sm border border-border/30 text-card-foreground focus:outline-none focus:border-primary/50 focus:ring-2 focus:ring-primary/20 transition-all duration-300"
 					>
 						<option value="">全て</option>
 						{Object.entries(origins).map(([country, regions]) => (

--- a/apps/web/src/styles/themes/amber-dark.css
+++ b/apps/web/src/styles/themes/amber-dark.css
@@ -1,0 +1,47 @@
+:root {
+	--radius: 1rem;
+	/*
+	 * #383 案A: ダークブラウン × アンバーゴールド。
+	 * 本 Issue（#389）のスコープは「切替を阻害していた header/footer/search-form の
+	 * ハードコード色」＝新設した --surface-panel / --surface-control のみをダーク化する。
+	 * それ以外の既存トークン（--background / --primary / --card-foreground / --border など）は
+	 * 現状 hsl() ラップされておらず色として機能していない（bg-primary 等は透明）ため、
+	 * ここで有効な色値に置き換えると current では見えていなかった色が amber-dark でのみ
+	 * 出現し、テーマ間の非対称（＝実質デグレ）になる。全トークンの有効化・全画面ダーク化は
+	 * 別 Issue（実行時テーマトグル基盤）に委ね、本テーマは current と同じ据え置き値を保つ。
+	 */
+	--background: 35 25% 92%;
+	--foreground: 30 15% 20%;
+	--card: 35 20% 96%;
+	--card-foreground: 30 15% 25%;
+	--popover: 35 20% 96%;
+	--popover-foreground: 30 15% 25%;
+	--primary: 30 75% 45%;
+	--primary-foreground: 0 0% 100%;
+	--secondary: 35 60% 55%;
+	--secondary-foreground: 30 15% 20%;
+	--muted: 35 20% 85%;
+	--muted-foreground: 30 10% 45%;
+	--accent: 30 50% 88%;
+	--accent-foreground: 30 75% 40%;
+	--destructive: 0 84% 60%;
+	--border: 35 15% 82%;
+	--input: 35 15% 82%;
+	--ring: 30 75% 45%;
+	--chart-1: 30 75% 45%;
+	--chart-2: 35 60% 55%;
+	--chart-3: 40 65% 50%;
+	--chart-4: 25 70% 50%;
+	--chart-5: 35 55% 60%;
+	--sidebar: 35 20% 96%;
+	--sidebar-foreground: 30 15% 20%;
+	--sidebar-primary: 30 75% 45%;
+	--sidebar-primary-foreground: 0 0% 100%;
+	--sidebar-accent: 35 20% 90%;
+	--sidebar-accent-foreground: 30 15% 20%;
+	--sidebar-border: 35 15% 82%;
+	--sidebar-ring: 30 75% 45%;
+	/* #383 案A: 帯（header/footer/search カード）＝ダークブラウン、操作面（入力欄・チップ・アイコン）＝一段明るいブラウン */
+	--surface-panel: #2a1c0e;
+	--surface-control: #3d2b17;
+}

--- a/apps/web/src/styles/themes/current.css
+++ b/apps/web/src/styles/themes/current.css
@@ -1,0 +1,36 @@
+:root {
+	--radius: 1rem;
+	--background: 35 25% 92%;
+	--foreground: 30 15% 20%;
+	--card: 35 20% 96%;
+	--card-foreground: 30 15% 25%;
+	--popover: 35 20% 96%;
+	--popover-foreground: 30 15% 25%;
+	--primary: 30 75% 45%;
+	--primary-foreground: 0 0% 100%;
+	--secondary: 35 60% 55%;
+	--secondary-foreground: 30 15% 20%;
+	--muted: 35 20% 85%;
+	--muted-foreground: 30 10% 45%;
+	--accent: 30 50% 88%;
+	--accent-foreground: 30 75% 40%;
+	--destructive: 0 84% 60%;
+	--border: 35 15% 82%;
+	--input: 35 15% 82%;
+	--ring: 30 75% 45%;
+	--chart-1: 30 75% 45%;
+	--chart-2: 35 60% 55%;
+	--chart-3: 40 65% 50%;
+	--chart-4: 25 70% 50%;
+	--chart-5: 35 55% 60%;
+	--sidebar: 35 20% 96%;
+	--sidebar-foreground: 30 15% 20%;
+	--sidebar-primary: 30 75% 45%;
+	--sidebar-primary-foreground: 0 0% 100%;
+	--sidebar-accent: 35 20% 90%;
+	--sidebar-accent-foreground: 30 15% 20%;
+	--sidebar-border: 35 15% 82%;
+	--sidebar-ring: 30 75% 45%;
+	--surface-panel: #f0e68c;
+	--surface-control: #ffffff;
+}


### PR DESCRIPTION
## 概要

配色を「テーマ」として差し替え可能にするための基盤整備。デザインを変えても**容易に前のデザインへ戻せる**ようにする（#388 で配色変更が「一発で戻せない」と判明した根本原因＝ハードコード色の点在を解消）。

Closes #389

## 根本原因（調査で判明した新事実）

配色が2レイヤーに分裂していた:
- **トークン層**: `globals.css` の `:root`。ただし既存 HSL トークン（`--background: 35 25% 92%` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` は**レンダリング上は透明で機能していない**（Tailwind ビルド出力で確認）。有効なのは `.dark` の `oklch` のみ。
- **ハードコード層**: header/footer/search-form が `#f0e68c`（カーキ帯）/ `#ffffff`（入力欄）/ `bg-white`（アイコン・チップ）を直接焼き込み。**現状の画面はこのハードコード色だけが見えている状態**だった。

→ `:root` を差し替えてもこの3ファイルが取り残される。これが「戻せない」直接原因。

## 変更内容

### トークン化（#389 明記の3ファイル）
| ファイル | 置換前 → 置換後 |
|---|---|
| `header.tsx` | `#f0e68c`帯 / `bg-white`アイコン → `bg-surface-panel` / `bg-surface-control` |
| `footer.tsx` | `#f0e68c`帯 / `bg-white`ナビ → `bg-surface-panel` / `bg-surface-control` |
| `search-form.tsx` | `#f0e68c`カード / `#ffffff`入力欄×3 / `bg-white`チップ → `bg-surface-panel` / `bg-surface-control` |

`--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）を**有効な CSS 色値**で新設し `@theme inline` にマップ。入力欄は `glass-input`（`bg-card-foreground/5`）が後勝ちで白ベタを打ち消すため、背景以外の個別ユーティリティに展開して背景を `bg-surface-control` で確定させた（デグレ回避）。

### テーマ切替の仕組み
- `apps/web/src/styles/themes/current.css`（巻き戻し先）/ `amber-dark.css`（#383 案A）
- `globals.css` の `:root` を `/* THEME:START〜END */` で囲み差し替え対象を明示
- `apps/web/scripts/apply-theme.ts` + `pnpm --filter @beersalon/web theme <name>`

```bash
pnpm --filter @beersalon/web theme amber-dark  # ダークブラウン×アンバー
pnpm --filter @beersalon/web theme current     # 巻き戻し
```

## テスト

### UT（Vitest）
- `apply-theme.test.ts`（10 ケース）: 置換ロジック・マーカー欠落エラー・**current テーマと globals.css の一致（デグレ検出）**・amber-dark 切替・**往復巻き戻しの冪等/完全一致**
- 既存 UT を含め **381 テスト全緑**（DOM 構造・要素は不変）

### E2E（Playwright MCP 実機）
ローカル Supabase + dev server でログイン後トップページを目視確認（スクショは下記コメントで添付）:
- current: カーキ帯・白入力欄・白チップ・白アイコン（リファクタ前と一致）
- amber-dark: 帯・入力欄・チップ・アイコンが**ダークブラウンへ一貫追従**（取り残しなし）
- current 巻き戻し: 完全に元へ復帰

配色回帰はスクショ比較が必要で E2E アサーションに不向きなため、常設 E2E コードは追加せず UT で担保（テストピラミッド原則）。

## スコープ外（別 Issue 前提）

既存の壊れた HSL トークン（`--background` / `--primary` 等）の `hsl()` 有効化・全画面ダーク化・実行時テーマトグル（next-themes）は本 Issue 対象外。`amber-dark` でも `--surface-*` 以外の面はダーク化しない（有効化すると current との非対称＝実質デグレになるため）。本 Issue のトークン化がその前提基盤になる。

## 破壊的変更

なし（DB・API・Props 変更なし。純リファクタ + 開発者向けスクリプト追加）。