### PR TITLE
impl の E2E フェーズで dev サーバーを自動起動する（docker 起動チェックでブロック）

### DIFF
--- a/.claude/hooks/check-dev-servers.sh
+++ b/.claude/hooks/check-dev-servers.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 
-# implスキル実行前にdev:web(3000)とdev:admin(3001)が起動済みか確認する
+# implスキル実行前にdev:web(3000)とdev:admin(3001)が起動済みか確認し、
+# 未起動なら start-dev-servers.sh に自動起動を委譲する。
+
+# Why not ここで直接nohup起動: 自動起動ロジック(べき等・ヘルスチェック待機・ログ退避)は
+# start-dev-servers.sh に集約し、このスクリプトは「確認→委譲」の薄い入口に留める（二重メンテ防止）。
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 WEB_UP=false
 ADMIN_UP=false
 
-if curl -s -o /dev/null -w '' --max-time 2 http://localhost:3000 2>/dev/null; then
+if curl -s -o /dev/null --max-time 2 http://localhost:3000 2>/dev/null; then
   WEB_UP=true
 fi
 
-if curl -s -o /dev/null -w '' --max-time 2 http://localhost:3001 2>/dev/null; then
+if curl -s -o /dev/null --max-time 2 http://localhost:3001 2>/dev/null; then
   ADMIN_UP=true
 fi
 
-if [ "$WEB_UP" = false ] && [ "$ADMIN_UP" = false ]; then
-  echo 'BLOCKED: dev:web(localhost:3000)とdev:admin(localhost:3001)が両方起動していません。実装タスクを開始する前に、別ターミナルで `pnpm run dev:web` と `pnpm run dev:admin` を起動してください。' >&2
-  exit 2
-elif [ "$WEB_UP" = false ]; then
-  echo 'BLOCKED: dev:web(localhost:3000)が起動していません。実装タスクを開始する前に、別ターミナルで `pnpm run dev:web` を起動してください。' >&2
-  exit 2
-elif [ "$ADMIN_UP" = false ]; then
-  echo 'BLOCKED: dev:admin(localhost:3001)が起動していません。実装タスクを開始する前に、別ターミナルで `pnpm run dev:admin` を起動してください。' >&2
-  exit 2
+# 両方起動済みなら何もしない（べき等）
+if [ "$WEB_UP" = true ] && [ "$ADMIN_UP" = true ]; then
+  exit 0
 fi
+
+# 未起動があれば自動起動を委譲。start-dev-servers.sh がヘルスチェックまで行い、
+# 起動失敗時は exit 2 でブロックする。
+exec bash "$HOOK_DIR/start-dev-servers.sh"

--- a/.claude/hooks/check-dev-servers.sh
+++ b/.claude/hooks/check-dev-servers.sh
@@ -11,11 +11,13 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEB_UP=false
 ADMIN_UP=false
 
-if curl -s -o /dev/null --max-time 2 http://localhost:3000 2>/dev/null; then
+# Why not -f 無し: start-dev-servers.sh の is_up と判定基準を揃える。Next.js devはコンパイル中に
+# 5xxを返すため、-f(--fail)で5xxを未起動扱いにして委譲側の自動起動・待機に回す。
+if curl -sf -o /dev/null --max-time 2 http://localhost:3000 2>/dev/null; then
   WEB_UP=true
 fi
 
-if curl -s -o /dev/null --max-time 2 http://localhost:3001 2>/dev/null; then
+if curl -sf -o /dev/null --max-time 2 http://localhost:3001 2>/dev/null; then
   ADMIN_UP=true
 fi
 

--- a/.claude/hooks/check-docker.sh
+++ b/.claude/hooks/check-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# implスキル実行前にDocker(=Supabaseローカルスタックの実体)が起動済みか確認する。
+# 未起動なら実装タスクをブロックする（devサーバー自動起動の前提を保証するため）。
+
+# Why not `open -a Docker` で自動起動: デーモン起動は数十秒かかり非決定的。
+# ブロックに留め、ユーザーにDocker Desktop起動を促す方が安全。
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo 'BLOCKED: docker コマンドが見つかりません。Docker Desktop をインストール・起動してから再実行してください。' >&2
+  exit 2
+fi
+
+if ! docker info > /dev/null 2>&1; then
+  echo 'BLOCKED: Docker デーモンが起動していません。Docker Desktop を起動してから impl を再実行してください。ローカルSupabase(54421)の起動にDockerが必要です。' >&2
+  exit 2
+fi
+
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qi supabase; then
+  echo 'BLOCKED: Supabaseコンテナが起動していません。プロジェクトルートで `supabase start` を実行してから impl を再実行してください。' >&2
+  exit 2
+fi

