### PR TITLE
fix(web): service_role キー貼り間違いの起動時検知ガードを横展開 (#410)

### DIFF
--- a/apps/web/src/lib/jwt-role.test.ts
+++ b/apps/web/src/lib/jwt-role.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { decodeJwtRole } from "./jwt-role";
+
+function makeJwt(payload: Record<string, unknown>): string {
+	const header = Buffer.from(
+		JSON.stringify({ alg: "HS256", typ: "JWT" }),
+	).toString("base64url");
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `${header}.${body}.signature`;
+}
+
+describe("decodeJwtRole", () => {
+	it("service_role キーの role を取り出す", () => {
+		expect(
+			decodeJwtRole(makeJwt({ role: "service_role", iss: "supabase" })),
+		).toBe("service_role");
+	});
+
+	it("anon キーの role を取り出す（貼り間違い検知に使用）", () => {
+		expect(decodeJwtRole(makeJwt({ role: "anon", iss: "supabase" }))).toBe(
+			"anon",
+		);
+	});
+
+	it("role クレームが無い場合は null", () => {
+		expect(decodeJwtRole(makeJwt({ iss: "supabase" }))).toBeNull();
+	});
+
+	it("role が文字列でない場合は null", () => {
+		expect(decodeJwtRole(makeJwt({ role: 123 }))).toBeNull();
+	});
+
+	it("JWT形式でない文字列は null（新形式のシークレットキー等で誤警告しないため）", () => {
+		expect(decodeJwtRole("sb_secret_xxxxxxxx")).toBeNull();
+	});
+
+	it("空文字は null", () => {
+		expect(decodeJwtRole("")).toBeNull();
+	});
+
+	it("ペイロードが不正なbase64/JSONでも例外を投げず null", () => {
+		expect(decodeJwtRole("a.!!!not-base64!!!.c")).toBeNull();
+	});
+});

--- a/apps/web/src/lib/jwt-role.ts
+++ b/apps/web/src/lib/jwt-role.ts
@@ -1,0 +1,12 @@
+// Why not: 署名検証は不要（設定ミス検知用途）。role クレームだけを取り出す軽量デコード
+export function decodeJwtRole(token: string): string | null {
+	try {
+		const payload = token.split(".")[1];
+		if (!payload) return null;
+		const json = Buffer.from(payload, "base64url").toString("utf8");
+		const claims = JSON.parse(json) as { role?: unknown };
+		return typeof claims.role === "string" ? claims.role : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,5 +1,19 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { decodeJwtRole } from "../jwt-role";
+
+// Why not: service_role 以外のキー（例: anon キーの貼り間違い）を渡すと Storage 書き込みが
+//          RLS で 403 失敗する（#392/#403）。createAdminClient() は呼び出しごとに走るため
+//          毎回警告するとノイズになる。モジュールロード時に1回だけ role を検証し、
+//          JWT形式で service_role でない場合のみ起動時に警告する（admin 側の実装と揃える）
+const serviceRoleKeyRole = decodeJwtRole(
+	process.env.SUPABASE_SERVICE_ROLE_KEY ?? "",
+);
+if (serviceRoleKeyRole && serviceRoleKeyRole !== "service_role") {
+	console.error(
+		`[supabase] SUPABASE_SERVICE_ROLE_KEY is not a service_role key (role="${serviceRoleKeyRole}"). Admin writes such as Storage uploads will fail with RLS violations. Check the environment variable.`,
+	);
+}
 
 export async function createClient() {
 	const cookieStore = await cookies();


### PR DESCRIPTION
## 概要

Issue #410 の対応。`SUPABASE_SERVICE_ROLE_KEY` に anon キー等を貼り間違えると Storage 書き込みが RLS で 403 失敗する事故（#392 / #399 / #403）が繰り返し起きてきた。admin（`apps/admin/src/lib/supabase.ts`）には #392 で起動時の検知ガードが入っているが、web（`apps/web/src/lib/supabase/server.ts`）の `createAdminClient()` には同等のガードが無かった。この横展開として web にも検知ガードを追加する。

## 変更内容

- 新規 `apps/web/src/lib/jwt-role.ts` — admin の `decodeJwtRole` 相当（署名検証なしで role クレームのみを取り出す軽量デコード）を web に配置
- 新規 `apps/web/src/lib/jwt-role.test.ts` — `service_role` / `anon` / `sb_secret_`（新形式）/ role なし / 非文字列 / 空文字 / 不正 base64 の UT（7 ケース）
- 変更 `apps/web/src/lib/supabase/server.ts` — モジュールロード時に `SUPABASE_SERVICE_ROLE_KEY` の role を1回だけ検証し、JWT 形式で `service_role` でなければ起動時に `console.error` で警告

## 実装メモ

- **web に同等関数を配置**（`packages/shared` へ共通化しない）: `decodeJwtRole` は `Buffer` 依存のサーバー専用・12行と小さく、shared（現状 Node ランタイム前提の `middleware-logger` のみ）へ寄せると役割が曖昧になるため。
- **検知位置は案B（モジュールトップレベルで1回検証）**: admin と同じ「起動時警告」挙動に揃える。`createAdminClient()` は呼び出しごとに走るため関数内チェックだと警告がノイズになる。`decodeJwtRole("")` は `null` を返すため、空文字・未設定・`sb_secret_` 形式では警告しない（誤検知しない）。

## テスト

- UT: `pnpm --filter @beersalon/web test` → 398 passed（新規 7 ケース含む）
- E2E: 本 Issue は起動時 `console.error` を出す内部ガードで画面操作を伴うフロー変更が無いため対象外
- `pnpm format` / `pnpm lint` クリーン

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)