### PR TITLE
fix(db): #513 anon/authenticated の過剰 DML GRANT を REVOKE し最小権限化

### DIFF
--- a/apps/web/e2e/rls-security.spec.ts
+++ b/apps/web/e2e/rls-security.spec.ts
@@ -94,6 +94,53 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 	});
 });
 
+// Issue #513: anon/authenticated への過剰 DML GRANT を REVOKE したことを検証する。
+// #511 のテストは「GRANT の有無に関わらずデータが取れない」終状態を担保するが、
+// #513 では「そもそも GRANT が剥がれ permission denied(401/403) になる」ことを主眼に
+// 検証する。GRANT が残ったまま RLS deny で空配列(200)になるケースは #513 では不合格とし、
+// 過剰権限そのものが除去されたことを主張する。
+test.describe("最小権限化: anon/authenticated の過剰 GRANT REVOKE (#513)", () => {
+	test.skip(
+		!SUPABASE_URL || !ANON_KEY,
+		"NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY が未設定のためスキップ",
+	);
+
+	const restBase = () => `${SUPABASE_URL}/rest/v1`;
+	const anonHeaders = () => ({
+		apikey: ANON_KEY as string,
+		Authorization: `Bearer ${ANON_KEY}`,
+	});
+
+	const expectPermissionDenied = (status: number, ctx: string) => {
+		// GRANT が無いと PostgREST は 401(anon)/403(role あり) の permission denied を返す。
+		expect(status, ctx).toBeGreaterThanOrEqual(401);
+		expect(status, ctx).toBeLessThan(404);
+	};
+
+	// anon から SELECT が GRANT レベルで拒否される(200+空配列ではない)ことを検証する。
+	// これらのテーブルは anon に SELECT GRANT が残っていない。
+	for (const table of ["user_profiles", "admin_users", "invoices", "bars"]) {
+		test(`anon の ${table} SELECT は GRANT 拒否される`, async ({ request }) => {
+			const url = `${restBase()}/${table}?select=*&limit=1`;
+			const res = await request.get(url, { headers: anonHeaders() });
+			expectPermissionDenied(res.status(), `GET ${url} -> ${await res.text()}`);
+		});
+	}
+
+	test("anon の user_profiles INSERT は GRANT 拒否される", async ({
+		request,
+	}) => {
+		const res = await request.post(`${restBase()}/user_profiles`, {
+			headers: { ...anonHeaders(), "Content-Type": "application/json" },
+			data: { last_name: "__probe__", first_name: "__probe__" },
+		});
+		expectPermissionDenied(
+			res.status(),
+			`POST user_profiles -> ${await res.text()}`,
+		);
+	});
+});
+
 // authenticated ロールの自己参照ポリシーの検証は、JWT 署名用シークレットが
 // テスト環境に存在する場合のみ実行する(CI 等で無い場合はスキップ)。
 test.describe("RLS: authenticated の自己プロフィール参照 (#511)", () => {
@@ -136,5 +183,27 @@ test.describe("RLS: authenticated の自己プロフィール参照 (#511)", () 
 		expect(res.ok()).toBeTruthy();
 		const rows = (await res.json()) as unknown[];
 		expect(rows.length).toBe(1);
+	});
+
+	// Issue #513: authenticated は user_profiles 以外のテーブルへ GRANT を持たないため、
+	// 自己参照ポリシーがあっても他テーブルへの SELECT は permission denied になる。
+	test("authenticated は user_profiles 以外の bars を SELECT できない (#513)", async ({
+		request,
+	}) => {
+		const jwt = signAuthenticatedJwt(AUTH_UID as string, JWT_SECRET as string);
+		const res = await request.get(
+			`${SUPABASE_URL}/rest/v1/bars?select=id&limit=1`,
+			{
+				headers: {
+					apikey: ANON_KEY as string,
+					Authorization: `Bearer ${jwt}`,
+				},
+			},
+		);
+		expect(
+			res.status(),
+			`GET bars -> ${await res.text()}`,
+		).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
 	});
 });

