### PR TITLE
fix(admin): プレビュー画像アップロード失敗の原因を可視化し回復導線を是正 (#392)

### DIFF
--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
@@ -159,7 +159,7 @@ describe("POST /api/bars/:barId/preview-image", () => {
 		expect(body.error).toBe("画像形式はJPEG、PNG、WebPのみ対応しています");
 	});
 
-	it("Storage アップロード失敗時、500 を返し実エラーはサーバーログにのみ出す（detailは返さない）", async () => {
+	it("Storage アップロード失敗時、admin には detail を返しログにも出す", async () => {
 		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		setupSupabase({
 			uploadResult: {
@@ -173,8 +173,8 @@ describe("POST /api/bars/:barId/preview-image", () => {
 
 		expect(response.status).toBe(500);
 		expect(body.error).toBe("画像のアップロードに失敗しました");
-		// Why not: 内部情報の外部露出を防ぐため detail はクライアントに返さない
-		expect(body.detail).toBeUndefined();
+		// Why not: admin は内部ユーザーのため詳細を返して原因追跡を容易にする
+		expect(body.detail).toBe("new row violates row-level security policy");
 		expect(consoleSpy).toHaveBeenCalledWith(
 			"[preview-image] storage upload failed:",
 			{ message: "new row violates row-level security policy" },
@@ -183,7 +183,35 @@ describe("POST /api/bars/:barId/preview-image", () => {
 		consoleSpy.mockRestore();
 	});
 
-	it("DB更新失敗時、500 を返し実エラーはサーバーログにのみ出す（detailは返さない）", async () => {
+	it("Storage アップロード失敗時、bar_owner には detail を返さない（ログには出す）", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		mockGetCurrentUser.mockResolvedValue({
+			id: "owner-1",
+			barManageId: "fuji-beer",
+			name: "オーナー",
+			role: "bar_owner" as const,
+			barId: 1,
+		});
+		setupSupabase({
+			uploadResult: {
+				data: null,
+				error: { message: "new row violates row-level security policy" },
+			},
+		});
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("画像のアップロードに失敗しました");
+		// Why not: 外部ユーザーへの内部情報露出を防ぐため detail は返さない
+		expect(body.detail).toBeUndefined();
+		expect(consoleSpy).toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("DB更新失敗時、admin には detail を返しログにも出す", async () => {
 		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		setupSupabase({ updateError: { message: "column does not exist" } });
 
@@ -192,7 +220,7 @@ describe("POST /api/bars/:barId/preview-image", () => {
 
 		expect(response.status).toBe(500);
 		expect(body.error).toBe("データベースの更新に失敗しました");
-		expect(body.detail).toBeUndefined();
+		expect(body.detail).toBe("column does not exist");
 		expect(consoleSpy).toHaveBeenCalledWith(
 			"[preview-image] db update failed:",
 			{

--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-testing-purpose-only";
+
+const mockGetCurrentUser = vi.fn();
+const mockCanAccessBar = vi.fn();
+vi.mock("@/lib/auth", () => ({
+	getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+	canAccessBar: (...args: unknown[]) => mockCanAccessBar(...args),
+}));
+
+const mockFrom = vi.fn();
+const mockStorageFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+	supabaseAdmin: {
+		from: (...args: unknown[]) => mockFrom(...args),
+		storage: {
+			from: (...args: unknown[]) => mockStorageFrom(...args),
+		},
+	},
+}));
+
+import { POST } from "@/app/api/bars/[barId]/preview-image/route";
+
+type FileLike = {
+	size: number;
+	type: string;
+	arrayBuffer: () => Promise<ArrayBuffer>;
+};
+
+function validFile(overrides: Partial<FileLike> = {}): FileLike {
+	return {
+		size: 104 * 1024,
+		type: "image/png",
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+		...overrides,
+	};
+}
+
+function createRequest(file: FileLike | null): Parameters<typeof POST>[0] {
+	return {
+		formData: () =>
+			Promise.resolve({
+				get: (key: string) => (key === "file" ? file : null),
+			}),
+	} as unknown as Parameters<typeof POST>[0];
+}
+
+function createParams(barId = "1"): Parameters<typeof POST>[1] {
+	return { params: Promise.resolve({ barId }) };
+}
+
+const adminUser = {
+	id: "user-1",
+	barManageId: "admin",
+	name: "管理者",
+	role: "admin" as const,
+	barId: null,
+};
+
+// bars テーブルの select/update と storage 操作を設定する
+function setupSupabase(options: {
+	existingPreviewUrl?: string | null;
+	uploadResult?: {
+		data: { path: string } | null;
+		error: { message: string } | null;
+	};
+	updateError?: { message: string } | null;
+}) {
+	const {
+		existingPreviewUrl = null,
+		uploadResult = { data: { path: "bars/1/preview_123.png" }, error: null },
+		updateError = null,
+	} = options;
+
+	const readChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi
+			.fn()
+			.mockResolvedValue({ data: { preview_image_url: existingPreviewUrl } }),
+	};
+	const updateEq = vi.fn().mockResolvedValue({ error: updateError });
+	const updateChain = {
+		update: vi.fn().mockReturnValue({ eq: updateEq }),
+	};
+	mockFrom.mockReturnValueOnce(readChain).mockReturnValueOnce(updateChain);
+
+	const storageChain = {
+		remove: vi.fn().mockResolvedValue({ error: null }),
+		upload: vi.fn().mockResolvedValue(uploadResult),
+		getPublicUrl: vi.fn().mockReturnValue({
+			data: {
+				publicUrl:
+					"https://example.supabase.co/storage/v1/object/public/bar-preview-images/bars/1/preview_123.png",
+			},
+		}),
+	};
+	mockStorageFrom.mockReturnValue(storageChain);
+
+	return { readChain, updateChain, updateEq, storageChain };
+}
+
+describe("POST /api/bars/:barId/preview-image", () => {
+	beforeEach(() => {
+		// Why not: clearAllMocks は mockReturnValueOnce のキューを消さず、前テストの残りが漏れるため reset を使う
+		vi.resetAllMocks();
+		mockGetCurrentUser.mockResolvedValue(adminUser);
+		mockCanAccessBar.mockReturnValue(true);
+	});
+
+	it("未認証の場合 401 を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(body.error).toBe("認証されていません");
+	});
+
+	it("アクセス権限がない場合 403 を返す", async () => {
+		mockCanAccessBar.mockReturnValue(false);
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(body.error).toBe("アクセス権限がありません");
+	});
+
+	it("ファイル未選択の場合 400 を返す", async () => {
+		const response = await POST(createRequest(null), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe("画像ファイルが選択されていません");
+	});
+
+	it("5MB を超える場合 400 を返す", async () => {
+		const response = await POST(
+			createRequest(validFile({ size: 5 * 1024 * 1024 + 1 })),
+			createParams(),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe("画像サイズは5MB以下にしてください");
+	});
+
+	it("対応外のMIMEタイプの場合 400 を返す", async () => {
+		const response = await POST(
+			createRequest(validFile({ type: "image/gif" })),
+			createParams(),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe("画像形式はJPEG、PNG、WebPのみ対応しています");
+	});
+
+	it("Storage アップロード失敗時、500 と実エラー detail を返す", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		setupSupabase({
+			uploadResult: {
+				data: null,
+				error: { message: "new row violates row-level security policy" },
+			},
+		});
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("画像のアップロードに失敗しました");
+		expect(body.detail).toBe("new row violates row-level security policy");
+		expect(consoleSpy).toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("DB更新失敗時、500 と実エラー detail を返す", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		setupSupabase({ updateError: { message: "column does not exist" } });
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("データベースの更新に失敗しました");
+		expect(body.detail).toBe("column does not exist");
+		expect(consoleSpy).toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("正常時、公開URLを返し bars.preview_image_url を更新する", async () => {
+		const { updateChain, updateEq } = setupSupabase({});
+
+		const response = await POST(createRequest(validFile()), createParams());
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.preview_image_url).toBe(
+			"https://example.supabase.co/storage/v1/object/public/bar-preview-images/bars/1/preview_123.png",
+		);
+		expect(updateChain.update).toHaveBeenCalledWith({
+			preview_image_url:
+				"https://example.supabase.co/storage/v1/object/public/bar-preview-images/bars/1/preview_123.png",
+		});
+		expect(updateEq).toHaveBeenCalledWith("id", "1");
+	});
+});

--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.test.ts
@@ -159,7 +159,7 @@ describe("POST /api/bars/:barId/preview-image", () => {
 		expect(body.error).toBe("画像形式はJPEG、PNG、WebPのみ対応しています");
 	});
 
-	it("Storage アップロード失敗時、500 と実エラー detail を返す", async () => {
+	it("Storage アップロード失敗時、500 を返し実エラーはサーバーログにのみ出す（detailは返さない）", async () => {
 		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		setupSupabase({
 			uploadResult: {
@@ -173,13 +173,17 @@ describe("POST /api/bars/:barId/preview-image", () => {
 
 		expect(response.status).toBe(500);
 		expect(body.error).toBe("画像のアップロードに失敗しました");
-		expect(body.detail).toBe("new row violates row-level security policy");
-		expect(consoleSpy).toHaveBeenCalled();
+		// Why not: 内部情報の外部露出を防ぐため detail はクライアントに返さない
+		expect(body.detail).toBeUndefined();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[preview-image] storage upload failed:",
+			{ message: "new row violates row-level security policy" },
+		);
 
 		consoleSpy.mockRestore();
 	});
 
-	it("DB更新失敗時、500 と実エラー detail を返す", async () => {
+	it("DB更新失敗時、500 を返し実エラーはサーバーログにのみ出す（detailは返さない）", async () => {
 		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		setupSupabase({ updateError: { message: "column does not exist" } });
 
@@ -188,10 +192,30 @@ describe("POST /api/bars/:barId/preview-image", () => {
 
 		expect(response.status).toBe(500);
 		expect(body.error).toBe("データベースの更新に失敗しました");
-		expect(body.detail).toBe("column does not exist");
-		expect(consoleSpy).toHaveBeenCalled();
+		expect(body.detail).toBeUndefined();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[preview-image] db update failed:",
+			{
+				message: "column does not exist",
+			},
+		);
 
 		consoleSpy.mockRestore();
+	});
+
+	it("既存画像がある場合、旧ファイルを削除してから新規アップロードする", async () => {
+		const { storageChain } = setupSupabase({
+			existingPreviewUrl:
+				"https://example.supabase.co/storage/v1/object/public/bar-preview-images/bars/1/preview_old.png",
+		});
+
+		const response = await POST(createRequest(validFile()), createParams());
+
+		expect(response.status).toBe(200);
+		expect(storageChain.remove).toHaveBeenCalledWith([
+			"bars/1/preview_old.png",
+		]);
+		expect(storageChain.upload).toHaveBeenCalled();
 	});
 
 	it("正常時、公開URLを返し bars.preview_image_url を更新する", async () => {

--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
@@ -97,10 +97,13 @@ export async function POST(
 			});
 
 		if (uploadError) {
-			// Why not: 詳細をレスポンスに載せると外部の bar_owner に内部情報が露出するため、真因はサーバーログにのみ残す
+			// Why not: 詳細を全ユーザーに返すと外部の bar_owner に内部情報が露出するため、内部の admin にのみ返す
 			console.error("[preview-image] storage upload failed:", uploadError);
 			return NextResponse.json(
-				{ error: "画像のアップロードに失敗しました" },
+				{
+					error: "画像のアップロードに失敗しました",
+					...(user.role === "admin" ? { detail: uploadError.message } : {}),
+				},
 				{ status: 500 },
 			);
 		}
@@ -121,7 +124,10 @@ export async function POST(
 		if (updateError) {
 			console.error("[preview-image] db update failed:", updateError);
 			return NextResponse.json(
-				{ error: "データベースの更新に失敗しました" },
+				{
+					error: "データベースの更新に失敗しました",
+					...(user.role === "admin" ? { detail: updateError.message } : {}),
+				},
 				{ status: 500 },
 			);
 		}

--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
@@ -97,8 +97,13 @@ export async function POST(
 			});
 
 		if (uploadError) {
+			// Why not: 握りつぶすと本番/プレビューでの失敗原因が追えないため、実エラーをログとレスポンスに残す
+			console.error("[preview-image] storage upload failed:", uploadError);
 			return NextResponse.json(
-				{ error: "画像のアップロードに失敗しました" },
+				{
+					error: "画像のアップロードに失敗しました",
+					detail: uploadError.message,
+				},
 				{ status: 500 },
 			);
 		}
@@ -117,8 +122,12 @@ export async function POST(
 			.eq("id", barId);
 
 		if (updateError) {
+			console.error("[preview-image] db update failed:", updateError);
 			return NextResponse.json(
-				{ error: "データベースの更新に失敗しました" },
+				{
+					error: "データベースの更新に失敗しました",
+					detail: updateError.message,
+				},
 				{ status: 500 },
 			);
 		}
@@ -126,9 +135,13 @@ export async function POST(
 		return NextResponse.json({
 			preview_image_url: previewImageUrl,
 		});
-	} catch (_error) {
+	} catch (error) {
+		console.error("[preview-image] unexpected error:", error);
 		return NextResponse.json(
-			{ error: "画像のアップロードに失敗しました" },
+			{
+				error: "画像のアップロードに失敗しました",
+				detail: error instanceof Error ? error.message : String(error),
+			},
 			{ status: 500 },
 		);
 	}

--- a/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/preview-image/route.ts
@@ -97,13 +97,10 @@ export async function POST(
 			});
 
 		if (uploadError) {
-			// Why not: 握りつぶすと本番/プレビューでの失敗原因が追えないため、実エラーをログとレスポンスに残す
+			// Why not: 詳細をレスポンスに載せると外部の bar_owner に内部情報が露出するため、真因はサーバーログにのみ残す
 			console.error("[preview-image] storage upload failed:", uploadError);
 			return NextResponse.json(
-				{
-					error: "画像のアップロードに失敗しました",
-					detail: uploadError.message,
-				},
+				{ error: "画像のアップロードに失敗しました" },
 				{ status: 500 },
 			);
 		}
@@ -124,10 +121,7 @@ export async function POST(
 		if (updateError) {
 			console.error("[preview-image] db update failed:", updateError);
 			return NextResponse.json(
-				{
-					error: "データベースの更新に失敗しました",
-					detail: updateError.message,
-				},
+				{ error: "データベースの更新に失敗しました" },
 				{ status: 500 },
 			);
 		}
@@ -138,10 +132,7 @@ export async function POST(
 	} catch (error) {
 		console.error("[preview-image] unexpected error:", error);
 		return NextResponse.json(
-			{
-				error: "画像のアップロードに失敗しました",
-				detail: error instanceof Error ? error.message : String(error),
-			},
+			{ error: "画像のアップロードに失敗しました" },
 			{ status: 500 },
 		);
 	}
@@ -206,16 +197,18 @@ export async function DELETE(
 			.eq("id", barId);
 
 		if (updateError) {
+			console.error("[preview-image] delete db update failed:", updateError);
 			return NextResponse.json(
-				{ error: "データベ��スの更新に失敗しま���た" },
+				{ error: "データベースの更新に失敗しました" },
 				{ status: 500 },
 			);
 		}
 
 		return NextResponse.json({ success: true });
-	} catch (_error) {
+	} catch (error) {
+		console.error("[preview-image] delete unexpected error:", error);
 		return NextResponse.json(
-			{ error: "画像の削除��失敗しました" },
+			{ error: "画像の削除に失敗しました" },
 			{ status: 500 },
 		);
 	}

--- a/apps/admin/src/app/bars/new/BarNewForm.tsx
+++ b/apps/admin/src/app/bars/new/BarNewForm.tsx
@@ -263,7 +263,14 @@ export default function BarNewForm() {
 							{ method: "POST", body: imageFormData },
 						);
 						if (!imageResponse.ok) {
-							uploadErrors.push("プレビュー画像");
+							// Why not: 店舗登録は admin 専用画面のため、API が admin に返す detail をそのまま表示して原因を追いやすくする
+							const detail = await imageResponse
+								.json()
+								.then((d) => d.detail as string | undefined)
+								.catch(() => undefined);
+							uploadErrors.push(
+								detail ? `プレビュー画像 (${detail})` : "プレビュー画像",
+							);
 						}
 					} catch {
 						uploadErrors.push("プレビュー画像");

--- a/apps/admin/src/app/bars/new/BarNewForm.tsx
+++ b/apps/admin/src/app/bars/new/BarNewForm.tsx
@@ -263,7 +263,13 @@ export default function BarNewForm() {
 							{ method: "POST", body: imageFormData },
 						);
 						if (!imageResponse.ok) {
-							uploadErrors.push("プレビュー画像");
+							const detail = await imageResponse
+								.json()
+								.then((d) => d.detail as string | undefined)
+								.catch(() => undefined);
+							uploadErrors.push(
+								detail ? `プレビュー画像 (${detail})` : "プレビュー画像",
+							);
 						}
 					} catch {
 						uploadErrors.push("プレビュー画像");
@@ -290,8 +296,9 @@ export default function BarNewForm() {
 					setError(
 						`店舗は登録されましたが、以下のアップロードに失敗しました: ${uploadErrors.join(", ")}。編集画面から再度アップロードしてください。`,
 					);
+					// Why not: 一覧へ戻すと画像欠落が「No Image」に埋もれて気付けないため、再アップロード可能な編集画面へ誘導する
 					setTimeout(() => {
-						router.push("/bars");
+						router.push(`/bars/${responseData.id}/edit`);
 						router.refresh();
 					}, REDIRECT_DELAY_MS);
 					return;

--- a/apps/admin/src/app/bars/new/BarNewForm.tsx
+++ b/apps/admin/src/app/bars/new/BarNewForm.tsx
@@ -263,13 +263,7 @@ export default function BarNewForm() {
 							{ method: "POST", body: imageFormData },
 						);
 						if (!imageResponse.ok) {
-							const detail = await imageResponse
-								.json()
-								.then((d) => d.detail as string | undefined)
-								.catch(() => undefined);
-							uploadErrors.push(
-								detail ? `プレビュー画像 (${detail})` : "プレビュー画像",
-							);
+							uploadErrors.push("プレビュー画像");
 						}
 					} catch {
 						uploadErrors.push("プレビュー画像");

--- a/apps/admin/src/lib/jwt-role.test.ts
+++ b/apps/admin/src/lib/jwt-role.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { decodeJwtRole } from "./jwt-role";
+
+function makeJwt(payload: Record<string, unknown>): string {
+	const header = Buffer.from(
+		JSON.stringify({ alg: "HS256", typ: "JWT" }),
+	).toString("base64url");
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `${header}.${body}.signature`;
+}
+
+describe("decodeJwtRole", () => {
+	it("service_role キーの role を取り出す", () => {
+		expect(
+			decodeJwtRole(makeJwt({ role: "service_role", iss: "supabase" })),
+		).toBe("service_role");
+	});
+
+	it("anon キーの role を取り出す（貼り間違い検知に使用）", () => {
+		expect(decodeJwtRole(makeJwt({ role: "anon", iss: "supabase" }))).toBe(
+			"anon",
+		);
+	});
+
+	it("role クレームが無い場合は null", () => {
+		expect(decodeJwtRole(makeJwt({ iss: "supabase" }))).toBeNull();
+	});
+
+	it("role が文字列でない場合は null", () => {
+		expect(decodeJwtRole(makeJwt({ role: 123 }))).toBeNull();
+	});
+
+	it("JWT形式でない文字列は null（新形式のシークレットキー等で誤警告しないため）", () => {
+		expect(decodeJwtRole("sb_secret_xxxxxxxx")).toBeNull();
+	});
+
+	it("空文字は null", () => {
+		expect(decodeJwtRole("")).toBeNull();
+	});
+
+	it("ペイロードが不正なbase64/JSONでも例外を投げず null", () => {
+		expect(decodeJwtRole("a.!!!not-base64!!!.c")).toBeNull();
+	});
+});

--- a/apps/admin/src/lib/jwt-role.ts
+++ b/apps/admin/src/lib/jwt-role.ts
@@ -1,0 +1,12 @@
+// Why not: 署名検証は不要（設定ミス検知用途）。role クレームだけを取り出す軽量デコード
+export function decodeJwtRole(token: string): string | null {
+	try {
+		const payload = token.split(".")[1];
+		if (!payload) return null;
+		const json = Buffer.from(payload, "base64url").toString("utf8");
+		const claims = JSON.parse(json) as { role?: unknown };
+		return typeof claims.role === "string" ? claims.role : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/admin/src/lib/supabase.ts
+++ b/apps/admin/src/lib/supabase.ts
@@ -1,19 +1,30 @@
 import "server-only";
 import { createClient } from "@supabase/supabase-js";
+import { decodeJwtRole } from "./jwt-role";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 // Service role client (サーバーサイドのみで使用)
-export const supabaseAdmin = createClient(
-	supabaseUrl,
-	process.env.SUPABASE_SERVICE_ROLE_KEY ?? "",
-	{
-		auth: {
-			autoRefreshToken: false,
-			persistSession: false,
-		},
+export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+	auth: {
+		autoRefreshToken: false,
+		persistSession: false,
 	},
-);
+});
+
+// Why not: service_role 以外のキー（例: anon キーの貼り間違い）を渡すと Storage 書き込みが
+//          RLS で 403 失敗する（#392）。JWT形式の場合のみ role を検証し、不一致なら起動時に警告する
+const serviceRoleKeyRole = decodeJwtRole(serviceRoleKey);
+if (
+	serviceRoleKey &&
+	serviceRoleKeyRole &&
+	serviceRoleKeyRole !== "service_role"
+) {
+	console.error(
+		`[supabase] SUPABASE_SERVICE_ROLE_KEY is not a service_role key (role="${serviceRoleKeyRole}"). Admin writes such as Storage uploads will fail with RLS violations. Check the environment variable.`,
+	);
+}


### PR DESCRIPTION
## 概要

管理画面の店舗登録でプレビュー画像を添付しても店舗一覧の店舗カードに表示されない問題（#392）の **診断・観測性改善・再発防止**。

## 真因（恒久修正は Vercel の環境変数側）

調査の結果、根本原因は **Vercel の環境変数設定ミス**でした。`beer-salon-admin` の **Preview** 環境の `SUPABASE_SERVICE_ROLE_KEY` に **anon キー**が設定されており、`supabaseAdmin` が anon 権限で動作していました。

- `storage.objects` の insert ポリシーは `to authenticated` → anon は 403（`new row violates row-level security policy`）で弾かれ、画像アップロードのみ失敗
- `bars` insert は anon でも通るためバー作成は成功し、症状が分かりにくかった（`preview_image_url` が null、Storage に実ファイル0件）

dev/preview プロジェクト（`utwrpxokugqgyrntbpfw`）に対しルートと同一のアップロードを再現して 403 を確認し、当該キーの JWT が `role: anon`（かつ anon キーと値が一致）であることをデコードで確定済み。

→ **恒久修正は Vercel の Preview 環境変数 `SUPABASE_SERVICE_ROLE_KEY` を正しい service_role キーに差し替えること**（コードでは直せない）。本PRはその早期検知・診断のための改善。

## 変更内容

- `preview-image/route.ts`: 失敗時の実エラーを `console.error` 出力＋**admin にのみ** `detail` 返却（role ゲート）。→ 真因 `new row violates RLS` を可視化
- `BarNewForm.tsx`: アップロード失敗時に `detail` を表示し、遷移先を作成した店舗の編集ページに変更
- `supabase.ts` + `jwt-role.ts`: `SUPABASE_SERVICE_ROLE_KEY` の role が `service_role` でなければ起動時に `console.error` で警告（同種の env 貼り間違いを早期検知）
- UT 追加（preview-image の role 別挙動 / `decodeJwtRole`）

## テスト

- admin UT **61件 pass** / `typecheck` / `biome` clean

## #392 のクローズについて

本PRは env 修正を含まないため **`Closes #392` は付与しない**。Vercel の環境変数を修正・検証してから #392 をクローズする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)