### PR TITLE
fix(db): #511 public 全テーブルの RLS を有効化し anon 経由の読み書き削除を遮断

### DIFF
--- a/apps/web/e2e/rls-security.spec.ts
+++ b/apps/web/e2e/rls-security.spec.ts
@@ -22,7 +22,12 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 		Authorization: `Bearer ${ANON_KEY}`,
 	});
 
-	// 機微テーブル: RLS 有効 + ポリシー無し = anon からは 0 件になるべき。
+	// 機微テーブル: anon からデータを取得できないこと(=RLSで遮断)を検証する。
+	// Why not(200+0件に固定しない): anon にテーブルの SELECT GRANT が残る環境では
+	// RLS deny により 200+空配列、GRANT すら無い環境(Supabase の新ベーステンプレート)
+	// では 401 permission denied になる。どちらも「anon はデータを取得できない」で
+	// 目的は同じため、両方を合格とみなす。GRANT 状態は環境差があり本テストの主眼で
+	// ないため、ここでは終状態(データ非取得)のみを担保する。
 	const sensitiveTables = [
 		"user_profiles",
 		"admin_users",
@@ -33,16 +38,22 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 	];
 
 	for (const table of sensitiveTables) {
-		test(`anon は ${table} を SELECT しても 0 件になる`, async ({
-			request,
-		}) => {
+		test(`anon は ${table} からデータを取得できない`, async ({ request }) => {
 			const url = `${restBase()}/${table}?select=*&limit=5`;
 			const res = await request.get(url, { headers: anonHeaders() });
-			// 失敗時に実 status/本文を CI ログへ残すため、第2引数にメッセージを渡す。
-			expect(res.status(), `GET ${url} -> ${await res.text()}`).toBe(200);
-			const rows = (await res.json()) as unknown[];
-			expect(Array.isArray(rows)).toBeTruthy();
-			expect(rows.length).toBe(0);
+			const body = await res.text();
+			if (res.status() === 200) {
+				// GRANT が残る環境: RLS deny で必ず空配列になる。
+				const rows = JSON.parse(body) as unknown[];
+				expect(Array.isArray(rows), `GET ${url} -> ${body}`).toBeTruthy();
+				expect(rows.length, `GET ${url} -> ${body}`).toBe(0);
+			} else {
+				// GRANT が無い環境: permission denied(401/403)で弾かれる。
+				expect(res.status(), `GET ${url} -> ${body}`).toBeGreaterThanOrEqual(
+					401,
+				);
+				expect(res.status(), `GET ${url} -> ${body}`).toBeLessThan(404);
+			}
 		});
 	}
 
@@ -61,22 +72,25 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 		expect(res.status()).toBeLessThan(404);
 	});
 
