### PR TITLE
feat(web): ヘッダー/フッター帯色を落ち着いたウォームサンドへ変更 (#414)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ pnpm --filter @beersalon/web theme amber-dark
 
 - テーマ本体は `apps/web/src/styles/themes/<name>.css`（各ファイルが `:root { ... }` を1つ持つ）。
 - `pnpm theme <name>` は `apps/web/src/app/globals.css` 内の `/* THEME:START */` 〜 `/* THEME:END */` で囲まれた `:root` ブロックを、指定テーマの内容へ差し替える。反映は `pnpm dev` の再ビルド / ブラウザリロードで行われる。
-- 切替が一貫して追従するのは、共通ヘッダー / フッターの帯・検索フォームのカード・入力欄・チップ・アイコン背景で使う `--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）の2トークン。以前はこれらが `#f0e68c` / `#ffffff` / `bg-white` としてハードコードされ、テーマ切替から取り残されていた（#388 で「戻せない」と判明した直接原因）。
+- 切替が一貫して追従するのは、共通ヘッダー / フッターの帯・検索フォームのカード・入力欄・チップ・アイコン背景で使う `--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）の2トークン。以前はこれらが `#f0e68c` / `#ffffff` / `bg-white` としてハードコードされ、テーマ切替から取り残されていた（#388 で「戻せない」と判明した直接原因）。現行 current の帯色は `--surface-panel: #e2d6bf`（ウォームサンド。#414 で、以前の明るい黄色 `#f0e68c` がメインコンテンツと合わず幼い印象だったのを落ち着いた色味へ変更）。
 - **新しいテーマを足すときは `themes/` に CSS を1つ追加するだけ**でよい（`current.css` を複製して値を変える）。手で `globals.css` の `:root` を直接編集した場合は、巻き戻し先である `themes/current.css` も同じ内容に揃えること（UT `apply-theme.test.ts` が両者の一致を検査する）。
 - **既知の制約**: `globals.css` の既存 HSL トークン（`--background` / `--primary` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` などは現状レンダリング上は無色（透明）で機能していない。そのため `theme amber-dark`（ビルド時切替）でも「帯・操作面（`--surface-*`）」以外の面はダーク化しない。全画面のダークテーマ化・実行時テーマトグル（next-themes 等）は別 Issue で扱う。
 
@@ -164,7 +164,7 @@ pnpm --filter @beersalon/web theme amber-dark
 
 - 実装は `globals.css` の `.top-amber-dark` スコープと、`page-client.tsx` の最上位ラッパへのクラス付与。トップの本文背景・検索カード・入力欄・チップ・店舗カード・各「人気で探す」セクションがこのスコープ配下でダーク化される。
 - **なぜ `:root` ごとダーク化しないか**: 上記の既知の制約どおり `bg-card` / `text-foreground` 等は透明で機能しておらず、`:root` を有効化すると web 全体（他ページ・共通ヘッダー/フッター）へダークが芋づる波及する。#388 のスコープはトップページの見た目に限定のため、`.top-amber-dark` 配下だけに閉じ込めている。
-- **スコープ外**: 共通ヘッダー / フッターの帯（`--surface-panel` = クリーム）と、トップ以外の14ページはライト基調のまま。全画面ダーク化は別 Issue。
+- **スコープ外**: 共通ヘッダー / フッターの帯（`--surface-panel` = ウォームサンド `#e2d6bf`）と、トップ以外の14ページはライト基調のまま。全画面ダーク化は別 Issue。
 - スコープが `THEME:START`〜`THEME:END` の外にあること・`:root` が current のライト値のままであることは UT `apply-theme.test.ts` が検査する。
 
 ---

--- a/apps/web/scripts/apply-theme.test.ts
+++ b/apps/web/scripts/apply-theme.test.ts
@@ -55,7 +55,7 @@ describe("replaceThemeBlock", () => {
 	});
 
 	it("current → amber-dark → current で元の内容に戻る", () => {
-		const currentBlock = ":root {\n  --surface-panel: #f0e68c;\n}";
+		const currentBlock = ":root {\n  --surface-panel: #e2d6bf;\n}";
 		const darkBlock = ":root {\n  --surface-panel: #2a1c0e;\n}";
 		const toDark = replaceThemeBlock(base, darkBlock);
 		const backToCurrent = replaceThemeBlock(toDark, currentBlock);
@@ -92,8 +92,8 @@ describe("テーマファイルと globals.css の整合", () => {
 		const applied = replaceThemeBlock(globalsCss, darkBlock);
 		expect(applied).toContain("--surface-panel: #2a1c0e;");
 		expect(applied).toContain("--surface-control: #3d2b17;");
-		// current 固有の白帯・白操作面は消えている
-		expect(applied).not.toContain("--surface-panel: #f0e68c;");
+		// current 固有の帯色・白操作面は消えている
+		expect(applied).not.toContain("--surface-panel: #e2d6bf;");
 		expect(applied).not.toContain("--surface-control: #ffffff;");
 	});
 
@@ -132,8 +132,8 @@ describe("トップページ限定ダークスコープ（#388 案A）", () => {
 		const startIdx = globalsCss.indexOf("/* THEME:START");
 		const endIdx = globalsCss.indexOf("/* THEME:END */");
 		const themeBlock = globalsCss.slice(startIdx, endIdx);
-		// current のライト基調（帯=クリーム / 操作面=白）が :root に維持されていること
-		expect(themeBlock).toContain("--surface-panel: #f0e68c;");
+		// current のライト基調（帯=ウォームサンド / 操作面=白）が :root に維持されていること
+		expect(themeBlock).toContain("--surface-panel: #e2d6bf;");
 		expect(themeBlock).toContain("--surface-control: #ffffff;");
 	});
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -79,7 +79,7 @@
 	--sidebar-accent-foreground: 30 15% 20%;
 	--sidebar-border: 35 15% 82%;
 	--sidebar-ring: 30 75% 45%;
-	--surface-panel: #f0e68c;
+	--surface-panel: #e2d6bf;
 	--surface-control: #ffffff;
 }
 /* THEME:END */

--- a/apps/web/src/styles/themes/current.css
+++ b/apps/web/src/styles/themes/current.css
@@ -31,6 +31,6 @@
 	--sidebar-accent-foreground: 30 15% 20%;
 	--sidebar-border: 35 15% 82%;
 	--sidebar-ring: 30 75% 45%;
-	--surface-panel: #f0e68c;
+	--surface-panel: #e2d6bf;
 	--surface-control: #ffffff;
 }


### PR DESCRIPTION
## 概要
ユーザー画面（apps/web）の共通ヘッダー・フッターの帯が明るい黄色 `#f0e68c` で、幼い印象を与えメインコンテンツと調和していなかった。色彩観点で候補3案（ディープブラウン / ウォームサンド / ミューテッドアンバー）のモックを提示し、オーナー承認のもと **案B ウォームサンド `#e2d6bf`** を採用。帯色トークン `--surface-panel` のみを変更する最小差分で、メインのクリーム基調と地続きの落ち着いた色味にした。

Closes #414

## 変更内容
- `apps/web/src/app/globals.css`: `--surface-panel` を `#f0e68c` → `#e2d6bf`（`:root` / THEMEブロック内）
- `apps/web/src/styles/themes/current.css`: 巻き戻し先を同値 `#e2d6bf` に同期
- `apps/web/scripts/apply-theme.test.ts`: 帯色ハードコード期待値を新色へ更新（冪等性 / amber-dark切替 / THEMEブロック維持の3テスト）
- `README.md`: 現行帯色の記述をウォームサンドへ追随更新（#388 由来のハードコード史実 `#f0e68c` はそのまま保持）

## スコープ外（意図的に据え置き）
- `--surface-control`（白い操作面）: Issue の対象トークンは `--surface-panel` に限定のため据え置き。モック上、白い操作面が新帯色から浮かないことを確認済み
- トップページ（`/`）の帯: `.top-amber-dark` スコープで別途ダーク固定（`#2a1c0e`）のため、今回の変更の影響を受けない
- 文字色 `--foreground` / ロゴ文字色: 案Bは帯が明色のため変更不要

## テスト
- UT: `pnpm --filter @beersalon/web test` → 398 passed（`apply-theme.test.ts` 14件含む）
  - `current.css` と `globals.css` の一致検査 / amber-dark 往復切替の維持が緑
- E2E: 追加なし。CSSトークン1つの色値変更でロジック分岐が無く、`--surface-panel` の一致・テーマ切替の維持は UT で完全にカバーされるため、テストピラミッドの原則に基づき E2E コードは追加しない
- format / lint: いずれも No fixes applied

## 補足（レイアウトレビュー）
承認プロセスで提示した比較モック（現状 / 案A / 案B / 案C）を別途コメントで添付する。案Bは `text-foreground`（ダークブラウン ≈ `#3a3129`）とのコントラストを保ちつつ、メイン背景クリームと地続きで統一感が最も高いことを判断根拠とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)