--- a/apps/web/e2e/rls-security.spec.ts
+++ b/apps/web/e2e/rls-security.spec.ts
@@ -99,6 +99,13 @@ test.describe("RLS: public テーブルのアクセス制御 (#511)", () => {
 // #513 では「そもそも GRANT が剥がれ permission denied(401/403) になる」ことを主眼に
 // 検証する。GRANT が残ったまま RLS deny で空配列(200)になるケースは #513 では不合格とし、
 // 過剰権限そのものが除去されたことを主張する。
+//
+// 前提: このテストは 20260730000000_revoke_excess_grants_anon_authenticated.sql が
+// 適用済みの DB を対象とする。本リポジトリはリモート Supabase への migration が手動
+// push で遅延することがあり(CI 自動適用なし)、未適用の DB に対して実行すると
+// GRANT が残ったまま 200+空配列が返り、このテストは意図どおり失敗する。
+// その failure は「未適用の検知」であってテストの誤りではないため、失敗時はまず
+// 対象 DB に本マイグレーションが適用されているかを確認すること。
 test.describe("最小権限化: anon/authenticated の過剰 GRANT REVOKE (#513)", () => {
 	test.skip(
 		!SUPABASE_URL || !ANON_KEY,

--- a/database.md
+++ b/database.md
@@ -19,6 +19,8 @@
 - 例外的に `authenticated` ロールを使う経路（web middleware の自己プロフィール参照）のみ、必要最小限のポリシーで許可する：
   - `user_profiles`: `authenticated` が自分の行（`user_auth_id = auth.uid()`）のみ SELECT 可
 - 定義マイグレーション: `supabase/migrations/20260729000000_enable_rls_public_tables.sql`
+- **GRANT の最小権限化**: RLS の deny-by-default に加え、`anon` / `authenticated` への過剰な DML GRANT を REVOKE し、GRANT レベルでも最小権限を保証する。`anon` は `public` の全テーブル GRANT を持たず（公開データ読み取りも Prisma 経由）、`authenticated` は `user_profiles` の SELECT/INSERT/UPDATE のみを持つ。あわせて `public` スキーマのデフォルト権限（`ALTER DEFAULT PRIVILEGES`）から `anon` / `authenticated` を除去し、新規テーブル追加時に過剰 GRANT が復活しないようにする。
+- 定義マイグレーション: `supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql`
 
 ---
 

--- a/database.md
+++ b/database.md
@@ -21,6 +21,8 @@
 - 定義マイグレーション: `supabase/migrations/20260729000000_enable_rls_public_tables.sql`
 - **GRANT の最小権限化**: RLS の deny-by-default に加え、`anon` / `authenticated` への過剰な DML GRANT を REVOKE し、GRANT レベルでも最小権限を保証する。`anon` は `public` の全テーブル GRANT を持たず（公開データ読み取りも Prisma 経由）、`authenticated` は `user_profiles` の SELECT/INSERT/UPDATE のみを持つ。あわせて `public` スキーマのデフォルト権限（`ALTER DEFAULT PRIVILEGES`）から `anon` / `authenticated` を除去し、新規テーブル追加時に過剰 GRANT が復活しないようにする。
 - 定義マイグレーション: `supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql`
+- **運用ガード（テーブル追加）**: デフォルト権限の REVOKE は「新規テーブルは必ずマイグレーション（`postgres` 実行）で作られる」前提に依存する。テーブル追加は必ずマイグレーション（`postgres`）経由で行うこと。他ロールで `CREATE TABLE` すると、そのロール由来のデフォルト権限により `anon` / `authenticated` への過剰 GRANT が復活しうる。
+- **運用ガード（将来 anon で公開データを読む場合）**: 将来 `anon` で公開データ（例: `bars`）を読む要件が出た際は、テーブルへ直接 GRANT するだけにせず、「RLS の SELECT ポリシー」と「個別テーブルへの SELECT GRANT」の両方を同時に付与すること。GRANT のみだと RLS で拒否され、ポリシーのみだと GRANT レベルで拒否されるため、二層防御の設計思想を保つには両方が必要。
 
 ---
 

--- a/supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql
+++ b/supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql
@@ -26,7 +26,12 @@ REVOKE ALL ON ALL TABLES IN SCHEMA public FROM authenticated;
 GRANT SELECT, INSERT, UPDATE ON public.user_profiles TO authenticated;
 
 -- ステップ C: シーケンスの過剰 GRANT も REVOKE。
--- anon/authenticated は INSERT 経路が無く nextval を使わないため USAGE は不要。
+-- authenticated は user_profiles の INSERT を再 GRANT されているが、user_profiles.id は
+-- UUID(gen_random_uuid())で serial/identity のシーケンスに依存しないため、この REVOKE で
+-- INSERT が壊れることはない。anon は INSERT 経路自体が無い。
+-- Why not(一部シーケンスに USAGE を残さない): 現状 anon/authenticated が nextval を
+-- 必要とする書き込み経路が無いため。将来シーケンス PK のテーブルへ直接 INSERT する経路が
+-- 生じた場合は、その時点で該当シーケンスのみ USAGE を GRANT する。
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
 
 -- ステップ D: デフォルト権限(pg_default_acl)を打ち消す。恒久対策の核。

--- a/supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql
+++ b/supabase/migrations/20260730000000_revoke_excess_grants_anon_authenticated.sql
@@ -1,0 +1,48 @@
+-- Issue #513: anon / authenticated への過剰 DML GRANT を REVOKE し最小権限化する。
+--
+-- 背景: #511 で public 全テーブルの RLS を有効化したが、GRANT とデフォルト権限は
+-- 過剰なまま残存していた。実 DB では anon / authenticated の両ロールが public 全テーブルに
+-- GRANT ALL(DELETE/INSERT/REFERENCES/SELECT/TRIGGER/TRUNCATE/UPDATE)を保持し、
+-- さらに pg_default_acl に「新規テーブル/シーケンス/関数へ anon/authenticated へ ALL を
+-- 自動付与する」ALTER DEFAULT PRIVILEGES が postgres と supabase_admin の両ロール由来で
+-- 残っていた。これがある限り、テーブルを追加するたびに過剰 GRANT が復活する。
+--
+-- 方針: anon / authenticated からテーブル・シーケンスの ALL を REVOKE し、
+-- authenticated が web middleware の自己プロフィール参照に必要とする
+-- user_profiles の SELECT/INSERT/UPDATE のみ再付与する(20260612000000 と一致)。
+-- あわせてデフォルト権限を打ち消し、恒久的に最小権限を維持する。
+-- web/admin の実データアクセスは postgres(Prisma) / service_role(supabaseAdmin) 経由で
+-- RLS をバイパスするため、本 REVOKE の影響を受けない。
+
+-- ステップ A: anon から public 全テーブルの ALL を REVOKE。
+-- Why not(SELECT を残さない): anon で public データを読む経路は現状存在せず(公開バー情報も
+-- Prisma 経由)、将来必要になった時点で個別テーブルに SELECT を GRANT する方針のため。
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM anon;
+
+-- ステップ B: authenticated から全テーブルの ALL を REVOKE し、必要分のみ再付与。
+-- Why not(user_profiles だけ個別 REVOKE しない): 全消し→必要分再付与にすることで、
+-- 過去テンプレート由来の取りこぼしテーブルも確実に剥がれるため。
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.user_profiles TO authenticated;
+
+-- ステップ C: シーケンスの過剰 GRANT も REVOKE。
+-- anon/authenticated は INSERT 経路が無く nextval を使わないため USAGE は不要。
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
+
+-- ステップ D: デフォルト権限(pg_default_acl)を打ち消す。恒久対策の核。
+-- 実 DB には postgres 由来と supabase_admin 由来の 2 系統の defacl が残っているが、
+-- 打ち消せるのは「マイグレーション実行ロール(postgres)自身」の defacl のみ。
+-- Why not(supabase_admin 由来も REVOKE しない): ALTER DEFAULT PRIVILEGES FOR ROLE
+-- supabase_admin は postgres が supabase_admin のメンバーでないため permission denied となり、
+-- 本番/プレビューの supabase db push(postgres 実行)でマイグレーション全体が失敗する。
+-- 新規テーブルに適用される defacl は「そのテーブルを CREATE したロール」の defacl であり、
+-- マイグレーションでテーブルを作るのは postgres のため、postgres 由来 defacl の REVOKE だけで
+-- 新規テーブルへの過剰 GRANT は構造的に防げる(実測で新規テーブルに anon/authenticated の
+-- GRANT が付かないことを確認済み)。supabase_admin が直接テーブルを作る運用経路は無い。
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON FUNCTIONS FROM anon, authenticated;
+
+-- Why not(USAGE ON SCHEMA public を剥がさない): 20260612000000 で anon/authenticated に
+-- 付与済み。スキーマ USAGE は個別テーブル権限とは別レイヤで、テーブル GRANT を剥がせば
+-- 実害はなく、RLS ポリシー評価や Auth 関連経路への副作用を避けるため維持する。


### PR DESCRIPTION
## 概要

Closes #513

#511 で `public` 全テーブルの RLS を有効化したが、`anon` / `authenticated` への過剰な DML GRANT とデフォルト権限（`ALTER DEFAULT PRIVILEGES`）は過剰なまま残存していた。RLS の deny-by-default に加え、GRANT レベルでも最小権限を保証する。

## 根本原因（実測）

ローカル DB の実測で以下を確認:

- `anon` / `authenticated` の両ロールが `public` の全テーブルに `GRANT ALL`（DELETE/INSERT/REFERENCES/SELECT/TRIGGER/TRUNCATE/UPDATE）を保持（`admin_users.password_hash` や `invoices` すら anon が全操作可能）
- `pg_default_acl` に `postgres` / `supabase_admin` 由来の「新規テーブル/シーケンス/関数へ anon/authenticated へ ALL を自動付与する」デフォルト権限が残存。これがある限り新規テーブル追加のたびに過剰 GRANT が復活する

## 変更内容

新規マイグレーション `20260730000000_revoke_excess_grants_anon_authenticated.sql`:

1. `anon` から `public` 全テーブルの ALL を REVOKE
2. `authenticated` から全テーブルの ALL を REVOKE → `user_profiles` の SELECT/INSERT/UPDATE のみ再付与（`20260612000000` と一致）
3. シーケンスの過剰 GRANT を REVOKE
4. `postgres` 由来のデフォルト権限から anon/authenticated を除去（恒久対策）

`USAGE ON SCHEMA public` は維持（テーブル GRANT を剥がせば実害なし）。

### supabase_admin 由来デフォルト権限を除外した理由

`ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin` は、マイグレーション実行ロール（`postgres`）が `supabase_admin` のメンバーでないため `permission denied` となり、本番/プレビューの `supabase db push` 全体が失敗する。新規テーブルに適用されるデフォルト権限は「そのテーブルを CREATE したロール」の defacl であり、マイグレーションでテーブルを作るのは postgres のため、**postgres 由来 defacl の REVOKE だけで新規テーブルへの過剰 GRANT は構造的に防げる**（実測で新規テーブルに anon/authenticated の GRANT が付かないことを確認済み）。

## 影響範囲

**アプリへの影響なし**:
- web は Prisma（`postgres`, `rolbypassrls`）、admin は `supabaseAdmin`（`service_role`, `rolbypassrls`）経由 → GRANT 変更の影響を受けない（実測で service_role/postgres の SELECT 権限維持を確認）
- web middleware の自己プロフィール参照は `authenticated` の `user_profiles` GRANT を維持

## テスト

### DB 層検証（ローカル、手作り JWT で REST 検証）
- ✅ authenticated が自分の `user_profiles` を SELECT/UPDATE 可能（自己参照維持）
- ✅ authenticated の他テーブル（bars/admin_users）SELECT は permission denied（403）
- ✅ anon の `user_profiles` SELECT は permission denied（401）
- ✅ マイグレーションは冪等（2回適用してもエラーなし）

### UT
- `pnpm test:unit`: 528 passed

### E2E（`rls-security.spec.ts`）
- 13 passed / 2 skipped（JWT シークレット未設定ケースは手動検証済み）
- #513 観点（anon の SELECT/INSERT が GRANT 拒否で permission denied になること）のケースを追加

## 設計ドキュメント

`database.md` の RLS 方針節に GRANT 最小権限化とデフォルト権限 REVOKE を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmgfpP2dJ15zigJZPSXkAQ