### PR TITLE
リデザイン基盤: Dark Taproom のデザイントークン整備とフォント導入 (#440)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ pnpm --filter @beersalon/web theme amber-dark
 - **拡張トークン**: `--heading` / `--subtext` / `--primary-strong` / `--surface-deep` / `--surface-raised` / `--success` を追加（`text-heading` / `bg-surface-raised` 等で参照可）。
 - **タイポグラフィ（`next/font`）**: `apps/web/src/app/layout.tsx` で **Zen Old Mincho**（見出し・店名・記事本文）/ **Zen Kaku Gothic New**（UI 本文・デフォルト）/ **Archivo**（ラテン見出し・ロゴ）を読み込み、CSS 変数（`--font-mincho` / `--font-gothic` / `--font-archivo`）を `<body>` に付与。デフォルト UI フォント（`font-sans`）は Zen Kaku Gothic New。明朝は `.font-mincho`、Archivo は `.font-archivo` ユーティリティで任意要素へ当てる。
 - **新しいテーマを足すときは `themes/` に CSS を1つ追加するだけ**でよい（`current.css` を複製して値を変える）。手で `globals.css` の `:root` を直接編集した場合は、巻き戻し先である `themes/current.css` も同じ内容に揃えること（UT `apply-theme.test.ts` が両者の一致を検査する）。
-- **`amber-dark.css` の位置づけ**: #389 で作られた「surface トークンのみダーク化・他は旧ライト HSL 値の据え置き」テーマ。基盤が Dark Taproom になった今は役割が薄いが、テーマ切替フローの互換のため残置（撤去は別 Issue）。このテーマを当てると surface 以外は旧 HSL 値のため透明化する。
+- **`amber-dark.css` の位置づけ**: #389 で作られた「surface トークンのみダーク化・他は旧ライト HSL 値の据え置き」テーマ。基盤が Dark Taproom になった今は役割を失っており、このテーマを当てると surface 以外は旧 HSL 値のため透明化する（＝壊れたテーマ）。テーマ切替フローの互換のため #440 では残置し、**撤去は別 Issue #449 で扱う**。
 
 ### トップページ（`/`）の `.top-amber-dark` スコープ
 

--- a/README.md
+++ b/README.md
@@ -140,32 +140,36 @@ claude --plugin-dir ./plugins/bs-workflow
 
 ---
 
-## 🎨 配色テーマの切替（ユーザー画面 / apps/web）
+## 🎨 配色テーマ（ユーザー画面 / apps/web）＝ Dark Taproom 基盤
 
-ユーザー画面の配色を「テーマ」単位で差し替えられる（方式③: ビルド時・開発者切替。実行時のユーザー向けトグルは対象外）。目的は、デザインを変えても**容易に前へ戻せる**こと。
+ユーザー画面は **Dark Taproom（ダーク×アンバー基調）** で全画面を統一する方針（#440 で基盤導入）。配色は「テーマ」単位で差し替えられる（方式③: ビルド時・開発者切替。実行時のユーザー向けトグルは対象外）。目的は、デザインを変えても**容易に前へ戻せる**こと。配色・タイポの正は `design_handoff_user_screens/README.md` の Design Tokens 表。
 
 ```bash
-# 現行（ライトなアンバー・クリーム基調 = 巻き戻し先）に戻す
+# 現行 = Dark Taproom（巻き戻し先）に戻す
 pnpm --filter @beersalon/web theme current
 
-# #383 案A（ダークブラウン × アンバーゴールド）に切り替える
+# Dark Taproom を明示的に復元する（current.css と同内容）
+pnpm --filter @beersalon/web theme dark-taproom
+
+# 旧: #383 案A（surface のみダーク化・他トークンは旧ライト値の据え置き）
 pnpm --filter @beersalon/web theme amber-dark
 ```
 
 - テーマ本体は `apps/web/src/styles/themes/<name>.css`（各ファイルが `:root { ... }` を1つ持つ）。
 - `pnpm theme <name>` は `apps/web/src/app/globals.css` 内の `/* THEME:START */` 〜 `/* THEME:END */` で囲まれた `:root` ブロックを、指定テーマの内容へ差し替える。反映は `pnpm dev` の再ビルド / ブラウザリロードで行われる。
-- 切替が一貫して追従するのは、共通ヘッダー / フッターの帯・検索フォームのカード・入力欄・チップ・アイコン背景で使う `--surface-panel`（帯・カード）/ `--surface-control`（白い操作面）の2トークン。以前はこれらが `#f0e68c` / `#ffffff` / `bg-white` としてハードコードされ、テーマ切替から取り残されていた（#388 で「戻せない」と判明した直接原因）。現行 current の帯色は `--surface-panel: #e2d6bf`（ウォームサンド。#414 で、以前の明るい黄色 `#f0e68c` がメインコンテンツと合わず幼い印象だったのを落ち着いた色味へ変更）。
+- **#440 で HSL トークンの透明化を解消済み**: 以前は `:root` の `--background` / `--primary` 等が HSL 成分値（`30 75% 45%`）のままで `@theme inline` が `hsl()` ラップせず、`bg-background` / `bg-primary` / `text-foreground` / `bg-card` 等が**透明（無色）**で機能していなかった。#440 で各トークンに**実 Hex 値**（例 `--primary: #e0a341`、`--background: #15100a`）を直接持たせ、`@theme inline` の `--color-*` がそれを返すことでこれらのクラスが有効化された。web 全体の面が Dark Taproom で色を持つ。
+- **拡張トークン**: `--heading` / `--subtext` / `--primary-strong` / `--surface-deep` / `--surface-raised` / `--success` を追加（`text-heading` / `bg-surface-raised` 等で参照可）。
+- **タイポグラフィ（`next/font`）**: `apps/web/src/app/layout.tsx` で **Zen Old Mincho**（見出し・店名・記事本文）/ **Zen Kaku Gothic New**（UI 本文・デフォルト）/ **Archivo**（ラテン見出し・ロゴ）を読み込み、CSS 変数（`--font-mincho` / `--font-gothic` / `--font-archivo`）を `<body>` に付与。デフォルト UI フォント（`font-sans`）は Zen Kaku Gothic New。明朝は `.font-mincho`、Archivo は `.font-archivo` ユーティリティで任意要素へ当てる。
 - **新しいテーマを足すときは `themes/` に CSS を1つ追加するだけ**でよい（`current.css` を複製して値を変える）。手で `globals.css` の `:root` を直接編集した場合は、巻き戻し先である `themes/current.css` も同じ内容に揃えること（UT `apply-theme.test.ts` が両者の一致を検査する）。
-- **既知の制約**: `globals.css` の既存 HSL トークン（`--background` / `--primary` 等）は `hsl()` ラップされておらず、`bg-background` / `bg-primary` などは現状レンダリング上は無色（透明）で機能していない。そのため `theme amber-dark`（ビルド時切替）でも「帯・操作面（`--surface-*`）」以外の面はダーク化しない。全画面のダークテーマ化・実行時テーマトグル（next-themes 等）は別 Issue で扱う。
+- **`amber-dark.css` の位置づけ**: #389 で作られた「surface トークンのみダーク化・他は旧ライト HSL 値の据え置き」テーマ。基盤が Dark Taproom になった今は役割が薄いが、テーマ切替フローの互換のため残置（撤去は別 Issue）。このテーマを当てると surface 以外は旧 HSL 値のため透明化する。
 
-### トップページ（`/`）のダーク基調（#388 案A / Amber Taproom）
+### トップページ（`/`）の `.top-amber-dark` スコープ
 
-トップページ（`apps/web` の `/`）は、上記のビルド時テーマ切替とは別に、**トップページ限定でダークブラウン × アンバーゴールド基調**に固定している（#383 案A）。
+トップページ（`apps/web` の `/`）の最上位ラッパには `page-client.tsx` で `.top-amber-dark` クラスが付いている。
 
-- 実装は `globals.css` の `.top-amber-dark` スコープと、`page-client.tsx` の最上位ラッパへのクラス付与。トップの本文背景・検索カード・入力欄・チップ・店舗カード・各「人気で探す」セクションがこのスコープ配下でダーク化される。
-- **なぜ `:root` ごとダーク化しないか**: 上記の既知の制約どおり `bg-card` / `text-foreground` 等は透明で機能しておらず、`:root` を有効化すると web 全体（他ページ・共通ヘッダー/フッター）へダークが芋づる波及する。#388 のスコープはトップページの見た目に限定のため、`.top-amber-dark` 配下だけに閉じ込めている。
-- **スコープ外**: 共通ヘッダー / フッターの帯（`--surface-panel` = ウォームサンド `#e2d6bf`）と、トップ以外の14ページはライト基調のまま。全画面ダーク化は別 Issue。
-- スコープが `THEME:START`〜`THEME:END` の外にあること・`:root` が current のライト値のままであることは UT `apply-theme.test.ts` が検査する。
+- **#440 以降の役割**: `:root` 自体が Dark Taproom 化され、壊れトークンが実 Hex で有効化されたため、以前このスコープ内で壊れトークンを実色に置換していた個別上書き（`.top-amber-dark .bg-card` 等）は**不要になり撤去済み**。スコープは背景・文字色を基盤トークン（`--background` / `--foreground`）へ寄せるだけの薄い定義に縮小した。
+- **スコープ全撤去は別 Issue**: `.top-amber-dark` ラッパの撤去とトップの見た目最適化は #440（基盤のみ）のスコープ外。後続の共通レイアウト / 各画面 Issue が扱う。
+- スコープ定義が `THEME:START`〜`THEME:END` の外にあること・`:root` が Dark Taproom の実 Hex トークンで定義されていることは UT `apply-theme.test.ts` が検査する。
 
 ---
 

--- a/apps/web/scripts/apply-theme.test.ts
+++ b/apps/web/scripts/apply-theme.test.ts
@@ -55,7 +55,8 @@ describe("replaceThemeBlock", () => {
 	});
 
 	it("current → amber-dark → current で元の内容に戻る", () => {
-		const currentBlock = ":root {\n  --surface-panel: #e2d6bf;\n}";
+		const currentBlock =
+			":root {\n  --surface-panel: rgba(21, 16, 10, 0.9);\n}";
 		const darkBlock = ":root {\n  --surface-panel: #2a1c0e;\n}";
 		const toDark = replaceThemeBlock(base, darkBlock);
 		const backToCurrent = replaceThemeBlock(toDark, currentBlock);
@@ -97,17 +98,52 @@ describe("テーマファイルと globals.css の整合", () => {
 		expect(applied).not.toContain("--surface-control: #ffffff;");
 	});
 
-	it("listThemes が current と amber-dark を返す", () => {
+	it("listThemes が current / amber-dark / dark-taproom を返す", () => {
 		const themes = listThemes(themesDir);
 		expect(themes).toContain("current");
 		expect(themes).toContain("amber-dark");
+		// Issue #440: current と同内容の Dark Taproom 復元用テーマ
+		expect(themes).toContain("dark-taproom");
+	});
+
+	it("dark-taproom テーマの :root ブロックが current.css と一致する（復元用の同一性）", () => {
+		const currentCss = readFileSync(join(themesDir, "current.css"), "utf8");
+		const darkTaproomCss = readFileSync(
+			join(themesDir, "dark-taproom.css"),
+			"utf8",
+		);
+		// コメント文言は異なるため、色トークンの実値が揃っていることを主要トークンで検査する
+		for (const token of [
+			"--background: #15100a;",
+			"--primary: #e0a341;",
+			"--heading: #f5e9d4;",
+			"--surface-panel: rgba(21, 16, 10, 0.9);",
+		]) {
+			expect(currentCss).toContain(token);
+			expect(darkTaproomCss).toContain(token);
+		}
 	});
 });
 
-describe("トップページ限定ダークスコープ（#388 案A）", () => {
+describe("Dark Taproom 基盤（Issue #440）", () => {
 	const globalsCss = readFileSync(globalsPath, "utf8");
 
-	it("globals.css にトップ限定スコープ .top-amber-dark が定義されている", () => {
+	it("THEME ブロック（:root）が Dark Taproom の実 Hex トークンを実値で定義している", () => {
+		const startIdx = globalsCss.indexOf("/* THEME:START");
+		const endIdx = globalsCss.indexOf("/* THEME:END */");
+		const themeBlock = globalsCss.slice(startIdx, endIdx);
+		// 壊れた HSL 成分値ではなく実 Hex 値で定義され、bg-* / text-* が透明化しないこと
+		expect(themeBlock).toContain("--background: #15100a;");
+		expect(themeBlock).toContain("--card: #1e160d;");
+		expect(themeBlock).toContain("--primary: #e0a341;");
+		expect(themeBlock).toContain("--foreground: #e6d3ac;");
+		expect(themeBlock).toContain("--heading: #f5e9d4;");
+		// 旧ライト基調（透明化していた HSL 成分値・白操作面）が残っていないこと
+		expect(themeBlock).not.toContain("--surface-control: #ffffff;");
+		expect(themeBlock).not.toContain("--primary: 30 75% 45%;");
+	});
+
+	it("globals.css にトップ限定スコープ .top-amber-dark が残っている（撤去は別 Issue）", () => {
 		expect(globalsCss).toContain(".top-amber-dark");
 	});
 
@@ -120,20 +156,10 @@ describe("トップページ限定ダークスコープ（#388 案A）", () => {
 		expect(themeBlock).not.toContain(".top-amber-dark");
 	});
 
-	it("スコープ内で surface トークンを案Aのダーク値へ上書きしている", () => {
-		const scopeIdx = globalsCss.indexOf(".top-amber-dark {");
-		const scopeEnd = globalsCss.indexOf("}", scopeIdx);
-		const scopeBlock = globalsCss.slice(scopeIdx, scopeEnd);
-		expect(scopeBlock).toContain("--surface-panel: #2a1c0e;");
-		expect(scopeBlock).toContain("--surface-control: #3d2b17;");
-	});
-
-	it("THEME ブロック（:root）は現行 current のライト値のまま（全画面ダーク化していない）", () => {
-		const startIdx = globalsCss.indexOf("/* THEME:START");
-		const endIdx = globalsCss.indexOf("/* THEME:END */");
-		const themeBlock = globalsCss.slice(startIdx, endIdx);
-		// current のライト基調（帯=ウォームサンド / 操作面=白）が :root に維持されていること
-		expect(themeBlock).toContain("--surface-panel: #e2d6bf;");
-		expect(themeBlock).toContain("--surface-control: #ffffff;");
+	it("@theme inline に明朝・Archivo のフォント変数が登録されている", () => {
+		// next/font で読み込む Zen Old Mincho / Archivo を任意要素へ適用できること
+		expect(globalsCss).toContain("--font-mincho: var(--font-mincho);");
+		expect(globalsCss).toContain("--font-archivo: var(--font-archivo);");
+		expect(globalsCss).toContain("--font-sans: var(--font-gothic);");
 	});
 });

--- a/apps/web/scripts/apply-theme.test.ts
+++ b/apps/web/scripts/apply-theme.test.ts
@@ -9,6 +9,18 @@ const webRoot = join(scriptDir, "..");
 const themesDir = join(webRoot, "src", "styles", "themes");
 const globalsPath = join(webRoot, "src", "app", "globals.css");
 
+/**
+ * テーマ CSS から `--token: value;` 形式の宣言行だけを抽出して並べる。
+ * コメント（`/* ... *​/`）や `:root {` / `}` などの構造行は落とすため、
+ * コメント文言だけが異なる2ファイルでもトークンの完全一致を検査できる。
+ */
+function extractDeclarations(css: string): string[] {
+	return css
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => /^--[\w-]+\s*:/.test(line));
+}
+
 describe("extractRootBlock", () => {
 	it(":root ブロックのみを抜き出す（前後のコメント・他セレクタは含めない）", () => {
 		const css = `/* comment */\n:root {\n  --a: 1;\n  --b: #fff;\n}\n.other { color: red; }`;
@@ -106,22 +118,18 @@ describe("テーマファイルと globals.css の整合", () => {
 		expect(themes).toContain("dark-taproom");
 	});
 
-	it("dark-taproom テーマの :root ブロックが current.css と一致する（復元用の同一性）", () => {
+	it("dark-taproom テーマの全トークンが current.css と完全一致する（片方だけ変更したらドリフト検出）", () => {
 		const currentCss = readFileSync(join(themesDir, "current.css"), "utf8");
 		const darkTaproomCss = readFileSync(
 			join(themesDir, "dark-taproom.css"),
 			"utf8",
 		);
-		// コメント文言は異なるため、色トークンの実値が揃っていることを主要トークンで検査する
-		for (const token of [
-			"--background: #15100a;",
-			"--primary: #e0a341;",
-			"--heading: #f5e9d4;",
-			"--surface-panel: rgba(21, 16, 10, 0.9);",
-		]) {
-			expect(currentCss).toContain(token);
-			expect(darkTaproomCss).toContain(token);
-		}
+		// コメント文言は両ファイルで異なるため、:root 内の `--token: value;` 行だけを
+		// 全件抽出して比較する。主要4トークンだけの部分検査だと残り約30トークンが片方だけ
+		// 変更されても緑のまま通ってしまうため、全トークンの完全一致で守る。
+		expect(extractDeclarations(currentCss)).toEqual(
+			extractDeclarations(darkTaproomCss),
+		);
 	});
 });
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -6,8 +6,13 @@
 @theme inline {
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
-	--font-sans: var(--font-geist-sans);
-	--font-mono: var(--font-geist-mono);
+	/* Why not var(--font-geist-*): Dark Taproom は Zen Kaku Gothic New を UI 本文の
+	   デフォルトにするため、--font-sans を Gothic 変数に付け替える。Zen Old Mincho（見出し・
+	   店名・記事本文）と Archivo（ラテン見出し・ロゴ）は個別ユーティリティで参照する。 */
+	--font-sans: var(--font-gothic);
+	--font-mincho: var(--font-mincho);
+	--font-archivo: var(--font-archivo);
+	--font-mono: var(--font-archivo);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -39,6 +44,13 @@
 	--color-card: var(--card);
 	--color-surface-panel: var(--surface-panel);
 	--color-surface-control: var(--surface-control);
+	/* Dark Taproom 拡張トークン（README の Design Tokens 表を正とする） */
+	--color-surface-deep: var(--surface-deep);
+	--color-surface-raised: var(--surface-raised);
+	--color-primary-strong: var(--primary-strong);
+	--color-heading: var(--heading);
+	--color-subtext: var(--subtext);
+	--color-success: var(--success);
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
@@ -47,40 +59,54 @@
 
 /* THEME:START (このブロックは pnpm theme <name> で src/styles/themes/<name>.css の内容に差し替わる。手編集する場合は themes/current.css も揃えること) */
 :root {
+	/*
+	 * Dark Taproom（ダーク×アンバー基調）。
+	 * Why not HSL 成分値: 従来の `--primary: 30 75% 45%` は @theme inline で hsl() 未ラップのため
+	 * bg-primary / text-foreground / bg-card 等が透明化し機能していなかった（Issue #440）。
+	 * トークンに実 Hex を直接持たせ、@theme inline の --color-* がそれを返すことで有効化する。
+	 * 値は design_handoff_user_screens/README.md の Design Tokens 表を正とする。
+	 */
 	--radius: 1rem;
-	--background: 35 25% 92%;
-	--foreground: 30 15% 20%;
-	--card: 35 20% 96%;
-	--card-foreground: 30 15% 25%;
-	--popover: 35 20% 96%;
-	--popover-foreground: 30 15% 25%;
-	--primary: 30 75% 45%;
-	--primary-foreground: 0 0% 100%;
-	--secondary: 35 60% 55%;
-	--secondary-foreground: 30 15% 20%;
-	--muted: 35 20% 85%;
-	--muted-foreground: 30 10% 45%;
-	--accent: 30 50% 88%;
-	--accent-foreground: 30 75% 40%;
-	--destructive: 0 84% 60%;
-	--border: 35 15% 82%;
-	--input: 35 15% 82%;
-	--ring: 30 75% 45%;
-	--chart-1: 30 75% 45%;
-	--chart-2: 35 60% 55%;
-	--chart-3: 40 65% 50%;
-	--chart-4: 25 70% 50%;
-	--chart-5: 35 55% 60%;
-	--sidebar: 35 20% 96%;
-	--sidebar-foreground: 30 15% 20%;
-	--sidebar-primary: 30 75% 45%;
-	--sidebar-primary-foreground: 0 0% 100%;
-	--sidebar-accent: 35 20% 90%;
-	--sidebar-accent-foreground: 30 15% 20%;
-	--sidebar-border: 35 15% 82%;
-	--sidebar-ring: 30 75% 45%;
-	--surface-panel: #e2d6bf;
-	--surface-control: #ffffff;
+	--background: #15100a;
+	--foreground: #e6d3ac;
+	--card: #1e160d;
+	--card-foreground: #f3e7d2;
+	--popover: #1e160d;
+	--popover-foreground: #f3e7d2;
+	--primary: #e0a341;
+	--primary-foreground: #20160a;
+	--secondary: #2c2013;
+	--secondary-foreground: #f5e9d4;
+	--muted: #241a0e;
+	--muted-foreground: #9c8763;
+	--accent: #2c2013;
+	--accent-foreground: #e0a341;
+	--destructive: #e0483a;
+	--border: rgba(224, 163, 65, 0.18);
+	--input: #241a0e;
+	--ring: #e0a341;
+	--chart-1: #e0a341;
+	--chart-2: #c47f28;
+	--chart-3: #a5691f;
+	--chart-4: #8a5a2a;
+	--chart-5: #5a3818;
+	--sidebar: #1e160d;
+	--sidebar-foreground: #e6d3ac;
+	--sidebar-primary: #e0a341;
+	--sidebar-primary-foreground: #20160a;
+	--sidebar-accent: #2c2013;
+	--sidebar-accent-foreground: #f5e9d4;
+	--sidebar-border: rgba(224, 163, 65, 0.18);
+	--sidebar-ring: #e0a341;
+	--surface-panel: rgba(21, 16, 10, 0.9);
+	--surface-control: #241a0e;
+	/* Dark Taproom 拡張トークン */
+	--surface-deep: #0f0b06;
+	--surface-raised: #241a0e;
+	--primary-strong: #c47f28;
+	--heading: #f5e9d4;
+	--subtext: #c9b48c;
+	--success: #7fc47f;
 }
 /* THEME:END */
 
@@ -128,45 +154,28 @@
 }
 
 /*
- * トップページ（/）限定の案A（Amber Taproom / ダーク基調）スコープ。
- * Why not :root ごとダーク化: globals.css の既存 HSL トークン（--background / --card / --card-foreground 等）は
- * @theme inline で hsl() ラップされておらず bg-card / text-foreground 等は透明で機能していない。
- * これを :root で有効化すると web 全体（他14ページ・共通ヘッダー/フッター）へダークが芋づる波及し、
- * Issue #388 が明示的にスコープ外とした「全画面ダーク化」になる。よってトップの最上位ラッパに付与した
- * .top-amber-dark の配下だけで、実 CSS 値の背景・面・テキスト色を当ててダーク化を閉じ込める。
+ * トップページ（/）限定スコープ（旧: 案A Amber Taproom）。
+ * Issue #440 で :root 自体を Dark Taproom 化し、壊れていた HSL トークンを実 Hex で有効化したため、
+ * bg-card / text-foreground / text-muted-foreground 等は :root 経由で正しく色が付くようになった。
+ * よって、以前スコープ内で壊れトークンを実色に置換していた個別上書きは不要になり撤去する。
+ * スコープ内の surface トークン上書きも、基盤（:root）の Dark Taproom 値へ寄せて二重定義の色ズレを防ぐ。
+ * Why not スコープ全撤去: .top-amber-dark ラッパの撤去とトップの見た目最適化は本 Issue（基盤のみ）の
+ * スコープ外で、後続の共通レイアウト / 各画面 Issue が扱う。ここではラッパを残しつつ基盤と整合させる。
  */
 .top-amber-dark {
-	/* 案A: ダークブラウン基調の本文背景とアンバー寄りのテキスト */
-	background-color: #1a1206;
-	color: #f5e9d4;
-
-	/* 帯（検索カード）＝ダークブラウン、操作面（入力欄・チップ）＝一段明るいブラウン。
-	   surface トークンはスコープ内で上書きし、テーマ切替(current)の他画面には影響させない。 */
-	--surface-panel: #2a1c0e;
-	--surface-control: #3d2b17;
-}
-
-/* 透明で機能していない壊れトークン依存クラスを、スコープ配下で実色に置換する。 */
-.top-amber-dark .bg-card {
-	background-color: #241a0c;
-}
-.top-amber-dark .text-card-foreground {
-	color: #f5e9d4;
-}
-.top-amber-dark .text-foreground {
-	color: #f5e9d4;
-}
-.top-amber-dark .text-muted-foreground {
-	color: #c4a878;
-}
-.top-amber-dark .bg-muted {
-	background-color: #3d2b17;
-}
-.top-amber-dark .border-border {
-	border-color: #4a3620;
+	background-color: var(--background);
+	color: var(--foreground);
 }
 
 @layer utilities {
+	/* Dark Taproom タイポグラフィ。見出し・店名・記事本文は明朝、ラテン見出し・ロゴは Archivo。 */
+	.font-mincho {
+		font-family: var(--font-mincho), serif;
+	}
+	.font-archivo {
+		font-family: var(--font-archivo), sans-serif;
+	}
+
 	.glass-card {
 		@apply bg-card/80 backdrop-blur-xl border border-border/20 shadow-2xl;
 	}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -12,7 +12,11 @@
 	--font-sans: var(--font-gothic);
 	--font-mincho: var(--font-mincho);
 	--font-archivo: var(--font-archivo);
-	--font-mono: var(--font-archivo);
+	/* Why not var(--font-archivo): Archivo はプロポーショナルサンセリフで等幅ではないため、
+	   font-mono に割り当てるとコードブロック・桁揃え数値で桁ズレが起きる。等幅スタックを明示する。 */
+	--font-mono:
+		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,27 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Archivo, Zen_Kaku_Gothic_New, Zen_Old_Mincho } from "next/font/google";
 import { Toaster } from "sonner";
 import "./globals.css";
 
-const geistSans = Geist({
-	variable: "--font-geist-sans",
+// Dark Taproom タイポグラフィ（design_handoff_user_screens/README.md を正とする）
+// Zen Old Mincho: 見出し・店名・PR文・記事本文（明朝）
+const zenOldMincho = Zen_Old_Mincho({
+	variable: "--font-mincho",
+	weight: ["700", "900"],
 	subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-	variable: "--font-geist-mono",
+// Zen Kaku Gothic New: UI 本文・ラベル・ボタンのデフォルト（ゴシック）
+const zenKakuGothicNew = Zen_Kaku_Gothic_New({
+	variable: "--font-gothic",
+	weight: ["400", "500", "700", "900"],
+	subsets: ["latin"],
+});
+
+// Archivo: ラテン見出し・ロゴ "Salon"・オーバーライン・カウンタ数字
+const archivo = Archivo({
+	variable: "--font-archivo",
+	weight: ["500", "600", "700", "800"],
 	subsets: ["latin"],
 });
 
@@ -27,7 +39,7 @@ export default function RootLayout({
 	return (
 		<html lang="ja">
 			<body
-				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+				className={`${zenKakuGothicNew.variable} ${zenOldMincho.variable} ${archivo.variable} font-sans antialiased`}
 			>
 				{children}
 				<Toaster />

--- a/apps/web/src/styles/themes/dark-taproom.css
+++ b/apps/web/src/styles/themes/dark-taproom.css
@@ -1,9 +1,7 @@
 :root {
 	/*
-	 * Dark Taproom（ダーク×アンバー基調）。
-	 * Why not HSL 成分値: 従来の `--primary: 30 75% 45%` は @theme inline で hsl() 未ラップのため
-	 * bg-primary / text-foreground / bg-card 等が透明化し機能していなかった（Issue #440）。
-	 * トークンに実 Hex を直接持たせ、@theme inline の --color-* がそれを返すことで有効化する。
+	 * Dark Taproom（ダーク×アンバー基調）。current.css と同内容の復元用テーマ（Issue #440）。
+	 * `pnpm --filter @beersalon/web theme dark-taproom` で globals.css の :root をこの内容へ戻せる。
 	 * 値は design_handoff_user_screens/README.md の Design Tokens 表を正とする。
 	 */
 	--radius: 1rem;

--- a/design_handoff_user_screens/README.md
+++ b/design_handoff_user_screens/README.md
@@ -70,6 +70,7 @@ Google Fonts で読み込み:
 - **Zen Old Mincho**（serif, 700/900）— 見出し・店名・PR文・記事本文。ブランドの落ち着いた世界観の核。
 - **Zen Kaku Gothic New**（sans, 400/500/700/900）— UI本文・ラベル・ボタンのデフォルト。
 - **Archivo**（sans, 500–800）— ラテン文字の見出し・ロゴの "Salon"・オーバーライン（`letter-spacing` を広めに, `text-transform: uppercase`）・カウンタ数字・monospace風のキャプション。
+  - **運用ルール**: Archivo は**和文グリフを持たない**ため、`.font-archivo`（実装は `apps/web/src/app/globals.css`）は**ラテン文字（英字・数字）要素に限定**して適用する。日本語を含む要素に当てると和文がフォールバックフォントへ落ちてラテン字と和字でフォントが混在するため、和文を含む見出し・本文は Zen Old Mincho / Zen Kaku Gothic New を使う。
 
 代表サイズ:
 - モバイル ヒーロー見出し: 25–27px / 900 / line-height 1.25–1.35（Zen Old Mincho）


### PR DESCRIPTION
## 概要

`apps/web`（ユーザー画面）を **Dark Taproom（ダーク×アンバー基調）** へ全面リデザインするための**共通基盤**を整備した。配色トークン・タイポグラフィを整え、後続のリデザイン各画面 Issue がこの基盤の上に乗れるようにする。配色・タイポの正は `design_handoff_user_screens/README.md` の Design Tokens 表。

## 根本原因の解消（HSL トークンの透明化）

従来 `globals.css` の `:root` は `--primary: 30 75% 45%` のような **HSL 成分値**のままで、`@theme inline` が `hsl()` ラップしていなかったため、`bg-primary` / `bg-background` / `text-foreground` / `bg-card` 等が**透明（無色）**で機能していなかった。本 PR で各トークンに**実 Hex 値**を直接持たせ、`@theme inline` の `--color-*` がそれを返すことで有効化した。

## 変更内容

- **`globals.css`**: `:root`（THEMEブロック）を Dark Taproom の実 Hex 値へ差し替え。拡張トークン（`--heading` / `--subtext` / `--primary-strong` / `--surface-deep` / `--surface-raised` / `--success`）を `@theme inline` に追加。`.top-amber-dark` は壊れトークン置換の個別上書きを撤去し、基盤トークンへ寄せた薄い定義へ縮小。
- **`layout.tsx`**: `next/font/google` で **Zen Old Mincho**（見出し・店名・記事本文）/ **Zen Kaku Gothic New**（UI 本文・デフォルト）/ **Archivo**（ラテン見出し・ロゴ）を読み込み、CSS 変数を `<body>` に付与。`font-mincho` / `font-archivo` ユーティリティを追加。
- **`themes/current.css`**: Dark Taproom 化（巻き戻し先）。**`themes/dark-taproom.css`**: 復元用テーマを新規追加。
- **`apply-theme.test.ts`**: Dark Taproom 前提へ更新（`dark-taproom` テーマ検査・実 Hex トークン検査・フォント変数検査を追加）。

## スコープ外（後続 Issue）

- `.top-amber-dark` ラッパの全撤去とトップページの見た目最適化
- 他14ページの個別ダーク最適化・共通ヘッダー/フッターのリデザイン

これらは「共通レイアウト Issue」「各画面 Issue」で扱う（この基盤に依存）。

## 受入条件の検証結果

- [x] Dark Taproom のカラートークンが CSS 変数として定義され、`bg-*` / `text-*` で実際に色が付く（Playwright で `bg-primary` = `rgb(224,163,65)`、`text-foreground` = `rgb(230,211,172)`、`bg-card` = `rgb(30,22,13)`、body 背景 = `rgb(21,16,10)` を実測確認）
- [x] Zen Old Mincho / Zen Kaku Gothic New / Archivo が `next/font` で読み込まれ、任意要素に適用できる（Playwright で `font-mincho` → Zen Old Mincho、`font-archivo` → Archivo、body → Zen Kaku Gothic New を実測確認）
- [x] `pnpm --filter @beersalon/web build` が通る
- [x] `pnpm test`（407件・`apply-theme.test.ts` 含む）が通る

## テスト

- UT: `apply-theme.test.ts` を更新（Dark Taproom トークン検査・`dark-taproom` テーマ存在検査・フォント変数検査を追加）。全407件 green。
- E2E: 基盤のみで完成画面を持たないためテストピラミッド原則により E2E コードは追加せず、UT + Playwright MCP での実測確認で担保。

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)