--- a/.claude/hooks/start-dev-servers.sh
+++ b/.claude/hooks/start-dev-servers.sh
@@ -6,13 +6,17 @@
 # Why not Bashツール経由でpnpm devを起動: settings.jsonのBashフックが`pnpm dev`を無条件ブロックし、
 # run_in_background:true も禁止のため、Claude自身のBash経由では起動不可。フック内nohupで回避する。
 
+# Why not worktree側から起動: dev:web/dev:admin は単一ポート(3000/3001)を共有するため、
+# 常にメインcheckoutから1組だけ起動する。worktreeごとに起こすとポート競合するため、REPO_ROOTを固定する。
 REPO_ROOT="/Users/rikushimoida/Documents/repository/BeerSalon"
 LOG_DIR="/tmp/beersalon-dev-logs"
 mkdir -p "$LOG_DIR"
 
 is_up() {
   # $1: ポート番号
-  curl -s -o /dev/null --max-time 2 "http://localhost:$1" 2>/dev/null
+  # Why not -f 無し: Next.js devはコンパイル完了前でも5xxを返すため、-f(--fail)で5xxを失敗扱いにし、
+  # コンパイル中を「起動済み」と誤判定してE2Eが500に当たるのを減らす。
+  curl -sf -o /dev/null --max-time 2 "http://localhost:$1" 2>/dev/null
 }
 
 wait_up() {

--- a/.claude/hooks/start-dev-servers.sh
+++ b/.claude/hooks/start-dev-servers.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# implスキル実行前にdev:web(3000)とdev:admin(3001)を自動起動する。
+# フック(=ハーネスが実行)経由のため、`pnpm dev`ブロックフックやrun_in_background禁止には抵触しない。
+
+# Why not Bashツール経由でpnpm devを起動: settings.jsonのBashフックが`pnpm dev`を無条件ブロックし、
+# run_in_background:true も禁止のため、Claude自身のBash経由では起動不可。フック内nohupで回避する。
+
+REPO_ROOT="/Users/rikushimoida/Documents/repository/BeerSalon"
+LOG_DIR="/tmp/beersalon-dev-logs"
+mkdir -p "$LOG_DIR"
+
+is_up() {
+  # $1: ポート番号
+  curl -s -o /dev/null --max-time 2 "http://localhost:$1" 2>/dev/null
+}
+
+wait_up() {
+  # $1: ポート番号 / $2: ラベル。最大60秒待機
+  local port="$1" label="$2" i
+  for i in $(seq 1 30); do
+    if is_up "$port"; then
+      echo "start-dev-servers: $label (localhost:$port) 起動確認" >&2
+      return 0
+    fi
+    sleep 2
+  done
+  echo "BLOCKED: $label (localhost:$port) が起動しませんでした。$LOG_DIR/$label.log を確認してください。" >&2
+  return 1
+}
+
+# べき等: 起動済みなら二重起動しない
+if ! is_up 3000; then
+  nohup pnpm --dir "$REPO_ROOT" run dev:web > "$LOG_DIR/web.log" 2>&1 &
+fi
+
+if ! is_up 3001; then
+  nohup pnpm --dir "$REPO_ROOT" run dev:admin > "$LOG_DIR/admin.log" 2>&1 &
+fi
+
+FAILED=false
+wait_up 3000 web || FAILED=true
+wait_up 3001 admin || FAILED=true
+
+if [ "$FAILED" = true ]; then
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,6 +71,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash /Users/rikushimoida/Documents/repository/BeerSalon/.claude/hooks/check-docker.sh",
+            "if": "Skill(impl *)"
+          },
+          {
+            "type": "command",
             "command": "bash /Users/rikushimoida/Documents/repository/BeerSalon/.claude/hooks/check-dev-servers.sh",
             "if": "Skill(impl *)"
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,7 +77,8 @@
           {
             "type": "command",
             "command": "bash /Users/rikushimoida/Documents/repository/BeerSalon/.claude/hooks/check-dev-servers.sh",
-            "if": "Skill(impl *)"
+            "if": "Skill(impl *)",
+            "timeout": 120
           },
           {
             "type": "command",

--- a/.claude/skills/impl/SKILL.md
+++ b/.claude/skills/impl/SKILL.md
@@ -31,6 +31,12 @@ agent: frontend-engineer
 
 #### 1-0. 前提チェック（worktree モード。満たさなければ停止）
 
+- **Docker が起動済みであること**（`check-docker.sh` フックが impl 起動時に自動で検証する）。
+  - Docker デーモン未起動、または Supabase コンテナ未起動の場合、impl は PreToolUse フックで
+    ブロックされ、それ以上先に進めない。ローカル Supabase(54421) の実体が Docker のため、
+    dev サーバー自動起動（1-4）と E2E の前提として Docker 起動を保証する。
+  - ブロックされたら、Docker Desktop を起動し（必要なら `supabase start`）、impl を再実行する。
+    **Docker 自体の自動起動は行わない**（デーモン起動は非決定的なため、ブロックに留める）。
 - `git branch --show-current` が `develop` であること。
   - developメイン会話を司令塔とし、ここから worktree を切る運用のため。
   - develop 以外なら「`git switch develop` してから再実行してください」と案内して停止。
@@ -136,6 +142,11 @@ git / Claude Code のネイティブ機能では自動化されないため、wo
 - **承認レスで実行する**。E2E計画の事前提示・承認待ちは行わない
   （何を検証するかは `/plan` 承認時点で受入条件として確定済みのため。許可プロンプト排除方針に整合）。
 - Playwright MCP の操作、および E2E 実行に必要なコマンド（`pnpm e2e` 等）は、確認を求めずそのまま実行してよい。
+- **dev サーバーはユーザーへの手動起動依頼をしない**。impl 起動時の `check-dev-servers.sh` フックが
+  未起動の dev:web(3000)/dev:admin(3001) を `start-dev-servers.sh` 経由で自動起動し、ヘルスチェックで
+  起動を待ってから impl 本体を開始する。したがって E2E フェーズ到達時点で両サーバーは起動済みである。
+  - フックが起動に失敗した場合のみブロックされる。その際は `/tmp/beersalon-dev-logs/` のログを確認して報告する。
+  - 「dev サーバーを起動してください」とユーザーに依頼してはならない（自動起動が前提）。
 - 起動済みの localhost に対して E2E 確認を実施する。
 - ポートが不明な場合のみユーザーに確認する。
 - 不具合を発見した場合は修正せず、再現手順・期待結果・実際の結果を報告する

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ pnpm e2e              # E2E 7本を実行 (web 5本 + admin 2本)
 
 詳細・トラブルシューティング・UIモード起動方法は `docs/e2e.md` を参照。
 
+> **impl スキル経由の場合は dev サーバーの手動起動は不要**：`impl` 実行時、`check-docker.sh` フックが
+> Docker（＝ローカル Supabase の実体）の起動を検証し（未起動ならブロック）、`check-dev-servers.sh` →
+> `start-dev-servers.sh` フックが dev:web(3000)/dev:admin(3001) を自動起動してから E2E フェーズに入る。
+> Docker 自体の自動起動は行わない（未起動時は Docker Desktop 起動＋`supabase start` を促してブロック）。
+
 ---
 
 ## 🧩 開発ワークフロープラグイン（bs-workflow）


### PR DESCRIPTION
## 概要
`impl` スキルの E2E フェーズで dev サーバーが自動起動されず、毎回ユーザーが手動で「dev サーバーを起動してください」と指示していた問題を解消する。impl を「実装 → テスト → PR → レビュー → 指摘対応」まで一気通貫で回すため、dev サーバーの自動起動と、その前提となる Docker 起動チェックのゲートを追加した。

Closes #479

## 調査結果（原因 / 根本原因 / 改善策）

| 区分 | 内容 |
|---|---|
| **原因（現象）** | E2E フェーズ前に dev サーバーが自動起動されず、`check-dev-servers.sh` がブロックしてユーザーへ「手動で起動してください」と要求していた。一気通貫が途切れる。 |
| **根本原因** | 設計思想が「dev サーバーはユーザーが手動起動し、Claude は起動済みサーバーを使うだけ」に固定されていた。①`pnpm dev` を Bash フックで無条件ブロック、②`run_in_background: true` を CLAUDE.md/フックで禁止、という2制約が「Claude 自身がバックグラウンドで dev を起こす」ことを構造的に不可能にしていた。さらに Docker（=Supabase 54421/54422 の実体）の起動保証がどこにも無く、仮に dev を起こしても DB 未起動で E2E が落ちる余地が残っていた。 |
| **改善策** | (a) impl 経路に **Docker 起動チェックのゲート**を追加（未起動ならブロック）。(b) dev サーバーを **フック経由（nohup）で自動起動**し、`pnpm dev` 全面ブロック・`run_in_background` 禁止という既存ルールを一切変更せずに実現。(c) impl スキル本文の E2E フェーズに「dev サーバーは自動起動される・手動依頼しない」を明記。 |

## 変更内容
- **`.claude/hooks/check-docker.sh`（新規）**: Docker コマンド有無 → デーモン起動 → Supabase コンテナ起動の3段で検証。いずれか欠ければ `exit 2` でブロック。Docker 自体の自動起動はしない（デーモン起動は非決定的なため）。
- **`.claude/hooks/start-dev-servers.sh`（新規）**: 3000/3001 が未起動なら `nohup pnpm run dev:web/dev:admin` で起動。べき等（起動済みなら二重起動しない）、最大60秒のヘルスチェック待機、ログは `/tmp/beersalon-dev-logs/` に退避。
- **`.claude/hooks/check-dev-servers.sh`（改修）**: 「手動起動依頼でブロック」から「未起動なら `start-dev-servers.sh` へ委譲」に変更。
- **`.claude/settings.json`**: `PreToolUse(Skill impl *)` に `check-docker.sh` を追加（docker → dev サーバー → playwright の順で発火）。
- **`.claude/skills/impl/SKILL.md`**: 1-0 に Docker 前提ゲート、1-4 に dev サーバー自動起動（手動依頼禁止）を明記。
- **`README.md`**: impl 経由では dev サーバー手動起動が不要である旨を追記。

## 設計判断（案A: フック内 nohup 起動）
Bash ツール経由の `pnpm dev` はフックで無条件ブロックされ、`run_in_background: true` も禁止のため、Claude 自身の Bash からは dev を起動できない。フックはハーネスが実行し Bash ツールを経由しないため、フック内 `nohup pnpm run dev:*` はこれらの禁止に抵触しない。→ **CLAUDE.md の禁止事項を書き換えずに自動起動を実現**。

## 受入条件と検証結果
- [x] **docker 未起動でブロック**: `check-docker.sh` の4分岐（docker 不在 / デーモン未起動 / Supabase コンテナ未起動 / 全正常）を模擬 docker で検証。前3者は `exit 2`、正常時のみ `exit 0`。
- [x] **docker 起動済みで dev 自動起動**: 3000/3001 を落とした状態で `check-dev-servers.sh` を実行し、`start-dev-servers.sh` が両サーバーを自動起動 → ヘルスチェック通過 → `exit 0` を実地確認。
- [x] **手動指示が発生しない**: SKILL.md 1-4 に「dev サーバーを起動してくださいとユーザーに依頼してはならない」を明記。フックが自動起動するため手動依頼は発生しない。
- [x] **調査成果物が原因/根本原因/改善策を含む**: 本 PR 上表のとおり。
- 追加検証: べき等性（2回目実行は 0.03 秒で `exit 0`・二重起動なし）、既存 UT 486 件全パス。

## テスト方針
本タスクはアプリのソースコードではなく Claude Code のワークフロー基盤（フック/シェル/文書）の変更のため、受入条件はシェルスクリプト単体の動作検証で担保した（Vitest UT / Playwright E2E で新規検証すべきロジック・ユーザー操作は無い）。既存 UT が壊れていないことは確認済み。

## 影響範囲
- 本 PR マージ後、**全 impl 実行時に Docker 起動が必須**になる（受入条件どおりの意図した挙動）。Docker 未起動なら impl はブロックされる。
- `/parallel`・`/loop-issues` への dev 自動起動展開は、単一ポート共有によるポート競合設計を要するため本 PR のスコープ外（別 Issue 化を提案）。

## PR作成時の注意
PR名・内容ともに日本語で記載済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwK7JdVJj3EYTQyjD4hfau