### PR TITLE
create-issue スキルの引数に Evernote 共有リンクを渡せるようにする

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,22 +1,45 @@
 ---
 name: create-issue
-description: @issue_note.txt の課題Noをもとに、GitHub Issueを作成する。対応種別に応じてfeature/bugfixテンプレートを使い分ける。
-when_to_use: 「Issue作成」「create-issue」などの発言時、課題Noを指定してIssue作成を依頼された時
+description: @issue_note.txt の課題No、または Evernote 共有リンク（ノート下書き）をもとに、GitHub Issueを作成する。対応種別に応じてfeature/bugfixテンプレートを使い分ける。
+when_to_use: 「Issue作成」「create-issue」などの発言時、課題No または Evernote 共有リンクを指定して Issue 作成を依頼された時
 ---
 
 ## GitHub Issue 作成フロー
 
 **このスキルの目的は GitHub Issue を新規作成すること。** 設計ドキュメントの更新・同期は一切行わない（それは sync-docs スキルの役割）。本スキルで設計ドキュメントに触れるのは、Issue 本文の項目を埋めるための「読み取り専用の参照」に限る。
 
-引数: `$ARGUMENTS`（課題No。例: ISSUE-001）
+引数: `$ARGUMENTS`（次の2形態のいずれか）
 
-### Phase 1: 課題情報の取得
+- **課題No**（例: `ISSUE-001`）: `issue_note.txt` の該当セクションを入力ソースにする（従来どおり）
+- **Evernote 共有リンク**（例: `https://share.evernote.com/note/<GUID>`）または **ノート GUID**: そのノート本文を入力ソースにする
+
+### Phase 1: 入力ソースの判別と取得
+
+引数の形式を先に判別し、入力ソースを決める。
+
+- 引数が `ISSUE-` で始まる → **課題No経路（Phase 1-A）**
+- 引数が `share.evernote.com/note/...` を含む共有 URL、または GUID 形式（`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`）→ **Evernote 経路（Phase 1-B）**
+
+#### Phase 1-A: 課題No経路（`issue_note.txt`）
 
 1. `@issue_note.txt` を読み込む
 2. 引数で受け取った課題No（`$ARGUMENTS`）に一致するセクションを探す
 3. 該当する課題が見つからない場合はエラーメッセージを表示して終了する
 
-### Phase 2: テンプレートの選定
+#### Phase 1-B: Evernote 経路（共有リンク / GUID）
+
+1. 引数からノート GUID を取り出す
+   - 共有 URL（`https://share.evernote.com/note/<GUID>`）の場合は末尾の `<GUID>` 部分を抽出する
+   - GUID が直接渡された場合はそのまま使う
+2. Evernote MCP の `get_note`（引数 `noteId=<GUID>`）でノートのタイトル・本文（ENML）を取得する
+3. 取得に失敗した場合（GUID 不正・アクセス不可など）はエラーメッセージを表示して終了する
+4. この経路では `issue_note.txt` は参照しない（入力ソースはノート本文）
+
+> **`WebFetch` は使わない**: Evernote 共有リンクは `accounts.evernote.com` の認証リダイレクトに飛ぶため、`WebFetch` では本文を取得できない。ノート本文の取得は必ず Evernote MCP の `get_note` を使う。
+
+### Phase 2: テンプレートの選定（経路共通）
+
+Phase 1 でどちらの経路（課題No / Evernote）を通ったかに関わらず、以降の Phase 2〜4 は共通の手順で進める。
 
 課題の「対応種別」に応じて使用するテンプレートを決定する。
 
@@ -27,7 +50,12 @@ when_to_use: 「Issue作成」「create-issue」などの発言時、課題Noを
 | アーキテクチャ変更 | `.github/ISSUE_TEMPLATE/feature.md` |
 | バグ修正 | `.github/ISSUE_TEMPLATE/bugfix.md` |
 
