### PR TITLE
fix(admin): 国・産地マスタをマイグレーションで投入しメニュー登録で選択可能にする (#432)

### DIFF
--- a/apps/admin/src/__tests__/seed-countries-regions-migration.test.ts
+++ b/apps/admin/src/__tests__/seed-countries-regions-migration.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Issue #432: countries / regions はマイグレーションで投入しないと remote（preview/prod）へ
+// 届かず、管理画面のビールメニュー登録で国・産地のプルダウンが空になる（産地はユーザー画面の
+// 検索フィルタとも連動する）。#428（beer_categories）と同型の欠陥。マイグレーションが「全環境へ
+// 届く経路（migrate.yml の supabase db push 対象）」で、確定した初期マスタを冪等 INSERT
+// していることを、SQL ファイル本文を読んで機械的に担保する。
+
+// このテストの正となる初期マスタ。supabase/seed.sql の現行値を踏襲する。
+// 将来 seed.sql とマイグレーションのどちらかを変えたらこの一覧との差分でテストが落ちて気づける。
+const EXPECTED_COUNTRIES = [
+	"アメリカ",
+	"ベルギー",
+	"ドイツ",
+	"イギリス",
+	"チェコ",
+	"アイルランド",
+	"日本",
+	"オーストラリア",
+	"ニュージーランド",
+	"オランダ",
+];
+
+// 国名 → その国に投入する産地。regions INSERT が正しい国に紐付いていることを検証する。
+const EXPECTED_REGIONS_BY_COUNTRY: Record<string, string[]> = {
+	アメリカ: ["カリフォルニア", "オレゴン", "コロラド", "ワシントン"],
+	ベルギー: ["フランダース", "ワロン", "ブリュッセル"],
+	ドイツ: ["バイエルン", "ケルン", "ベルリン"],
+	イギリス: ["ロンドン", "バートン・アポン・トレント", "エディンバラ"],
+	チェコ: ["プルゼニ", "プラハ"],
+	アイルランド: ["ダブリン", "コーク"],
+	日本: ["静岡", "長野", "北海道", "東京", "大阪", "横浜"],
+	オーストラリア: ["メルボルン", "シドニー"],
+	ニュージーランド: ["ウェリントン", "オークランド"],
+	オランダ: ["アムステルダム"],
+};
+
+const MIGRATION_PATH = resolve(
+	__dirname,
+	"../../../../supabase/migrations/20260716000000_seed_countries_regions.sql",
+);
+
+function readMigration(): string {
+	return readFileSync(MIGRATION_PATH, "utf-8");
+}
+
+describe("countries / regions 初期マスタ投入マイグレーション（Issue #432）", () => {
+	it("countries テーブルへ INSERT している", () => {
+		const sql = readMigration();
+		expect(sql).toMatch(/INSERT\s+INTO\s+countries/i);
+	});
+
+	it("regions テーブルへ INSERT している", () => {
+		const sql = readMigration();
+		expect(sql).toMatch(/INSERT\s+INTO\s+regions/i);
+	});
+
+	it("countries を ON CONFLICT (name) DO NOTHING で冪等に投入している", () => {
+		const sql = readMigration();
+		// 既に投入済みの環境（seed 済みローカル等）でも再適用で失敗しないこと。
+		expect(sql).toMatch(/ON\s+CONFLICT\s*\(\s*name\s*\)\s+DO\s+NOTHING/i);
+	});
+
+	it("regions を ON CONFLICT (country_id, name) DO NOTHING で冪等に投入している", () => {
+		const sql = readMigration();
+		expect(sql).toMatch(
+			/ON\s+CONFLICT\s*\(\s*country_id\s*,\s*name\s*\)\s+DO\s+NOTHING/i,
+		);
+	});
+
+	it("確定した国をすべて投入している", () => {
+		const sql = readMigration();
+		for (const country of EXPECTED_COUNTRIES) {
+			expect(sql).toContain(`('${country}')`);
+		}
+	});
+
+	it("確定した以外の国を投入していない（countries の VALUES 行数が一致する）", () => {
+		const sql = readMigration();
+		// countries の INSERT ブロック（ON CONFLICT まで）から '...' で囲まれた値を抜き出す。
+		const insertBlock = sql
+			.slice(sql.search(/INSERT\s+INTO\s+countries/i))
+			.split(/ON\s+CONFLICT/i)[0];
+		const values = [...insertBlock.matchAll(/\('([^']+)'\)/g)].map((m) => m[1]);
+		expect(values.sort()).toEqual([...EXPECTED_COUNTRIES].sort());
+	});
+
+	it("各国の産地を、正しい国に紐付けて投入している（CROSS JOIN の国名で判定）", () => {
+		const sql = readMigration();
+		for (const [country, regions] of Object.entries(
+			EXPECTED_REGIONS_BY_COUNTRY,
+		)) {
+			// regions は「INSERT ... CROSS JOIN countries c WHERE c.name = '<国名>' ... ON CONFLICT」
+			// のブロック単位で国ごとに分かれている。国名で該当ブロックを切り出し、
+			// そのブロック内に期待する産地がすべて含まれることを検証する。
+			const marker = `WHERE c.name = '${country}'`;
+			const markerIndex = sql.indexOf(marker);
+			expect(
+				markerIndex,
+				`${country} の regions INSERT が見つからない`,
+			).toBeGreaterThan(-1);
+			// このブロックは marker の直前の VALUES から次の ON CONFLICT までが対象。
+			// marker より前の直近 VALUES ~ marker 以降最初の ON CONFLICT を1ブロックとして切る。
+			const blockStart = sql.lastIndexOf("VALUES", markerIndex);
+			const blockEnd = sql.indexOf("ON CONFLICT", markerIndex);
+			const block = sql.slice(blockStart, blockEnd);
+			for (const region of regions) {
+				expect(
+					block,
+					`${country} のブロックに産地「${region}」が含まれていない`,
+				).toContain(`('${region}')`);
+			}
+		}
+	});
+});

--- a/database.md
+++ b/database.md
@@ -181,6 +181,10 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 | created_at  | timestamptz| NOT NULL DEFAULT now() | 作成日時             |
 | updated_at  | timestamptz| NOT NULL DEFAULT now() | 更新日時             |
 
+**初期マスタデータ**: アメリカ / ベルギー / ドイツ / イギリス / チェコ / アイルランド / 日本 / オーストラリア / ニュージーランド / オランダ の10件。
+
+マイグレーション（`20260716000000_seed_countries_regions.sql`）で `ON CONFLICT (name) DO NOTHING` により冪等投入する（Issue #432）。従来 `countries` / `regions` はローカル専用の `seed.sql` にしか投入経路が無く、`migrate.yml`（`supabase db push` ＝マイグレーションのみ適用）では preview / production の remote DB に届かず、管理画面のビールメニュー登録で国・産地のプルダウンが空になっていた（産地はユーザー画面の検索フィルタ `getBeerRegions` とも連動するため検索側にも波及する）。`beer_categories`（#428）と同型の欠陥のため、同じくマイグレーション内 INSERT に一本化して全環境へ届かせる。投入内容は `seed.sql` の現行値を踏襲する（ローカル seed 側の INSERT も自己完結性のため残す）。
+
 ---
 
 ### 2-5. regions
@@ -202,6 +206,8 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 | updated_at  | timestamptz| NOT NULL DEFAULT now() | 更新日時             |
 
 UNIQUE制約: `country_id + name`
+
+**初期マスタデータ**: 各国の代表的ビール産地（例: 日本＝静岡 / 長野 / 北海道 / 東京 / 大阪 / 横浜、アメリカ＝カリフォルニア / オレゴン / コロラド / ワシントン ほか）。`countries` と同じマイグレーション（`20260716000000_seed_countries_regions.sql`）で投入する。`country_id` はハードコードせず `CROSS JOIN countries c WHERE c.name = '<国名>'` のサブクエリで動的解決し、`ON CONFLICT (country_id, name) DO NOTHING` で冪等投入する（Issue #432。詳細は `countries` を参照）。
 
 ---
 

--- a/supabase/migrations/20260716000000_seed_countries_regions.sql
+++ b/supabase/migrations/20260716000000_seed_countries_regions.sql
@@ -1,0 +1,108 @@
+-- ============================================================
+-- 国・産地 初期マスタ投入（countries / regions）
+-- Issue #432
+-- ============================================================
+-- なぜマイグレーションで投入するか（Why not seed）:
+--   countries / regions は従来 supabase/seed.sql（ローカル専用シード）にしか
+--   INSERT が無く、migrate.yml（supabase db push＝マイグレーションのみ適用）
+--   では preview / production の remote DB に届かなかった。その結果、管理画面の
+--   ビールメニュー登録で国・産地のプルダウンが空になり、選択できなかった。
+--   産地はユーザー画面の検索フィルタ（getBeerRegions）とも連動するため、remote で
+--   産地が空だと検索側にも波及する。#428（beer_categories）と同型の欠陥のため、
+--   同じくマイグレーション内 INSERT に一本化して全環境へ届かせる。
+--
+-- 投入内容は supabase/seed.sql の現行値を踏襲する。ON CONFLICT で冪等なため、
+-- seed 済みローカル（seed.sql / seed.e2e.sql）へ再適用しても衝突しない。
+-- country_id はハードコードせず、CROSS JOIN countries c WHERE c.name = '<国名>' で
+-- 動的解決する（先行する countries INSERT の結果を参照できる）。
+
+-- ============================================================
+-- Countries (主要ビール産地国)
+-- ============================================================
+
+INSERT INTO countries (name) VALUES
+  ('アメリカ'),
+  ('ベルギー'),
+  ('ドイツ'),
+  ('イギリス'),
+  ('チェコ'),
+  ('アイルランド'),
+  ('日本'),
+  ('オーストラリア'),
+  ('ニュージーランド'),
+  ('オランダ')
+ON CONFLICT (name) DO NOTHING;
+
+-- ============================================================
+-- Regions (各国の代表的ビール産地)
+-- ============================================================
+
+-- アメリカ
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('カリフォルニア'), ('オレゴン'), ('コロラド'), ('ワシントン')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'アメリカ'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- ベルギー
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('フランダース'), ('ワロン'), ('ブリュッセル')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'ベルギー'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- ドイツ
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('バイエルン'), ('ケルン'), ('ベルリン')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'ドイツ'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- イギリス
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('ロンドン'), ('バートン・アポン・トレント'), ('エディンバラ')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'イギリス'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- チェコ
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('プルゼニ'), ('プラハ')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'チェコ'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- アイルランド
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('ダブリン'), ('コーク')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'アイルランド'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- 日本
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('静岡'), ('長野'), ('北海道'), ('東京'), ('大阪'), ('横浜')) AS r(name)
+CROSS JOIN countries c WHERE c.name = '日本'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- オーストラリア
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('メルボルン'), ('シドニー')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'オーストラリア'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- ニュージーランド
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('ウェリントン'), ('オークランド')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'ニュージーランド'
+ON CONFLICT (country_id, name) DO NOTHING;
+
+-- オランダ
+INSERT INTO regions (name, country_id)
+SELECT r.name, c.id
+FROM (VALUES ('アムステルダム')) AS r(name)
+CROSS JOIN countries c WHERE c.name = 'オランダ'
+ON CONFLICT (country_id, name) DO NOTHING;


### PR DESCRIPTION
Closes #432

## 概要

管理画面のビールメニュー登録ページ（`/bars/[barId]/menus/new`）のビールメニュータブで、国（`countries`）・産地（`regions`）のプルダウンが preview / production で空になるバグを修正する。

## 根本原因（#428 と同型）

`countries` / `regions` の初期マスタは `supabase/seed.sql`（ローカル専用シード）にしか INSERT が無く、`supabase/migrations/` には無かった。`migrate.yml` は `supabase db push`（＝マイグレーションのみ適用）のため、seed.sql は preview / production の remote DB に届かず、remote では国・産地テーブルが空 → API（`is_active=true` で絞る）が空配列を返し、プルダウンが空になっていた。

産地はユーザー画面の検索フィルタ「ビールの地域」（`getBeerRegions()`）とも連動するため、remote で産地が空だと検索側にも波及していた。

## 修正内容

- **`supabase/migrations/20260716000000_seed_countries_regions.sql` を追加**
  - `countries`（国10件、`ON CONFLICT (name) DO NOTHING`）
  - `regions`（各国の産地、`country_id` は `CROSS JOIN countries c WHERE c.name = '<国名>'` で動的解決、`ON CONFLICT (country_id, name) DO NOTHING`）
  - 投入内容は `seed.sql` の現行値を踏襲。#428（`beer_categories`）と同じくマイグレーション内 INSERT に一本化し `migrate.yml` 経由で全環境へ届かせる。
- **UT を追加**（`apps/admin/src/__tests__/seed-countries-regions-migration.test.ts`）
  - #428 の同型テストを踏襲し、SQL 本文を機械検証（テーブル・ON CONFLICT・国10件・各国産地の国紐付け）。
- **`database.md`** の `countries` / `regions` セクションに初期マスタ投入方針を追記。
- `seed.sql` / `seed.e2e.sql` の既存 INSERT は自己完結性のため残す（#428 と一貫。ON CONFLICT で冪等なため二重管理でも実害なし）。

## 検証

- UT: `pnpm --filter @beersalon/admin test` 全 235 件 green（新規7件含む）。
- ローカルDB: worktree から `supabase migration up` で新規マイグレーションを適用 → `countries` 10件 / `regions` 28件（各国分）が投入されることを確認。
- 冪等性: マイグレーションSQL・seed.sql を再適用しても全 INSERT が衝突スキップ（`INSERT 0 0`）で件数不変・エラーなしを確認。
- E2E コード: 本修正の本質は remote DB へのマスタ配信であり、ローカルでは seed.sql により元々表示されていて UI 差分が出ないため、テストピラミッドの原則に沿い E2E コードは追加せず UT + DB適用実証でカバー。

※ preview / production への実適用は develop / main への push 後に `migrate.yml` が自動で行う（本 PR マージが適用トリガー）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)