### PR TITLE
docs(auth): 認証メール送信の独自SMTP(Resend)切替手順を整備 (#405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,23 @@ pnpm --filter @beersalon/web theme amber-dark
    - dev プロジェクト: preview オリジン（Vercel Preview はワイルドカード `https://*.vercel.app/auth/callback`。固定 URL の `https://beer-salon-develop.vercel.app/auth/callback` 等）＋ローカル（`http://127.0.0.1:3000/auth/callback` 等）の `/auth/callback` を許可する。
    - prod プロジェクト: production オリジン（`https://beer-salon.vercel.app/auth/callback` 等）の `/auth/callback` を許可する。
    - 許可外オリジンへのリダイレクトはブロックされ、メール内リンクが無効化される。
-3. **Supabase ダッシュボード → Project Settings → Authentication → SMTP**
-   - 無料枠のデフォルト SMTP は送信レート・到達率が低い。独自 SMTP（SendGrid 等）の設定を推奨。
+3. **Supabase ダッシュボード → Project Settings → Authentication → SMTP（独自SMTP = Resend。dev/prod 両プロジェクトに設定する）**
+   - 無料枠のデフォルト SMTP（`noreply@mail.app.supabase.io`）は送信レート（config.toml では 1時間2通）・到達率が低く「たまに届かない」状態になる。これを回避するため独自SMTP（**Resend**）に切り替える。
+   - 送信元は **`noreply@beersalon.com`**（独自ドメイン。SPF/DKIM を DNS に登録する）。
+   - **手順（dev / prod の各プロジェクトで同じ設定を行う。取り違えないこと）**:
+     1. Resend でアカウントを作成し、**Domains** に `beersalon.com` を追加する。表示される SPF（`TXT`）・DKIM（`TXT`）・（任意で）DMARC レコードを、`beersalon.com` の DNS に登録して Verified 状態にする。
+     2. Resend の **API Keys** で送信用 API キーを発行する（`RESEND_API_KEY`）。
+     3. Supabase ダッシュボード → **Project Settings → Authentication → SMTP Settings** で「Enable Custom SMTP」を ON にし、以下を設定する:
+        - Host: `smtp.resend.com`
+        - Port: `587`
+        - Username: `resend`
+        - Password: 発行した `RESEND_API_KEY`
+        - Sender email: `noreply@beersalon.com`
+        - Sender name: `Beer Salon`
+     4. あわせて **Authentication → Rate Limits** の "Emails sent per hour" を、デフォルトSMTP前提の低い値から実運用に耐える値へ引き上げる（config.toml のローカル値 `[auth.rate_limit] email_sent = 2` は Mailpit ローカル用であり、リモートには反映されない）。
+   - **これは `apps/web` の全認証メール（`/signup` の確認メール・`/password/forgot`/`/password/reset` の再設定メール）に共通で効く**（すべて同一の Supabase Auth SMTP を経由するため、SMTP を切り替えれば両方が同時に改善する）。
+   - **検証**: preview（dev プロジェクト）で新規登録し、メールが届くことを確認する。加えて Supabase ダッシュボード → **Logs → Auth Logs** で送信ログの `mail_from` が `noreply@beersalon.com`（= デフォルトの `noreply@mail.app.supabase.io` ではない）になっていることを確認する。
+   - **注意**: `supabase/config.toml` の `[auth.email.smtp]` はコメントアウトのままでよい（ローカルは Mailpit を使うため。config.toml は `supabase db push` の対象外で、この SMTP 設定はダッシュボードでの手動設定でのみ有効になる）。
 4. **Vercel → 環境変数 `NEXT_PUBLIC_SITE_URL`**
    - production では必ず設定する（Host Header Injection 対策。`apps/web/src/lib/site-url.ts` の `getSiteUrl()` が最優先で参照する）。
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -212,14 +212,16 @@ otp_length = 6
 otp_expiry = 3600
 
 # Use a production-ready SMTP server
+# ローカルは Mailpit で送信を捕捉するため有効化しない（dev/prod は各ダッシュボードで設定する。README「認証メールの配信設定」参照）。
+# 独自SMTP は Resend を採用。送信元は noreply@beersalon.com（独自ドメイン・SPF/DKIM 登録済み）。
 # [auth.email.smtp]
 # enabled = true
-# host = "smtp.sendgrid.net"
+# host = "smtp.resend.com"
 # port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# user = "resend"
+# pass = "env(RESEND_API_KEY)"
+# admin_email = "noreply@beersalon.com"
+# sender_name = "Beer Salon"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]


### PR DESCRIPTION
## 概要

認証メール（`/signup` の確認メール・`/password/forgot`/`/password/reset` の再設定メール）が、Supabase のデフォルトSMTP（`noreply@mail.app.supabase.io`）のレート制限（config.toml では 1時間2通）と低い到達率により「たまに届かない」状態が残る問題への対応。独自SMTP（**Resend** / 送信元 `noreply@beersalon.com`）へ切り替えるための手順を整備した。

Closes #405

## このIssueの性質（重要）

本Issueの核（実際のSMTP切替・到達検証）は **Supabase ダッシュボード（dev/prod 両プロジェクト）での手動設定**であり、コードでは完結しない。`supabase/config.toml` の `[auth.email.smtp]` は `supabase db push` の対象外のため、リポジトリでできるのは**ドキュメント整備とローカル config.toml の整合**のみ。よって本PRは補助（手順の明文化）であり、受入条件は **ユーザーによるダッシュボード設定 → preview 検証 → Auth Logs の `mail_from` 確認**まで行って初めて満たされる。

## 変更内容

- **README.md**: 「認証メールの配信設定」項目3を、Resend 採用前提の具体手順に更新
  - Resend の Domains（SPF/DKIM を DNS 登録し Verified に）・API キー発行
  - Supabase ダッシュボードの SMTP 設定値（host `smtp.resend.com` / port 587 / user `resend` / pass `RESEND_API_KEY` / sender `noreply@beersalon.com` / name `Beer Salon`）
  - Rate Limits の "Emails sent per hour" 引き上げ
  - Auth Logs で `mail_from` を検証する手順
  - dev/prod 両プロジェクトへ設定する（取り違えない）注意、`config.toml` はコメントアウトのままでよい旨
- **supabase/config.toml**: `[auth.email.smtp]` のコメント例を SendGrid → Resend（`noreply@beersalon.com`）に更新（ローカルは Mailpit のため有効化はしない）

## 横展開所見

- `/signup`・`/password/forgot`・`/password/reset` はいずれも**同一の Supabase Auth SMTP**を共有するため、SMTP を切り替えれば全認証メールが同時に改善する。個別対応は不要。
- `admin_users.contact_email`（請求書送付用）やアプリ内通知（`notifications` テーブルへの INSERT。メール送信しない）は本Issュー対象外。

## テスト

- **UT**: 対象なし（ロジック・バリデーション・整形処理を伴わないドキュメント修正のため。意味のないアサーションは追加しない方針）
- **E2E**: ローカル Playwright では担保不可（受入条件はリモート dev/prod への実メール送信でしか検証できない）。検証は preview での新規登録 + Auth Logs の `mail_from` 確認で行う

## 受入条件（コード外の残作業）

- [ ] dev / prod 両プロジェクトの SMTP が Resend に設定されている
- [ ] preview で新規登録するとメールが安定して届く
- [ ] Auth Logs の `mail_from` が `noreply@beersalon.com` になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)