+- 課題No経路では、`issue_note.txt` のセクションに記載された「対応種別」を使う。
+- Evernote 経路では、ノート本文から対応種別を読み取る。**本文から対応種別が判別できない場合は推測で決めず、ユーザーに確認する**（推測補完は禁止。禁止事項を参照）。
+
 ### Phase 3: Issue本文の作成
+
+入力ソースが「課題No のセクション」か「Evernote ノート本文」かに関わらず、下記の各テンプレート項目マッピングは共通で使う（「課題の〜」と書かれた箇所は、Evernote 経路ではノート本文の該当内容と読み替える）。
 
 #### feature テンプレートの場合
 
@@ -83,5 +111,6 @@ Issue作成に成功したら、報告の最後に **`/rename` コマンドを�
 - ユーザー承認なしでIssueを作成すること
 - @issue_note.txt に存在しない課題Noで作成を試みること
 - テンプレートの構造を無視してIssue本文を作成すること
-- 課題情報を推測で補完すること（不明点は「未確定事項」に記載する）
+- 課題情報を推測で補完すること（不明点は「未確定事項」に記載する）。Evernote 経路で本文から「対応種別」が判別できない場合も推測で決めず、ユーザーに確認すること
+- Evernote 共有リンクの本文取得を `WebFetch` で試みること（認証リダイレクトで取得できない。必ず Evernote MCP の `get_note` を使う）
 - 設計ドキュメント（routing.md / wireframe.md / database.md / README.md）を更新・同期すること（本スキルは参照のみ。同期は sync-docs の役割）


### PR DESCRIPTION
## 概要

`create-issue` スキルの引数として、従来の課題No（`ISSUE-XXX`）に加えて **Evernote 共有リンク / ノート GUID** を渡せるようにした。Evernote で下書きを作る運用に合わせ、「リンクを貼って手動指示」の二度手間を解消し、下書き → Issue 化の導線を一本化する。

Closes #411

## 変更内容

`.claude/skills/create-issue/SKILL.md` のみ変更（スキル手順書）。

- **frontmatter / 引数説明**: 課題No と Evernote 共有リンクの2形態対応に更新
- **Phase 1 を「入力ソースの判別」に再構成**:
  - `ISSUE-` で始まる → 課題No経路（Phase 1-A、従来どおり `issue_note.txt` 参照）
  - `share.evernote.com/note/...` または GUID 形式 → Evernote 経路（Phase 1-B）
  - Evernote 経路は共有 URL 末尾から GUID を抽出し、Evernote MCP の `get_note` で本文取得。取得失敗時はエラー終了
  - **`WebFetch` を使わない理由を明記**（共有リンクは `accounts.evernote.com` の認証リダイレクトに飛び本文を取得できない）
- **Phase 2 以降を経路共通と明示**。Evernote 経路で対応種別が判別できない場合は推測せずユーザー確認（禁止事項にも追記）
- Phase 4（承認必須）は現行踏襲

## テストについて

本変更は**スキル定義（Markdown 手順書）の更新のみ**で、実行コード（TS/JS）・UI・DB 分岐を一切追加しない。そのため UT（Vitest）/ E2E（Playwright）は物理的に検証対象が存在せず、追加していない。品質チェック（Biome の format/lint）も対象は `apps/web` / `apps/admin` の TS/JS であり、本変更（`.claude/` 配下の Markdown）は対象外。

受入確認は SKILL.md の記述レビューで行う（Issue #411 の受入条件を文言として満たすこと）。

## 受入条件との対応

- [x] `create-issue ISSUE-001` の課題No経路（`issue_note.txt`）を保持（Phase 1-A）
- [x] `create-issue <Evernote共有リンク>` で `get_note` によりノート本文を取得（Phase 1-B）
- [x] 取得失敗時はエラー終了（Phase 1-B の 3）
- [x] いずれの経路も承認前に Issue を作成しない（Phase 4 踏襲）
- [x] 引数形式・`get_note` 使用・`WebFetch` 不可の理由を記載

## PR作成時の注意
**PR名・内容は日本語で記載。**