### PR TITLE
docs(db): 廃止テーブルの散在節を末尾集約し過去経緯を整理 (#457)

### DIFF
--- a/database.md
+++ b/database.md
@@ -231,8 +231,6 @@ UNIQUE制約: `country_id + name`
 | created_at  | timestamptz| NOT NULL DEFAULT now() | 作成日時             |
 | updated_at  | timestamptz| NOT NULL DEFAULT now() | 更新日時             |
 
-**管理画面での変更**: 国IDを必須化し、管理画面でのフィルタリングを容易にする。
-
 ---
 
 ### 2-7. beers
@@ -280,8 +278,6 @@ UNIQUE制約: `country_id + name`
 | is_active    | boolean    | NOT NULL DEFAULT true            | 提供中フラグ                        |
 | created_at   | timestamptz| NOT NULL DEFAULT now()           | 作成日時                            |
 | updated_at   | timestamptz| NOT NULL DEFAULT now()           | 更新日時                            |
-
-**変更履歴**: `size` カラムと `price` カラムを削除。サイズ/価格は `bar_beer_menu_sizes` テーブルに移行（1メニューに複数サイズ/価格を設定可能に）。
 
 ---
 
@@ -415,10 +411,6 @@ UNIQUE制約: `country_id + name`
 | deleted_at   | timestamptz| NULLABLE                        | 削除日時（論理削除） |
 | created_at   | timestamptz| NOT NULL DEFAULT now()          | 作成日時        |
 | updated_at   | timestamptz| NOT NULL DEFAULT now()          | 更新日時        |
-
-**管理画面での変更**:
-- `is_published` を `status` に変更（draft/published/scheduledを管理）
-- `deleted_at` を追加（論理削除により誤削除からの復旧が可能）
 
 ---
 
@@ -720,12 +712,6 @@ BeerSalonAdmin（管理画面）専用のテーブル。ユーザー向けアプ
 
 ---
 
-### ~~8-2. bar_owners~~（廃止）
-
-**このテーブルは廃止されました。** `admin_users` テーブルに `bar_id` カラムを追加し、1対1の紐付けに変更。中間テーブルは不要になりました。
-
----
-
 ### 8-3. subscription_plans
 
 サブスクリプションプラン定義。
@@ -841,27 +827,15 @@ BeerSalonAdmin（管理画面）専用のテーブル。ユーザー向けアプ
 
 ---
 
-### ~~8-7. master_beer_styles~~（廃止）
+### 8-7. 廃止テーブル一覧（履歴）
 
-**このテーブルは廃止されました。** マスタ管理機能の廃止に伴い、不要となりました。
+以下のテーブルは廃止済み。現行スキーマには存在しない。
 
----
-
-### ~~8-8. master_breweries~~（廃止）
-
-**このテーブルは廃止されました。** マスタ管理機能の廃止に伴い、不要となりました。醸造所情報は Web 側の `breweries` テーブルに一本化。
-
----
-
-### ~~8-9. master_food_categories~~（廃止）
-
-**このテーブルは廃止されました。** マスタ管理機能の廃止に伴い、不要となりました。
-
----
-
-### ~~8-10. master_event_categories~~（廃止）
-
-**このテーブルは廃止されました。** マスタ管理機能の廃止に伴い、不要となりました。
+- `bar_owners` — `admin_users` に `bar_id` カラムを追加して1対1の紐付けに変更したため、中間テーブルを廃止
+- `master_beer_styles` — マスタ管理機能の廃止に伴い不要化
+- `master_breweries` — マスタ管理機能の廃止に伴い不要化。醸造所情報は Web 側の `breweries` テーブルに一本化
+- `master_food_categories` — マスタ管理機能の廃止に伴い不要化
+- `master_event_categories` — マスタ管理機能の廃止に伴い不要化
 
 ---
 


### PR DESCRIPTION
## 概要

Closes #457

毎ターン参照される設計ドキュメント中で最大の `database.md`（54,719バイト）から、現行スキーマを読む上で不要な「廃止テーブルの散在節」と「過去経緯の一文」を整理し、固定トークン消費を削減した。

## 変更内容

### 1. 散在していた廃止テーブルの独立節を末尾集約
打ち消し線見出し + 「このテーブルは廃止されました」本文で散在していた5テーブルの節を撤去し、セクション8末尾に **「8-7. 廃止テーブル一覧（履歴）」** を新設して各1行に集約した。

- `bar_owners`
- `master_beer_styles`
- `master_breweries`
- `master_food_categories`
- `master_event_categories`

### 2. 現行カラム表に含意される過去経緯の一文を削除
現行スキーマ理解に不要な経緯記述を削除。

- `breweries`「管理画面での変更: 国IDを必須化…」
- `bar_beer_menus`「変更履歴: size/price カラムを削除…」
- `articles`「管理画面での変更: is_published→status / deleted_at 追加…」

## 情報欠落がないことの確認

削除した経緯に含まれる**設計事実は現行カラム表・関連節に記載済み**で情報欠落なし。

| 削除した経緯 | 現行の記載場所 |
|---|---|
| breweries 国ID必須化 | カラム表の `country_id NOT NULL` |
| bar_beer_menus size/price 削除 | 直後の `2-8-2. bar_beer_menu_sizes` 節 |
| articles status 3値・deleted_at | カラム表の Description |

RPC（`sync_bar_opening_hours` / `use_user_coupon` / `sync_bar_payment_methods`）・UNIQUE制約・CASCADE削除等の**生きた仕様は一切削っていない**。

## 慣習の統一

routing.md「3-9 廃止したルート」/ wireframe-admin.md「10 廃止した画面」と同じ「末尾に1つの廃止節へ集約」する既存の慣習に database.md を揃えた。

## 検証

- バイト数: **54,719 → 53,871**（-848バイト）
- 打ち消し線 `~~` / 「このテーブルは廃止されました」 / 「管理画面での変更」 / 「変更履歴」の残存: **すべて 0**
- RPC 3種・UNIQUE制約・CASCADE削除の残存: **確認済み**

## テスト

ドキュメントのみの変更でありアプリの実行挙動・UIは変わらないため、UT/E2E の追加対象なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)