### PR TITLE
fix(admin): ビールカテゴリ初期マスタをマイグレーションで投入 (#428)

### DIFF
--- a/apps/admin/src/__tests__/seed-beer-categories-migration.test.ts
+++ b/apps/admin/src/__tests__/seed-beer-categories-migration.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Issue #428: beer_categories はマイグレーションで投入しないと remote（preview/prod）へ
+// 届かず、管理画面のメニュー登録でカテゴリが空になる。マイグレーションが「全環境へ届く
+// 経路（migrate.yml の supabase db push 対象）」で、確定した初期カテゴリを冪等 INSERT
+// していることを、SQL ファイル本文を読んで機械的に担保する。
+
+// このテストの正となる初期カテゴリ。ユーザー画面の検索フォーム（apps/web の
+// BEER_CATEGORIES）と語彙を揃える。検索側と登録側の語彙がズレるとヒットしないため、
+// 将来どちらかを変えたらこの一覧との差分でテストが落ちて気づける。
+const EXPECTED_CATEGORIES = [
+	"IPA",
+	"ピルスナー",
+	"スタウト",
+	"ヴァイツェン",
+	"ペールエール",
+];
+
+const MIGRATION_PATH = resolve(
+	__dirname,
+	"../../../../supabase/migrations/20260715000000_seed_beer_categories.sql",
+);
+
+function readMigration(): string {
+	return readFileSync(MIGRATION_PATH, "utf-8");
+}
+
+describe("beer_categories 初期マスタ投入マイグレーション（Issue #428）", () => {
+	it("beer_categories テーブルへ INSERT している", () => {
+		const sql = readMigration();
+		expect(sql).toMatch(/INSERT\s+INTO\s+beer_categories/i);
+	});
+
+	it("ON CONFLICT (name) DO NOTHING で冪等に投入している", () => {
+		const sql = readMigration();
+		// 既に投入済みの環境（E2E seed 済みローカル等）でも再適用で失敗しないこと。
+		expect(sql).toMatch(/ON\s+CONFLICT\s*\(\s*name\s*\)\s+DO\s+NOTHING/i);
+	});
+
+	it("確定した初期カテゴリをすべて投入している", () => {
+		const sql = readMigration();
+		for (const category of EXPECTED_CATEGORIES) {
+			expect(sql).toContain(`('${category}')`);
+		}
+	});
+
+	it("確定した以外のカテゴリを投入していない（VALUES 行数が一致する）", () => {
+		const sql = readMigration();
+		// INSERT ブロックの VALUES から '...' で囲まれた値だけを抜き出して件数を検証する。
+		const insertBlock = sql
+			.slice(sql.search(/INSERT\s+INTO\s+beer_categories/i))
+			.split(/ON\s+CONFLICT/i)[0];
+		const values = [...insertBlock.matchAll(/\('([^']+)'\)/g)].map((m) => m[1]);
+		expect(values.sort()).toEqual([...EXPECTED_CATEGORIES].sort());
+	});
+});

--- a/database.md
+++ b/database.md
@@ -153,6 +153,15 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 | created_at  | timestamptz| NOT NULL DEFAULT now()   | 作成日時             |
 | updated_at  | timestamptz| NOT NULL DEFAULT now()   | 更新日時             |
 
+**初期マスタデータ**:
+1. IPA
+2. ピルスナー
+3. スタウト
+4. ヴァイツェン
+5. ペールエール
+
+マイグレーション（`20260715000000_seed_beer_categories.sql`）で `ON CONFLICT (name) DO NOTHING` により冪等投入する（Issue #428）。従来 `beer_categories` はローカル専用の `seed.e2e.sql` にしか投入経路が無く、`migrate.yml`（`supabase db push` ＝マイグレーションのみ適用）では preview / production の remote DB に届かず、管理画面のメニュー登録でビールカテゴリのプルダウンが空になっていた。`payment_methods` と同じくマイグレーション内 INSERT に一本化して全環境へ届かせる。投入するカテゴリはユーザー画面の検索フォーム（`apps/web` の `BEER_CATEGORIES`）と語彙を揃える（検索側と登録側の語彙がズレるとヒットしないため）。
+
 ---
 
 ### 2-4. countries

--- a/supabase/migrations/20260715000000_seed_beer_categories.sql
+++ b/supabase/migrations/20260715000000_seed_beer_categories.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- ビールカテゴリ初期マスタ投入
+-- Issue #428
+-- ============================================================
+-- なぜマイグレーションで投入するか（Why not seed）:
+--   beer_categories は従来 supabase/seed.e2e.sql（E2E ローカル専用）にしか
+--   INSERT が無く、migrate.yml（supabase db push＝マイグレーションのみ適用）
+--   では preview / production の remote DB に届かなかった。その結果、管理画面の
+--   メニュー登録でビールカテゴリのプルダウンが空になり、必須項目のため登録できなかった。
+--   payment_methods と同じくマイグレーション内 INSERT に一本化し、全環境へ届かせる。
+--
+-- カテゴリはユーザー画面の検索フォーム（apps/web の BEER_CATEGORIES）と語彙を揃える。
+-- 検索側と登録側の語彙が一致しないと検索でヒットしないため。
+
+INSERT INTO beer_categories (name)
+VALUES
+  ('IPA'),
+  ('ピルスナー'),
+  ('スタウト'),
+  ('ヴァイツェン'),
+  ('ペールエール')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## 概要

管理画面のメニュー登録ページ（ビールメニュータブ）でビールカテゴリのプルダウンが空になり、必須項目のため店舗オーナーがビールメニューを登録できなかった問題を修正する。

Closes #428

## 根本原因

フロント（`BeerMenuCreateForm`）・API（`GET /api/master/beer-categories`）のコードは正常だった。プルダウンが空 = `beer_categories` テーブルに `is_active=true` の行が存在しないことが原因。

`beer_categories` は従来 `supabase/seed.e2e.sql`（E2E ローカル専用）にしか INSERT が無く、`migrate.yml`（`supabase db push` ＝マイグレーションのみ適用）では preview / production の remote DB に届かなかった。`payment_methods` はマイグレーション内 INSERT なので remote に届くが、`beer_categories` は投入経路が欠けていた。

## 変更内容

- **`supabase/migrations/20260715000000_seed_beer_categories.sql`（新規）**: `beer_categories` の初期マスタを `ON CONFLICT (name) DO NOTHING` で冪等投入。`develop`/`main` への push で `migrate.yml` が dev/prod 両プロジェクトへ自動適用するため、preview だけでなく全環境へ横展開される。
- 投入カテゴリはユーザー画面の検索フォーム（`apps/web` の `BEER_CATEGORIES`）と語彙を揃える（IPA / ピルスナー / スタウト / ヴァイツェン / ペールエール）。検索側と登録側の語彙がズレると検索でヒットしないため。
- **`apps/admin/src/__tests__/seed-beer-categories-migration.test.ts`（新規 UT）**: マイグレーション SQL 本文を読み、対象テーブル・`ON CONFLICT DO NOTHING` の冪等性・投入カテゴリ集合を機械検証。将来カテゴリを変えたら差分で落ちて気づける。
- **`database.md`**: `beer_categories` 節に初期マスタデータと投入経路を追記。

コード（フォーム／API）は正しいため変更していない。

## テスト

- **UT**: 追加した4テスト含め、`pnpm test` 全緑（admin 216 / web 403）。
- **DB 検証（ローカル）**: `supabase migration up --local` で適用後、REST API で `beer_categories` に5カテゴリが `is_active=true` で投入されることを確認。うち3件は既存 E2E seed 由来で `ON CONFLICT DO NOTHING` により重複せず、スタウト・ヴァイツェンが新規追加されることで冪等性も実証。
- **E2E**: 本修正はマスタデータ投入であり、ブラウザ固有挙動・複数画面フローではないため（テストピラミッド原則）、追加 UT でカバー。既存 E2E への追加はしない。

## 補足（別 Issue 提案）

`countries` / `regions` も同じ構造的欠陥（`seed.sql` にしか無く `migrate.yml` は seed 非適用）を抱えており、preview で国・産地プルダウンも空のはず。本 Issue スコープ外のため別 Issue 化を提案する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)