### PR TITLE
トップページを案A（Amber Taproom / ダーク基調）に刷新する (#388)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,16 @@ pnpm --filter @beersalon/web theme amber-dark
 - `pnpm theme <name>` は `apps/web/src/app/globals.css` 内の `/* THEME:START */` 〜 `/* THEME:END */` で囲まれた `:root` ブロックを、指定テーマの内容へ差し替える。反映は `pnpm dev` の再ビルド / ブラウザリロードで行われる。
 - 切替が一貫して追従するのは、共通ヘッダー / フッターの帯・検索フォームのカード・入力欄・チップ・アイコン背景で使う `--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）の2トークン。以前はこれらが `#f0e68c` / `#ffffff` / `bg-white` としてハードコードされ、テーマ切替から取り残されていた（#388 で「戻せない」と判明した直接原因）。
 - **新しいテーマを足すときは `themes/` に CSS を1つ追加するだけ**でよい（`current.css` を複製して値を変える）。手で `globals.css` の `:root` を直接編集した場合は、巻き戻し先である `themes/current.css` も同じ内容に揃えること（UT `apply-theme.test.ts` が両者の一致を検査する）。
-- **既知の制約（本 Issue #389 のスコープ外）**: `globals.css` の既存 HSL トークン（`--background` / `--primary` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` などは現状レンダリング上は無色（透明）で機能していない。そのため `amber-dark` でも「帯・操作面（`--surface-*`）」以外の面はダーク化しない。全画面のダークテーマ化・実行時テーマトグル（next-themes 等）は別 Issue で扱う。本 Issue のトークン化がその前提基盤になる。
+- **既知の制約**: `globals.css` の既存 HSL トークン（`--background` / `--primary` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` などは現状レンダリング上は無色（透明）で機能していない。そのため `theme amber-dark`（ビルド時切替）でも「帯・操作面（`--surface-*`）」以外の面はダーク化しない。全画面のダークテーマ化・実行時テーマトグル（next-themes 等）は別 Issue で扱う。
+
+### トップページ（`/`）のダーク基調（#388 案A / Amber Taproom）
+
+トップページ（`apps/web` の `/`）は、上記のビルド時テーマ切替とは別に、**トップページ限定でダークブラウン × アンバーゴールド基調**に固定している（#383 案A）。
+
+- 実装は `globals.css` の `.top-amber-dark` スコープと、`page-client.tsx` の最上位ラッパへのクラス付与。トップの本文背景・検索カード・入力欄・チップ・店舗カード・各「人気で探す」セクションがこのスコープ配下でダーク化される。
+- **なぜ `:root` ごとダーク化しないか**: 上記の既知の制約どおり `bg-card` / `text-foreground` 等は透明で機能しておらず、`:root` を有効化すると web 全体（他ページ・共通ヘッダー/フッター）へダークが芋づる波及する。#388 のスコープはトップページの見た目に限定のため、`.top-amber-dark` 配下だけに閉じ込めている。
+- **スコープ外**: 共通ヘッダー / フッターの帯（`--surface-panel` = クリーム）と、トップ以外の14ページはライト基調のまま。全画面ダーク化は別 Issue。
+- スコープが `THEME:START`〜`THEME:END` の外にあること・`:root` が current のライト値のままであることは UT `apply-theme.test.ts` が検査する。
 
 ---
 

--- a/apps/web/scripts/apply-theme.test.ts
+++ b/apps/web/scripts/apply-theme.test.ts
@@ -103,3 +103,37 @@ describe("テーマファイルと globals.css の整合", () => {
 		expect(themes).toContain("amber-dark");
 	});
 });
+
+describe("トップページ限定ダークスコープ（#388 案A）", () => {
+	const globalsCss = readFileSync(globalsPath, "utf8");
+
+	it("globals.css にトップ限定スコープ .top-amber-dark が定義されている", () => {
+		expect(globalsCss).toContain(".top-amber-dark");
+	});
+
+	it("スコープ定義は THEME:START〜THEME:END の外にあり、テーマ切替ブロックを侵さない", () => {
+		const startIdx = globalsCss.indexOf("/* THEME:START");
+		const endIdx = globalsCss.indexOf("/* THEME:END */");
+		const themeBlock = globalsCss.slice(startIdx, endIdx);
+		// Why not スコープを :root(THEMEブロック)内に置く: そこへ書くと apply-theme が
+		// 差し替え対象にしてテーマ切替で消える。スコープは THEME ブロックの外に置く。
+		expect(themeBlock).not.toContain(".top-amber-dark");
+	});
+
+	it("スコープ内で surface トークンを案Aのダーク値へ上書きしている", () => {
+		const scopeIdx = globalsCss.indexOf(".top-amber-dark {");
+		const scopeEnd = globalsCss.indexOf("}", scopeIdx);
+		const scopeBlock = globalsCss.slice(scopeIdx, scopeEnd);
+		expect(scopeBlock).toContain("--surface-panel: #2a1c0e;");
+		expect(scopeBlock).toContain("--surface-control: #3d2b17;");
+	});
+
+	it("THEME ブロック（:root）は現行 current のライト値のまま（全画面ダーク化していない）", () => {
+		const startIdx = globalsCss.indexOf("/* THEME:START");
+		const endIdx = globalsCss.indexOf("/* THEME:END */");
+		const themeBlock = globalsCss.slice(startIdx, endIdx);
+		// current のライト基調（帯=クリーム / 操作面=白）が :root に維持されていること
+		expect(themeBlock).toContain("--surface-panel: #f0e68c;");
+		expect(themeBlock).toContain("--surface-control: #ffffff;");
+	});
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -127,6 +127,45 @@
 	}
 }
 
+/*
+ * トップページ（/）限定の案A（Amber Taproom / ダーク基調）スコープ。
+ * Why not :root ごとダーク化: globals.css の既存 HSL トークン（--background / --card / --card-foreground 等）は
+ * @theme inline で hsl() ラップされておらず bg-card / text-foreground 等は透明で機能していない。
+ * これを :root で有効化すると web 全体（他14ページ・共通ヘッダー/フッター）へダークが芋づる波及し、
+ * Issue #388 が明示的にスコープ外とした「全画面ダーク化」になる。よってトップの最上位ラッパに付与した
+ * .top-amber-dark の配下だけで、実 CSS 値の背景・面・テキスト色を当ててダーク化を閉じ込める。
+ */
+.top-amber-dark {
+	/* 案A: ダークブラウン基調の本文背景とアンバー寄りのテキスト */
+	background-color: #1a1206;
+	color: #f5e9d4;
+
+	/* 帯（検索カード）＝ダークブラウン、操作面（入力欄・チップ）＝一段明るいブラウン。
+	   surface トークンはスコープ内で上書きし、テーマ切替(current)の他画面には影響させない。 */
+	--surface-panel: #2a1c0e;
+	--surface-control: #3d2b17;
+}
+
+/* 透明で機能していない壊れトークン依存クラスを、スコープ配下で実色に置換する。 */
+.top-amber-dark .bg-card {
+	background-color: #241a0c;
+}
+.top-amber-dark .text-card-foreground {
+	color: #f5e9d4;
+}
+.top-amber-dark .text-foreground {
+	color: #f5e9d4;
+}
+.top-amber-dark .text-muted-foreground {
+	color: #c4a878;
+}
+.top-amber-dark .bg-muted {
+	background-color: #3d2b17;
+}
+.top-amber-dark .border-border {
+	border-color: #4a3620;
+}
+
 @layer utilities {
 	.glass-card {
 		@apply bg-card/80 backdrop-blur-xl border border-border/20 shadow-2xl;

--- a/apps/web/src/app/page-client.tsx
+++ b/apps/web/src/app/page-client.tsx
@@ -228,52 +228,54 @@ export function HomeClient() {
 	];
 
 	return (
-		<div className="max-w-7xl mx-auto px-4 py-8 md:py-12">
-			<div className="flex flex-col gap-8 md:gap-12">
-				{/* 検索セクション */}
-				{/* Why not: 制御 input の value を毎レンダリング上書きすると入力中のIME変換が
+		<div className="top-amber-dark min-h-screen px-4 py-8 md:py-12">
+			<div className="max-w-7xl mx-auto">
+				<div className="flex flex-col gap-8 md:gap-12">
+					{/* 検索セクション */}
+					{/* Why not: 制御 input の value を毎レンダリング上書きすると入力中のIME変換が
 				    途切れるため、URL の q/city が変わったときだけ key で再マウントして初期値を反映する。 */}
-				<SearchForm
-					key={`${urlQuery}|${urlCity}`}
-					initialValues={searchParams}
-					onSearch={handleSearch}
-				/>
+					<SearchForm
+						key={`${urlQuery}|${urlCity}`}
+						initialValues={searchParams}
+						onSearch={handleSearch}
+					/>
 
-				{/* 地図エリア */}
-				<GoogleMap city={searchParams.city} bars={bars} />
+					{/* 地図エリア */}
+					<GoogleMap city={searchParams.city} bars={bars} />
 
-				{/* 店舗一覧 */}
-				<BarList bars={bars} isLoading={isBarsLoading} />
+					{/* 店舗一覧 */}
+					<BarList bars={bars} isLoading={isBarsLoading} />
 
-				{/* クラフトビールについて知る */}
-				<LearnAboutCraftBeerCard />
+					{/* クラフトビールについて知る */}
+					<LearnAboutCraftBeerCard />
 
-				{/* 先月いいねの多かった記事 */}
-				<PopularArticlesSection articles={mockPopularArticles} />
+					{/* 先月いいねの多かった記事 */}
+					<PopularArticlesSection articles={mockPopularArticles} />
 
-				{/* 人気なお店で探す */}
-				<PopularBarsSection title="人気なお店で探す" bars={mockPopularBars} />
+					{/* 人気なお店で探す */}
+					<PopularBarsSection title="人気なお店で探す" bars={mockPopularBars} />
 
-				{/* 人気な市町村で探す */}
-				<PopularCitiesSection
-					title="人気な市町村で探す"
-					cities={mockPopularCities}
-				/>
+					{/* 人気な市町村で探す */}
+					<PopularCitiesSection
+						title="人気な市町村で探す"
+						cities={mockPopularCities}
+					/>
 
-				{/* 人気なカテゴリのビールで探す */}
-				<PopularCategoriesSection
-					title="人気なカテゴリのビールで探す"
-					categories={mockPopularCategories}
-				/>
+					{/* 人気なカテゴリのビールで探す */}
+					<PopularCategoriesSection
+						title="人気なカテゴリのビールで探す"
+						categories={mockPopularCategories}
+					/>
 
-				{/* 人気なビールの産地で探す */}
-				<PopularRegionsSection
-					title="人気なビールの産地で探す"
-					regions={mockPopularRegions}
-				/>
+					{/* 人気なビールの産地で探す */}
+					<PopularRegionsSection
+						title="人気なビールの産地で探す"
+						regions={mockPopularRegions}
+					/>
 
-				{/* 利用規約エリア */}
-				<FooterLinks />
+					{/* 利用規約エリア */}
+					<FooterLinks />
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/home/footer-links.tsx
+++ b/apps/web/src/components/home/footer-links.tsx
@@ -2,25 +2,25 @@ import Link from "next/link";
 
 export function FooterLinks() {
 	return (
-		<footer className="w-full border-t border-gray-200 pt-8">
-			<div className="flex flex-wrap gap-4 md:gap-6 justify-center text-sm text-gray-600">
-				<Link href="/terms" className="hover:text-amber-600 transition-colors">
+		<footer className="w-full border-t border-[#4a3620] pt-8">
+			<div className="flex flex-wrap gap-4 md:gap-6 justify-center text-sm text-[#c4a878]">
+				<Link href="/terms" className="hover:text-amber-400 transition-colors">
 					利用規約
 				</Link>
 				<Link
 					href="/privacy"
-					className="hover:text-amber-600 transition-colors"
+					className="hover:text-amber-400 transition-colors"
 				>
 					プライバシーポリシー
 				</Link>
 				<Link
 					href="/contact"
-					className="hover:text-amber-600 transition-colors"
+					className="hover:text-amber-400 transition-colors"
 				>
 					お問い合わせ
 				</Link>
 			</div>
-			<p className="text-center text-xs text-gray-500 mt-4">
+			<p className="text-center text-xs text-[#c4a878]/70 mt-4">
 				© 2026 Beer Salon. All rights reserved.
 			</p>
 		</footer>

--- a/apps/web/src/components/home/popular-articles-section.tsx
+++ b/apps/web/src/components/home/popular-articles-section.tsx
@@ -31,10 +31,10 @@ export function PopularArticlesSection({
 					<Link
 						key={article.id}
 						href={`/articles/${article.id}`}
-						className="group block bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
+						className="group block bg-[#241a0c] border border-[#4a3620] rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
 					>
 						{article.imageUrl ? (
-							<div className="relative h-48 bg-gray-200">
+							<div className="relative h-48 bg-[#3d2b17]">
 								<Image
 									src={article.imageUrl}
 									alt={article.title}
@@ -43,16 +43,16 @@ export function PopularArticlesSection({
 								/>
 							</div>
 						) : (
-							<div className="h-48 bg-gradient-to-br from-gray-100 to-gray-200 flex items-center justify-center">
-								<span className="text-gray-400 text-sm">No Image</span>
+							<div className="h-48 bg-gradient-to-br from-[#3d2b17] to-[#241a0c] flex items-center justify-center">
+								<span className="text-[#c4a878] text-sm">No Image</span>
 							</div>
 						)}
 						<div className="p-4">
-							<h3 className="font-bold text-lg mb-2 line-clamp-2 group-hover:text-amber-600 transition-colors">
+							<h3 className="font-bold text-lg mb-2 line-clamp-2 text-[#f5e9d4] group-hover:text-amber-400 transition-colors">
 								{article.title}
 							</h3>
-							<p className="text-sm text-gray-600 mb-2">{article.barName}</p>
-							<div className="flex items-center justify-between text-sm text-gray-500">
+							<p className="text-sm text-[#c4a878] mb-2">{article.barName}</p>
+							<div className="flex items-center justify-between text-sm text-[#c4a878]">
 								<time dateTime={article.publishedAt}>
 									{new Date(article.publishedAt).toLocaleDateString("ja-JP", {
 										year: "numeric",

--- a/apps/web/src/components/home/popular-bars-section.tsx
+++ b/apps/web/src/components/home/popular-bars-section.tsx
@@ -28,7 +28,7 @@ export function PopularBarsSection({ title, bars }: PopularBarsSectionProps) {
 			case 3:
 				return "bg-amber-700 text-white";
 			default:
-				return "bg-gray-300 text-gray-700";
+				return "bg-[#3d2b17] text-[#c4a878]";
 		}
 	};
 

--- a/apps/web/src/components/home/popular-categories-section.tsx
+++ b/apps/web/src/components/home/popular-categories-section.tsx
@@ -31,7 +31,7 @@ export function PopularCategoriesSection({
 			case 3:
 				return "bg-amber-700 text-white";
 			default:
-				return "bg-gray-300 text-gray-700";
+				return "bg-[#3d2b17] text-[#c4a878]";
 		}
 	};
 

--- a/apps/web/src/components/home/popular-cities-section.tsx
+++ b/apps/web/src/components/home/popular-cities-section.tsx
@@ -31,7 +31,7 @@ export function PopularCitiesSection({
 			case 3:
 				return "bg-amber-700 text-white";
 			default:
-				return "bg-gray-300 text-gray-700";
+				return "bg-[#3d2b17] text-[#c4a878]";
 		}
 	};
 

--- a/apps/web/src/components/home/popular-regions-section.tsx
+++ b/apps/web/src/components/home/popular-regions-section.tsx
@@ -31,7 +31,7 @@ export function PopularRegionsSection({
 			case 3:
 				return "bg-amber-700 text-white";
 			default:
-				return "bg-gray-300 text-gray-700";
+				return "bg-[#3d2b17] text-[#c4a878]";
 		}
 	};
 


### PR DESCRIPTION
## 概要

トップページ（ユーザー画面 `apps/web` の `/`）の配色を、#383 で提案したデザイン案A「Amber Taproom（夜のビアバー・ダークブラウン × アンバーゴールド）」に刷新する。

Closes #388

## 実装方式（A案: トップページにダークを閉じ込める）

`globals.css` の `:root`（テーマ切替ブロック）は**一切変更せず**、トップページ限定スコープ `.top-amber-dark` の配下だけでダーク化する。

- **なぜ `:root` ごとダーク化しないか**: `globals.css` の既存 HSL トークン（`--background` / `--card` / `--card-foreground` 等）は `@theme inline` で `hsl()` ラップされておらず、`bg-card` / `text-foreground` などは現状レンダリング上は透明で機能していない。`:root` を有効化して全画面ダーク化すると web 全体（他14ページ・共通ヘッダー/フッター）へダークが芋づる波及する。これは Issue が明示的にスコープ外とした「全画面ダーク化」に該当するため、`.top-amber-dark` 配下に閉じ込めた。
- **スコープ外（仕様どおり）**: 共通ヘッダー/フッターの帯（クリーム色 `--surface-panel`）、トップ以外の14ページはライト基調のまま。全画面ダーク化は別 Issue。

## 変更内容

- `globals.css`: トップ限定スコープ `.top-amber-dark` を追加。本文背景 `#1a1206` / テキスト `#f5e9d4`、surface トークンをダーク値（`#2a1c0e` / `#3d2b17`）に上書き。透明で機能していない壊れ HSL トークン依存クラス（`bg-card` / `text-card-foreground` / `text-foreground` / `text-muted-foreground` / `bg-muted` / `border-border`）をスコープ配下で実 CSS 値に置換。
- `page-client.tsx`: トップの最上位ラッパに `.top-amber-dark` を付与。
- `home/*`（articles / bars / cities / categories / regions / footer-links）: ハードコード色（`bg-white` / `text-gray-*` / `from-gray-*` / 順位バッジのグレー）をダーク背景で映える色へ調整。
- `apply-theme.test.ts`: スコープの存在・`THEME:START〜END` 非侵襲・`:root` がライト値維持を検査するUTを4件追加。
- `README.md`: 配色テーマ節にトップページ限定ダーク化の方式を追記。

## テスト

- **UT**: 385件パス（追加4件含む）。`pnpm format` / `pnpm lint` クリーン。本番ビルド成功。
- **E2E（Playwright MCP）**: 受入条件5項目を実ブラウザで検証。
  - トップ本文背景がダークブラウン `#1a1206`（クリーム色でない）
  - 検索カード `#2a1c0e` / 入力欄・チップ `#3d2b17` がアンバー系ダークで表示
  - レイアウト構成・セクション並び順が現行維持（snapshot 確認）
  - 市町村フィルタ実操作で `?city=沼津市` 同期・件数更新・コンソールエラー0（検索デグレなし）
  - ダーク背景 × クリームテキストでコントラスト確保・判読可能

## スコープ外（別 Issue 候補）

- `globals.css` の壊れ HSL トークンの `hsl()` ラップ有効化 ＋ 全画面ダークテーマ移行（41ファイル + 14ページ波及）
- 共通ヘッダー/フッターを含む全ページの案A統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)