### PR TITLE
docs(auth): SMTP送信元ドメインを「未定」に修正 (#405 後続)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,20 +258,22 @@ pnpm --filter @beersalon/web theme amber-dark
    - 許可外オリジンへのリダイレクトはブロックされ、メール内リンクが無効化される。
 3. **Supabase ダッシュボード → Project Settings → Authentication → SMTP（独自SMTP = Resend。dev/prod 両プロジェクトに設定する）**
    - 無料枠のデフォルト SMTP（`noreply@mail.app.supabase.io`）は送信レート（config.toml では 1時間2通）・到達率が低く「たまに届かない」状態になる。これを回避するため独自SMTP（**Resend**）に切り替える。
-   - 送信元は **`noreply@beersalon.com`**（独自ドメイン。SPF/DKIM を DNS に登録する）。
-   - **手順（dev / prod の各プロジェクトで同じ設定を行う。取り違えないこと）**:
-     1. Resend でアカウントを作成し、**Domains** に `beersalon.com` を追加する。表示される SPF（`TXT`）・DKIM（`TXT`）・（任意で）DMARC レコードを、`beersalon.com` の DNS に登録して Verified 状態にする。
+   - **前提（未確定・ブロッカー）**: 独自SMTP には**自分が DNS を編集できる独自ドメイン**が必要（SPF/DKIM を登録して到達率を担保するため）。当初想定した `beersalon.com` は**第三者（ドメイン転売業者 Domain Asset Holdings, LLC）が保有しており取得・DNS 編集ができない**ため使えない。**送信元ドメインは未定**であり、まず以下のいずれかを決める必要がある:
+     - 取得可能な別ドメインを取る（例: `beersalon.jp` / `beer-salon.app` / `craftbeersalon.com` 等。空き状況を確認して年額数千円で取得）→ 送信元を `noreply@<取得したドメイン>` にする（**本命**）
+     - ドメイン取得までの暫定として Resend の共有ドメイン（`onboarding@resend.dev`）で送る（DNS 不要ですぐ動くが到達率は独自ドメインに劣る。動作確認・暫定運用向け）
+   - **手順（ドメイン確定後。dev / prod の各プロジェクトで同じ設定を行う。取り違えないこと）**:
+     1. Resend でアカウントを作成し、**Domains** に**取得した独自ドメイン**を追加する。表示される SPF（`TXT`）・DKIM（`TXT`）・Return-Path 用 `CNAME`・（任意で）DMARC など、**画面に出るレコードをすべて**そのドメインの DNS に登録して Verified 状態にする。
      2. Resend の **API Keys** で送信用 API キーを発行する（`RESEND_API_KEY`）。
      3. Supabase ダッシュボード → **Project Settings → Authentication → SMTP Settings** で「Enable Custom SMTP」を ON にし、以下を設定する:
         - Host: `smtp.resend.com`
         - Port: `587`
         - Username: `resend`
         - Password: 発行した `RESEND_API_KEY`
-        - Sender email: `noreply@beersalon.com`
+        - Sender email: `noreply@<取得したドメイン>`
         - Sender name: `Beer Salon`
      4. あわせて **Authentication → Rate Limits** の "Emails sent per hour" を、デフォルトSMTP前提の低い値から実運用に耐える値へ引き上げる（config.toml のローカル値 `[auth.rate_limit] email_sent = 2` は Mailpit ローカル用であり、リモートには反映されない）。
    - **これは `apps/web` の全認証メール（`/signup` の確認メール・`/password/forgot`/`/password/reset` の再設定メール）に共通で効く**（すべて同一の Supabase Auth SMTP を経由するため、SMTP を切り替えれば両方が同時に改善する）。
-   - **検証**: preview（dev プロジェクト）で新規登録し、メールが届くことを確認する。加えて Supabase ダッシュボード → **Logs → Auth Logs** で送信ログの `mail_from` が `noreply@beersalon.com`（= デフォルトの `noreply@mail.app.supabase.io` ではない）になっていることを確認する。
+   - **検証**: preview（dev プロジェクト）で新規登録し、メールが届くことを確認する。加えて Supabase ダッシュボード → **Logs → Auth Logs** で送信ログの `mail_from` が**設定した独自ドメインの送信元**（= デフォルトの `noreply@mail.app.supabase.io` ではない）になっていることを確認する。
    - **注意**: `supabase/config.toml` の `[auth.email.smtp]` はコメントアウトのままでよい（ローカルは Mailpit を使うため。config.toml は `supabase db push` の対象外で、この SMTP 設定はダッシュボードでの手動設定でのみ有効になる）。
 4. **Vercel → 環境変数 `NEXT_PUBLIC_SITE_URL`**
    - production では必ず設定する（Host Header Injection 対策。`apps/web/src/lib/site-url.ts` の `getSiteUrl()` が最優先で参照する）。

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -213,14 +213,15 @@ otp_expiry = 3600
 
 # Use a production-ready SMTP server
 # ローカルは Mailpit で送信を捕捉するため有効化しない（dev/prod は各ダッシュボードで設定する。README「認証メールの配信設定」参照）。
-# 独自SMTP は Resend を採用。送信元は noreply@beersalon.com（独自ドメイン・SPF/DKIM 登録済み）。
+# 独自SMTP は Resend を採用予定。送信元ドメインは未定（当初想定の beersalon.com は第三者保有で使えない。
+# 取得可能な独自ドメインを確定してから <取得したドメイン> を差し替える）。
 # [auth.email.smtp]
 # enabled = true
 # host = "smtp.resend.com"
 # port = 587
 # user = "resend"
 # pass = "env(RESEND_API_KEY)"
-# admin_email = "noreply@beersalon.com"
+# admin_email = "noreply@<取得したドメイン>"
 # sender_name = "Beer Salon"
 
 # Uncomment to customize email template


### PR DESCRIPTION
## 概要

PR #409 で SMTP 手順を整備した際、送信元を `noreply@beersalon.com` として記載していた。しかし調査の結果、**`beersalon.com` は第三者（ドメイン転売業者 Domain Asset Holdings, LLC）が保有**しており、取得も DNS 編集もできず**使えない**ことが判明した。

使えないドメインを前提にした手順がドキュメントに残ると、将来 SMTP 設定を行うときに詰まる。そのため送信元ドメインを「**未定（要ドメイン確定）**」に是正する。

関連: #405（クローズ済み。本PRはそのフォローアップ・ドキュメント是正）

## 背景（whois 調査結果）

`beersalon.com` の登録情報:
- Registrant: **Domain Asset Holdings, LLC**（米フロリダの企業）
- Name Server: `NS1.DOMAIN-IS-4-SALE-AT-DOMAINMARKET.COM`（＝売り物として押さえられている状態）

→ 個人開発では現実的に取得できない。別ドメインの取得が必要。

## 変更内容

- **README.md**: 「認証メールの配信設定」項目3を修正
  - 独自ドメインが**未確定でブロッカー**である前提を明記
  - 二択を提示: ①取得可能な別ドメインを取る（本命）②暫定で `onboarding@resend.dev` を使う
  - 送信元・検証手順の `beersalon.com` を `<取得したドメイン>` プレースホルダに置換
  - Resend の Return-Path 用 `CNAME` を含め「画面に出るレコードをすべて登録」に補強（PR #409 レビューの Low 指摘も反映）
- **supabase/config.toml**: SMTP コメント例の `admin_email` を `noreply@<取得したドメイン>` に変更し、`beersalon.com` が使えない理由を注記

## テスト

- **UT / E2E**: 対象なし（ドキュメント修正のみ。ロジック変更なし）

## 残作業（コード外）

このIssueの核（実際のSMTP切替・到達検証）は依然としてダッシュボード作業。加えて**独自ドメインの取得（または resend.dev での暫定運用の判断）**が前段の未確定事項として残る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)