-	test("anon は bars を DELETE しても実データが消えない", async ({
+	test("anon は bars を DELETE しても破壊的操作が成立しない", async ({
 		request,
 	}) => {
-		// RLS でマッチ行が 0 件のため 204 が返っても実際には何も削除されない。
-		// 削除後に(anon では読めないので)行数の直接確認はできないが、少なくとも
-		// エラーなく完了し、かつ SELECT が 0 件のまま = 破壊的操作が成立していない
-		// ことを担保する。
-		await request.delete(
+		// anon の DELETE は RLS/GRANT により拒否される(401/403)か、マッチ行 0 件で
+		// 何も消えず 204 が返る。いずれも破壊的操作は成立していない。
+		// Why not(実行後に行数を確認しない): anon は SELECT も遮断されるため、削除結果を
+		// anon 自身では観測できない。ここでは DELETE 応答が「拒否 or 無害な完了」で
+		// あることを担保する(実データ非破壊はマイグレーション適用先のDBで別途検証済み)。
+		const res = await request.delete(
 			`${restBase()}/bars?name=eq.__never_matches_anything__`,
 			{ headers: anonHeaders() },
 		);
-		const res = await request.get(`${restBase()}/bars?select=id&limit=1`, {
-			headers: anonHeaders(),
-		});
-		const rows = (await res.json()) as unknown[];
-		expect(rows.length).toBe(0);
+		const body = await res.text();
+		const okNoOp = res.status() === 204 || res.status() === 200;
+		const denied = res.status() >= 401 && res.status() < 404;
+		expect(
+			okNoOp || denied,
+			`DELETE bars -> status=${res.status()} body=${body}`,
+		).toBeTruthy();
 	});
 });
 

--- a/apps/web/e2e/rls-security.spec.ts
+++ b/apps/web/e2e/rls-security.spec.ts
@@ -36,10 +36,10 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 		test(`anon は ${table} を SELECT しても 0 件になる`, async ({
 			request,
 		}) => {
-			const res = await request.get(`${restBase()}/${table}?select=*&limit=5`, {
-				headers: anonHeaders(),
-			});
-			expect(res.ok()).toBeTruthy();
+			const url = `${restBase()}/${table}?select=*&limit=5`;
+			const res = await request.get(url, { headers: anonHeaders() });
+			// 失敗時に実 status/本文を CI ログへ残すため、第2引数にメッセージを渡す。
+			expect(res.status(), `GET ${url} -> ${await res.text()}`).toBe(200);
 			const rows = (await res.json()) as unknown[];
 			expect(Array.isArray(rows)).toBeTruthy();
 			expect(rows.length).toBe(0);

--- a/apps/web/e2e/rls-security.spec.ts
+++ b/apps/web/e2e/rls-security.spec.ts
@@ -1,0 +1,126 @@
+import { createHmac } from "node:crypto";
+import { expect, test } from "@playwright/test";
+
+// Issue #511: public 全テーブルの RLS 有効化を検証する。
+// anon 公開鍵だけで機微テーブルの読み書き削除ができない(=RLSで遮断される)こと、
+// および authenticated ロールが自分の user_profiles だけを SELECT できることを、
+// REST API を直接叩いて確認する。UI ではなく DB 層のアクセス制御が対象のため、
+// page ではなく request フィクスチャを使う。
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
+	test.skip(
+		!SUPABASE_URL || !ANON_KEY,
+		"NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY が未設定のためスキップ",
+	);
+
+	const restBase = () => `${SUPABASE_URL}/rest/v1`;
+	const anonHeaders = () => ({
+		apikey: ANON_KEY as string,
+		Authorization: `Bearer ${ANON_KEY}`,
+	});
+
+	// 機微テーブル: RLS 有効 + ポリシー無し = anon からは 0 件になるべき。
+	const sensitiveTables = [
+		"user_profiles",
+		"admin_users",
+		"invoices",
+		"bars",
+		"posts",
+		"user_coupons",
+	];
+
+	for (const table of sensitiveTables) {
+		test(`anon は ${table} を SELECT しても 0 件になる`, async ({
+			request,
+		}) => {
+			const res = await request.get(`${restBase()}/${table}?select=*&limit=5`, {
+				headers: anonHeaders(),
+			});
+			expect(res.ok()).toBeTruthy();
+			const rows = (await res.json()) as unknown[];
+			expect(Array.isArray(rows)).toBeTruthy();
+			expect(rows.length).toBe(0);
+		});
+	}
+
+	test("anon は bars に INSERT できない (RLS で拒否)", async ({ request }) => {
+		const res = await request.post(`${restBase()}/bars`, {
+			headers: { ...anonHeaders(), "Content-Type": "application/json" },
+			data: {
+				name: "__e2e_anon_insert_probe__",
+				prefecture: "東京都",
+				city: "test",
+				address_line1: "probe",
+			},
+		});
+		// RLS ポリシー違反は 401/403 を返す(row-level security policy violation)。
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+
+	test("anon は bars を DELETE しても実データが消えない", async ({
+		request,
+	}) => {
+		// RLS でマッチ行が 0 件のため 204 が返っても実際には何も削除されない。
+		// 削除後に(anon では読めないので)行数の直接確認はできないが、少なくとも
+		// エラーなく完了し、かつ SELECT が 0 件のまま = 破壊的操作が成立していない
+		// ことを担保する。
+		await request.delete(
+			`${restBase()}/bars?name=eq.__never_matches_anything__`,
+			{ headers: anonHeaders() },
+		);
+		const res = await request.get(`${restBase()}/bars?select=id&limit=1`, {
+			headers: anonHeaders(),
+		});
+		const rows = (await res.json()) as unknown[];
+		expect(rows.length).toBe(0);
+	});
+});
+
+// authenticated ロールの自己参照ポリシーの検証は、JWT 署名用シークレットが
+// テスト環境に存在する場合のみ実行する(CI 等で無い場合はスキップ)。
+test.describe("RLS: authenticated の自己プロフィール参照 (#511)", () => {
+	const JWT_SECRET = process.env.SUPABASE_JWT_SECRET;
+	const AUTH_UID = process.env.E2E_RLS_AUTH_UID;
+
+	test.skip(
+		!SUPABASE_URL || !ANON_KEY || !JWT_SECRET || !AUTH_UID,
+		"SUPABASE_JWT_SECRET / E2E_RLS_AUTH_UID 等が未設定のためスキップ",
+	);
+
+	const signAuthenticatedJwt = (sub: string, secret: string) => {
+		const b64 = (o: unknown) =>
+			Buffer.from(JSON.stringify(o)).toString("base64url");
+		const now = Math.floor(Date.now() / 1000);
+		const data = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({
+			aud: "authenticated",
+			role: "authenticated",
+			sub,
+			exp: now + 3600,
+			iat: now,
+		})}`;
+		const sig = createHmac("sha256", secret).update(data).digest("base64url");
+		return `${data}.${sig}`;
+	};
+
+	test("authenticated は自分の user_profiles を SELECT できる", async ({
+		request,
+	}) => {
+		const jwt = signAuthenticatedJwt(AUTH_UID as string, JWT_SECRET as string);
+		const res = await request.get(
+			`${SUPABASE_URL}/rest/v1/user_profiles?select=id&user_auth_id=eq.${AUTH_UID}`,
+			{
+				headers: {
+					apikey: ANON_KEY as string,
+					Authorization: `Bearer ${jwt}`,
+				},
+			},
+		);
+		expect(res.ok()).toBeTruthy();
+		const rows = (await res.json()) as unknown[];
+		expect(rows.length).toBe(1);
+	});
+});

--- a/database.md
+++ b/database.md
@@ -10,6 +10,16 @@
 - 画像は Supabase Storage に保存し、DB には `image_url` / `storage_path` などの文字列のみ保持する
 - タイムスタンプは `created_at`, `updated_at`（`timestamptz`）
 
+### Row-Level Security（RLS）方針
+
+- `public` スキーマの全テーブルで RLS を有効化し、既定は deny-by-default（ポリシー無し＝ `anon` / `authenticated` は全操作拒否）とする。ブラウザに露出する anon 公開鍵だけで機微データが読み書きされることを防ぐ。
+- アプリのデータアクセスは RLS をバイパスするロールで行う：
+  - ユーザー画面（web）: Prisma 経由（`postgres` ロール、`rolbypassrls`）
+  - 管理画面（admin）: `supabaseAdmin`（`service_role`、`rolbypassrls`）
+- 例外的に `authenticated` ロールを使う経路（web middleware の自己プロフィール参照）のみ、必要最小限のポリシーで許可する：
+  - `user_profiles`: `authenticated` が自分の行（`user_auth_id = auth.uid()`）のみ SELECT 可
+- 定義マイグレーション: `supabase/migrations/20260729000000_enable_rls_public_tables.sql`
+
 ---
 
 ## 1. 認証・ユーザ

--- a/supabase/migrations/20260729000000_enable_rls_public_tables.sql
+++ b/supabase/migrations/20260729000000_enable_rls_public_tables.sql
@@ -1,0 +1,55 @@
+-- Issue #511: public スキーマ全テーブルの RLS 未設定を解消する。
+--
+-- 背景: 初期スキーマ(20241201000000_init_schema.sql)以降、public の全テーブルで
+-- Row-Level Security が一度も有効化されておらず、かつ anon/authenticated ロールに
+-- 過剰な DML GRANT が残っている。この二重要因により、ブラウザに露出する anon 公開鍵
+-- だけで全テーブルの読み書き削除が成立してしまう(user_profiles の個人情報や
+-- admin_users.password_hash の匿名取得を含む)。
+--
+-- 方針: 全テーブルで RLS を有効化し deny-by-default にする。ポリシーが無い状態では
+-- anon/authenticated は全操作が拒否される。web/admin の実データアクセスは
+-- postgres(Prisma) / service_role(supabaseAdmin) 経由で RLS をバイパスするため影響しない。
+-- 唯一 authenticated ロールを使う web middleware の自己プロフィール参照だけ、
+-- 明示ポリシーで許可する。
+
+-- ステップ A: public 全テーブルで RLS を有効化(deny-by-default)
+ALTER TABLE public.admin_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.article_likes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.articles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_beer_menu_sizes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_beer_menus ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_coupons ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_food_menus ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_images ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_opening_hours ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_payment_methods ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bar_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bars ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.beer_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.beers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.breweries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.countries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.favorite_bars ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.login_histories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payment_methods ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.post_images ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.post_likes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.regions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.subscription_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_coupons ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_follow_relations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.view_histories ENABLE ROW LEVEL SECURITY;
+
+-- ステップ B: web(middleware)が壊れないための唯一のポリシー。
+-- authenticated ロールが自分の行のみ SELECT できる。他人の個人情報は読めない。
+-- Why not(anon への公開 SELECT を足さない): web は公開バー情報も Prisma(postgres)経由で
+-- 読んでおり anon で bars 等を読む経路が存在しないため、現時点で anon ポリシーは不要。
+-- 将来 anon で公開データを読む要件が出た時点で個別に SELECT ポリシーを追加する。
+CREATE POLICY user_profiles_select_own ON public.user_profiles
+	FOR SELECT TO authenticated
+	USING (user_auth_id = auth.uid());


### PR DESCRIPTION
## 概要
Supabase Security Advisor が検出した `rls_disabled_in_public` を解消する。
`public` スキーマの全31テーブルで RLS が未設定で、ブラウザに露出する anon 公開鍵
だけで全テーブルの読み書き削除が可能な状態だった（`user_profiles` の個人情報や
`admin_users.password_hash` の匿名取得、`bars` への匿名 INSERT/DELETE を含む）。

Closes #511

## 変更内容
- **supabase/migrations/20260729000000_enable_rls_public_tables.sql**
  - public 全31テーブルで `ENABLE ROW LEVEL SECURITY`（deny-by-default）
  - `user_profiles` に `authenticated` の自己 SELECT ポリシー1本
    （`user_auth_id = auth.uid()`）
- **apps/web/e2e/rls-security.spec.ts**: anon 遮断 / authenticated 自己参照の E2E
- **database.md**: RLS 方針を追記

## なぜ web/admin が壊れないか
RLS が制約するのは `anon` / `authenticated` ロールのみ。両アプリの実データアクセスは
これらを使わない（`rolbypassrls` を確認済み）。

| 経路 | 接続ロール | RLS |
|---|---|---|
| web のデータ取得・変更 | Prisma → `postgres`（rolbypassrls=t） | バイパス |
| admin の CRUD | `supabaseAdmin`（service_role, rolbypassrls=t） | バイパス |
| web middleware の自己プロフィール参照 | authenticated | ポリシーで許可 |

`authenticated` でテーブルを読む web の経路は `apps/web/src/middleware.ts:88` の
`user_profiles` 1箇所のみ（横断 grep 済み）。

## 検証結果（ローカル）
RLS 適用後、REST を直接叩いて確認：
- anon で `user_profiles` / `admin_users` / `invoices` / `bars` / `posts` / `user_coupons` の SELECT → いずれも 0 件
- anon で `bars` INSERT → `42501 row-level security policy violation` で拒否
- anon で `bars` DELETE → 実データは無傷（RLS でマッチ 0 件）
- authenticated で自分の `user_profiles` → 1件取得可 / 他人の行 → 0件 / `admin_users` → 0件
- middleware が `GET / → /login` を正常にたどりリダイレクトループしないことを確認

## テスト
- UT（Vitest）: 55ファイル・528テスト全て green
- E2E（Playwright, `rls-security.spec.ts`）: anon 遮断 8件 pass、authenticated 自己参照 1件 pass（CI では secret 未設定時 skip）

## マージ後の対応（重要）
本リポジトリは CI 自動マイグレーション適用が無いため、マージ後に dev / production の
リモート Supabase へ手動で `supabase db push` が必要（受入条件「Advisor で
`rls_disabled_in_public` 解消」はリモート適用が前提）。

## 別Issue化を提案
anon/authenticated への過剰な DML GRANT（`REVOKE` による多層防御）は受入条件の範囲外
かつ `user_profiles` の書き込み GRANT との整合検討が必要なため、本PRに混ぜず別Issue化
を提案（計画時に合意済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)