### PR TITLE
refactor(admin): #522 店舗フォームの重複を共通化

### DIFF
--- a/apps/admin/src/__tests__/bar-form.test.ts
+++ b/apps/admin/src/__tests__/bar-form.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+	type BarProfileFields,
+	createInitialOpeningHours,
+	INITIAL_BAR_PROFILE_FIELDS,
+	validateBarSnsUrls,
+} from "@/lib/bar-form";
+
+function makeFields(overrides: Partial<BarProfileFields>): BarProfileFields {
+	return { ...INITIAL_BAR_PROFILE_FIELDS, ...overrides };
+}
+
+describe("validateBarSnsUrls", () => {
+	it("全 URL 項目が空なら valid を返す", () => {
+		expect(validateBarSnsUrls(INITIAL_BAR_PROFILE_FIELDS)).toEqual({
+			isValid: true,
+		});
+	});
+
+	it("正しい URL がすべて入っていれば valid を返す", () => {
+		const fields = makeFields({
+			website_url: "https://example.com",
+			instagram_url: "https://www.instagram.com/your_account",
+			x_url: "https://x.com/example",
+			facebook_url: "https://www.facebook.com/yourpage",
+			line_url: "https://line.me/R/ti/p/@example",
+		});
+		expect(validateBarSnsUrls(fields)).toEqual({ isValid: true });
+	});
+
+	it("website_url が不正なら website のエラーを返す", () => {
+		const result = validateBarSnsUrls(makeFields({ website_url: "example" }));
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("ホームページURL");
+	});
+
+	it("instagram_url が不正なら Instagram のエラーを返す", () => {
+		const result = validateBarSnsUrls(
+			makeFields({ instagram_url: "https://example.com" }),
+		);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("Instagram");
+	});
+
+	it("x_url が不正なら X のエラーを返す", () => {
+		const result = validateBarSnsUrls(
+			makeFields({ x_url: "https://example.com" }),
+		);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("X（Twitter）");
+	});
+
+	it("facebook_url が不正なら Facebook のエラーを返す", () => {
+		const result = validateBarSnsUrls(
+			makeFields({ facebook_url: "https://example.com" }),
+		);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("Facebook");
+	});
+
+	it("line_url が不正なら LINE のエラーを返す", () => {
+		const result = validateBarSnsUrls(
+			makeFields({ line_url: "https://example.com" }),
+		);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("LINE URL");
+	});
+
+	it("複数項目が不正な場合は検証順（website→instagram→x→facebook→line）の先頭のエラーを返す", () => {
+		const result = validateBarSnsUrls(
+			makeFields({
+				website_url: "invalid-website",
+				instagram_url: "https://example.com",
+				line_url: "https://example.com",
+			}),
+		);
+		expect(result.isValid).toBe(false);
+		// website が最優先で検証されるため、website のエラーが返る
+		expect(result.error).toContain("ホームページURL");
+	});
+
+	it("website が正常で instagram が不正なら instagram のエラーを返す（website をスキップして次へ進む）", () => {
+		const result = validateBarSnsUrls(
+			makeFields({
+				website_url: "https://example.com",
+				instagram_url: "https://example.com",
+			}),
+		);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("Instagram");
+	});
+});
+
+describe("createInitialOpeningHours", () => {
+	it("7 要素（日〜土）の配列を返す", () => {
+		expect(createInitialOpeningHours()).toHaveLength(7);
+	});
+
+	it("各要素の day_of_week が 0〜6 で並ぶ", () => {
+		const hours = createInitialOpeningHours();
+		expect(hours.map((h) => h.day_of_week)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+	});
+
+	it("各要素が初期値（時刻空・sort_order 0・is_closed false）を持つ", () => {
+		for (const hour of createInitialOpeningHours()) {
+			expect(hour.open_time).toBe("");
+			expect(hour.close_time).toBe("");
+			expect(hour.sort_order).toBe(0);
+			expect(hour.is_closed).toBe(false);
+		}
+	});
+
+	it("呼び出しごとに独立した配列を返す（共有参照ではない）", () => {
+		const a = createInitialOpeningHours();
+		const b = createInitialOpeningHours();
+		a[0].is_closed = true;
+		expect(b[0].is_closed).toBe(false);
+	});
+});

--- a/apps/admin/src/__tests__/bar-form.test.ts
+++ b/apps/admin/src/__tests__/bar-form.test.ts
@@ -10,6 +10,18 @@ function makeFields(overrides: Partial<BarProfileFields>): BarProfileFields {
 	return { ...INITIAL_BAR_PROFILE_FIELDS, ...overrides };
 }
 
+// 検証結果が不正であることをアサートしつつ error 文字列を取り出す。
+// validateBarSnsUrls は判別可能ユニオンを返すため、error 参照前に isValid で narrow する。
+function expectInvalidError(
+	result: ReturnType<typeof validateBarSnsUrls>,
+): string {
+	expect(result.isValid).toBe(false);
+	if (result.isValid) {
+		throw new Error("valid な結果が返された（不正を期待）");
+	}
+	return result.error;
+}
+
 describe("validateBarSnsUrls", () => {
 	it("全 URL 項目が空なら valid を返す", () => {
 		expect(validateBarSnsUrls(INITIAL_BAR_PROFILE_FIELDS)).toEqual({
@@ -30,40 +42,35 @@ describe("validateBarSnsUrls", () => {
 
 	it("website_url が不正なら website のエラーを返す", () => {
 		const result = validateBarSnsUrls(makeFields({ website_url: "example" }));
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("ホームページURL");
+		expect(expectInvalidError(result)).toContain("ホームページURL");
 	});
 
 	it("instagram_url が不正なら Instagram のエラーを返す", () => {
 		const result = validateBarSnsUrls(
 			makeFields({ instagram_url: "https://example.com" }),
 		);
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("Instagram");
+		expect(expectInvalidError(result)).toContain("Instagram");
 	});
 
 	it("x_url が不正なら X のエラーを返す", () => {
 		const result = validateBarSnsUrls(
 			makeFields({ x_url: "https://example.com" }),
 		);
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("X（Twitter）");
+		expect(expectInvalidError(result)).toContain("X（Twitter）");
 	});
 
 	it("facebook_url が不正なら Facebook のエラーを返す", () => {
 		const result = validateBarSnsUrls(
 			makeFields({ facebook_url: "https://example.com" }),
 		);
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("Facebook");
+		expect(expectInvalidError(result)).toContain("Facebook");
 	});
 
 	it("line_url が不正なら LINE のエラーを返す", () => {
 		const result = validateBarSnsUrls(
 			makeFields({ line_url: "https://example.com" }),
 		);
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("LINE URL");
+		expect(expectInvalidError(result)).toContain("LINE URL");
 	});
 
 	it("複数項目が不正な場合は検証順（website→instagram→x→facebook→line）の先頭のエラーを返す", () => {
@@ -74,9 +81,8 @@ describe("validateBarSnsUrls", () => {
 				line_url: "https://example.com",
 			}),
 		);
-		expect(result.isValid).toBe(false);
 		// website が最優先で検証されるため、website のエラーが返る
-		expect(result.error).toContain("ホームページURL");
+		expect(expectInvalidError(result)).toContain("ホームページURL");
 	});
 
 	it("website が正常で instagram が不正なら instagram のエラーを返す（website をスキップして次へ進む）", () => {
@@ -86,8 +92,7 @@ describe("validateBarSnsUrls", () => {
 				instagram_url: "https://example.com",
 			}),
 		);
-		expect(result.isValid).toBe(false);
-		expect(result.error).toContain("Instagram");
+		expect(expectInvalidError(result)).toContain("Instagram");
 	});
 });
 

--- a/apps/admin/src/app/bars/[barId]/edit/BarEditForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/edit/BarEditForm.tsx
@@ -3,29 +3,17 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
+import BarProfileFields from "@/components/BarProfileFields";
 import OpeningHoursEditor from "@/components/OpeningHoursEditor";
 import SliderMediaManager from "@/components/SliderMediaManager";
 import {
-	SHIZUOKA_MUNICIPALITIES,
-	SHIZUOKA_PREFECTURE,
-} from "@/lib/shizuoka-cities";
-import {
-	validateCoordinates,
-	validateFacebookUrl,
-	validateInstagramUrl,
-	validateLineUrl,
-	validateWebsiteUrl,
-	validateXUrl,
-} from "@/lib/validators";
+	createInitialOpeningHours,
+	INITIAL_BAR_PROFILE_FIELDS,
+	type OpeningHourInput,
+	validateBarSnsUrls,
+} from "@/lib/bar-form";
+import { validateCoordinates } from "@/lib/validators";
 import type { Bar } from "@/types/database";
-
-interface OpeningHourInput {
-	day_of_week: number;
-	open_time: string;
-	close_time: string;
-	sort_order: number;
-	is_closed: boolean;
-}
 
 interface PaymentMethodOption {
 	id: number;
@@ -45,32 +33,10 @@ export default function BarEditForm({ barId }: { barId: string }) {
 		[key: string]: string;
 	}>({});
 
-	const [formData, setFormData] = useState({
-		name: "",
-		description: "",
-		access: "",
-		phone_number: "",
-		prefecture: "",
-		city: "",
-		address_line1: "",
-		address_line2: "",
-		latitude: "",
-		longitude: "",
-		website_url: "",
-		instagram_url: "",
-		x_url: "",
-		facebook_url: "",
-		line_url: "",
-	});
+	const [formData, setFormData] = useState(INITIAL_BAR_PROFILE_FIELDS);
 
 	const [openingHours, setOpeningHours] = useState<OpeningHourInput[]>(
-		Array.from({ length: 7 }, (_, day) => ({
-			day_of_week: day,
-			open_time: "",
-			close_time: "",
-			sort_order: 0,
-			is_closed: false,
-		})),
+		createInitialOpeningHours,
 	);
 
 	const [regularHoliday, setRegularHoliday] = useState("");
@@ -312,40 +278,10 @@ export default function BarEditForm({ barId }: { barId: string }) {
 		setSuccessMessage("");
 		setOpeningHoursErrors({});
 
-		if (formData.website_url) {
-			const result = validateWebsiteUrl(formData.website_url);
-			if (!result.isValid) {
-				setError(result.error || "ホームページURLの形式が正しくありません");
-				return;
-			}
-		}
-		if (formData.instagram_url) {
-			const result = validateInstagramUrl(formData.instagram_url);
-			if (!result.isValid) {
-				setError(result.error || "Instagram URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (formData.x_url) {
-			const result = validateXUrl(formData.x_url);
-			if (!result.isValid) {
-				setError(result.error || "X URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (formData.facebook_url) {
-			const result = validateFacebookUrl(formData.facebook_url);
-			if (!result.isValid) {
-				setError(result.error || "Facebook URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (formData.line_url) {
-			const result = validateLineUrl(formData.line_url);
-			if (!result.isValid) {
-				setError(result.error || "LINE URLの形式が正しくありません");
-				return;
-			}
+		const snsResult = validateBarSnsUrls(formData);
+		if (!snsResult.isValid) {
+			setError(snsResult.error as string);
+			return;
 		}
 
 		const coordinatesResult = validateCoordinates(
@@ -569,249 +505,7 @@ export default function BarEditForm({ barId }: { barId: string }) {
 					onRegularHolidayChange={setRegularHoliday}
 				/>
 
-				<div>
-					<label
-						htmlFor="access"
-						className="block text-sm font-medium text-gray-700"
-					>
-						アクセス
-					</label>
-					<input
-						type="text"
-						id="access"
-						name="access"
-						value={formData.access}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="phone_number"
-						className="block text-sm font-medium text-gray-700"
-					>
-						電話番号
-					</label>
-					<input
-						type="tel"
-						id="phone_number"
-						name="phone_number"
-						value={formData.phone_number}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="prefecture"
-						className="block text-sm font-medium text-gray-700"
-					>
-						都道府県
-					</label>
-					<select
-						id="prefecture"
-						name="prefecture"
-						value={formData.prefecture}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					>
-						<option value="">選択してください</option>
-						<option value={SHIZUOKA_PREFECTURE}>{SHIZUOKA_PREFECTURE}</option>
-					</select>
-				</div>
-
-				<div>
-					<label
-						htmlFor="city"
-						className="block text-sm font-medium text-gray-700"
-					>
-						市区町村
-					</label>
-					<select
-						id="city"
-						name="city"
-						value={formData.city}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					>
-						<option value="">選択してください</option>
-						{SHIZUOKA_MUNICIPALITIES.map((city) => (
-							<option key={city} value={city}>
-								{city}
-							</option>
-						))}
-					</select>
-				</div>
-
-				<div>
-					<label
-						htmlFor="address_line1"
-						className="block text-sm font-medium text-gray-700"
-					>
-						住所1
-					</label>
-					<input
-						type="text"
-						id="address_line1"
-						name="address_line1"
-						value={formData.address_line1}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="address_line2"
-						className="block text-sm font-medium text-gray-700"
-					>
-						住所2
-					</label>
-					<input
-						type="text"
-						id="address_line2"
-						name="address_line2"
-						value={formData.address_line2}
-						onChange={handleChange}
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="latitude"
-						className="block text-sm font-medium text-gray-700"
-					>
-						緯度
-					</label>
-					<input
-						type="number"
-						step="any"
-						id="latitude"
-						name="latitude"
-						value={formData.latitude}
-						onChange={handleChange}
-						placeholder="35.0116"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-					<p className="mt-1 text-sm text-gray-500">
-						-90〜90（マップ表示用・任意）
-					</p>
-				</div>
-
-				<div>
-					<label
-						htmlFor="longitude"
-						className="block text-sm font-medium text-gray-700"
-					>
-						経度
-					</label>
-					<input
-						type="number"
-						step="any"
-						id="longitude"
-						name="longitude"
-						value={formData.longitude}
-						onChange={handleChange}
-						placeholder="135.7681"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-					<p className="mt-1 text-sm text-gray-500">
-						-180〜180（マップ表示用・任意）
-					</p>
-				</div>
-
-				<div>
-					<label
-						htmlFor="website_url"
-						className="block text-sm font-medium text-gray-700"
-					>
-						ホームページ
-					</label>
-					<input
-						type="url"
-						id="website_url"
-						name="website_url"
-						value={formData.website_url}
-						onChange={handleChange}
-						placeholder="https://example.com"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="instagram_url"
-						className="block text-sm font-medium text-gray-700"
-					>
-						Instagram
-					</label>
-					<input
-						type="url"
-						id="instagram_url"
-						name="instagram_url"
-						value={formData.instagram_url}
-						onChange={handleChange}
-						placeholder="https://www.instagram.com/your_account"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="x_url"
-						className="block text-sm font-medium text-gray-700"
-					>
-						X（Twitter）
-					</label>
-					<input
-						type="url"
-						id="x_url"
-						name="x_url"
-						value={formData.x_url}
-						onChange={handleChange}
-						placeholder="https://x.com/example"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="facebook_url"
-						className="block text-sm font-medium text-gray-700"
-					>
-						Facebook
-					</label>
-					<input
-						type="url"
-						id="facebook_url"
-						name="facebook_url"
-						value={formData.facebook_url}
-						onChange={handleChange}
-						placeholder="https://www.facebook.com/yourpage"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
-
-				<div>
-					<label
-						htmlFor="line_url"
-						className="block text-sm font-medium text-gray-700"
-					>
-						LINE
-					</label>
-					<input
-						type="url"
-						id="line_url"
-						name="line_url"
-						value={formData.line_url}
-						onChange={handleChange}
-						placeholder="https://line.me/R/ti/p/@example"
-						className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-					/>
-				</div>
+				<BarProfileFields fields={formData} onChange={handleChange} />
 
 				<fieldset>
 					<legend className="block text-sm font-medium text-gray-700">

--- a/apps/admin/src/app/bars/[barId]/edit/BarEditForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/edit/BarEditForm.tsx
@@ -280,7 +280,7 @@ export default function BarEditForm({ barId }: { barId: string }) {
 
 		const snsResult = validateBarSnsUrls(formData);
 		if (!snsResult.isValid) {
-			setError(snsResult.error as string);
+			setError(snsResult.error);
 			return;
 		}
 

--- a/apps/admin/src/app/bars/new/BarNewForm.tsx
+++ b/apps/admin/src/app/bars/new/BarNewForm.tsx
@@ -158,7 +158,7 @@ export default function BarNewForm() {
 
 		const snsResult = validateBarSnsUrls(phase2);
 		if (!snsResult.isValid) {
-			setError(snsResult.error as string);
+			setError(snsResult.error);
 			return;
 		}
 

--- a/apps/admin/src/app/bars/new/BarNewForm.tsx
+++ b/apps/admin/src/app/bars/new/BarNewForm.tsx
@@ -3,28 +3,17 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useState } from "react";
+import BarProfileFields from "@/components/BarProfileFields";
 import OpeningHoursEditor from "@/components/OpeningHoursEditor";
 import SliderMediaManager from "@/components/SliderMediaManager";
 import {
-	SHIZUOKA_MUNICIPALITIES,
-	SHIZUOKA_PREFECTURE,
-} from "@/lib/shizuoka-cities";
-import {
-	validateCoordinates,
-	validateFacebookUrl,
-	validateInstagramUrl,
-	validateLineUrl,
-	validateWebsiteUrl,
-	validateXUrl,
-} from "@/lib/validators";
-
-interface OpeningHourInput {
-	day_of_week: number;
-	open_time: string;
-	close_time: string;
-	sort_order: number;
-	is_closed: boolean;
-}
+	createInitialOpeningHours,
+	INITIAL_BAR_PROFILE_FIELDS,
+	type OpeningHourInput,
+	validateBarSnsUrls,
+} from "@/lib/bar-form";
+import { SHIZUOKA_PREFECTURE } from "@/lib/shizuoka-cities";
+import { validateCoordinates } from "@/lib/validators";
 
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const REDIRECT_DELAY_MS = 3000;
@@ -45,23 +34,7 @@ export default function BarNewForm() {
 		contact_phone: "",
 	});
 
-	const [phase2, setPhase2] = useState({
-		name: "",
-		description: "",
-		access: "",
-		phone_number: "",
-		prefecture: "",
-		city: "",
-		address_line1: "",
-		address_line2: "",
-		latitude: "",
-		longitude: "",
-		website_url: "",
-		instagram_url: "",
-		x_url: "",
-		facebook_url: "",
-		line_url: "",
-	});
+	const [phase2, setPhase2] = useState(INITIAL_BAR_PROFILE_FIELDS);
 
 	// Images
 	const [previewImageFile, setPreviewImageFile] = useState<File | null>(null);
@@ -70,13 +43,7 @@ export default function BarNewForm() {
 	const [sliderMediaFiles, setSliderMediaFiles] = useState<File[]>([]);
 
 	const [openingHours, setOpeningHours] = useState<OpeningHourInput[]>(
-		Array.from({ length: 7 }, (_, day) => ({
-			day_of_week: day,
-			open_time: "",
-			close_time: "",
-			sort_order: 0,
-			is_closed: false,
-		})),
+		createInitialOpeningHours,
 	);
 
 	const [regularHoliday, setRegularHoliday] = useState("");
@@ -189,40 +156,10 @@ export default function BarNewForm() {
 		setError("");
 		setOpeningHoursErrors({});
 
-		if (phase2.website_url) {
-			const result = validateWebsiteUrl(phase2.website_url);
-			if (!result.isValid) {
-				setError(result.error || "ホームページURLの形式が正しくありません");
-				return;
-			}
-		}
-		if (phase2.instagram_url) {
-			const result = validateInstagramUrl(phase2.instagram_url);
-			if (!result.isValid) {
-				setError(result.error || "Instagram URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (phase2.x_url) {
-			const result = validateXUrl(phase2.x_url);
-			if (!result.isValid) {
-				setError(result.error || "X URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (phase2.facebook_url) {
-			const result = validateFacebookUrl(phase2.facebook_url);
-			if (!result.isValid) {
-				setError(result.error || "Facebook URLの形式が正しくありません");
-				return;
-			}
-		}
-		if (phase2.line_url) {
-			const result = validateLineUrl(phase2.line_url);
-			if (!result.isValid) {
-				setError(result.error || "LINE URLの形式が正しくありません");
-				return;
-			}
+		const snsResult = validateBarSnsUrls(phase2);
+		if (!snsResult.isValid) {
+			setError(snsResult.error as string);
+			return;
 		}
 
 		const coordinatesResult = validateCoordinates(
@@ -517,253 +454,7 @@ export default function BarNewForm() {
 						onRegularHolidayChange={setRegularHoliday}
 					/>
 
-					<div>
-						<label
-							htmlFor="access"
-							className="block text-sm font-medium text-gray-700"
-						>
-							アクセス
-						</label>
-						<input
-							type="text"
-							id="access"
-							name="access"
-							value={phase2.access}
-							onChange={handlePhase2Change}
-							placeholder="JR静岡駅北口から徒歩5分"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="phone_number"
-							className="block text-sm font-medium text-gray-700"
-						>
-							電話番号
-						</label>
-						<input
-							type="tel"
-							id="phone_number"
-							name="phone_number"
-							value={phase2.phone_number}
-							onChange={handlePhase2Change}
-							placeholder="054-123-4567"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="prefecture"
-							className="block text-sm font-medium text-gray-700"
-						>
-							都道府県
-						</label>
-						<select
-							id="prefecture"
-							name="prefecture"
-							value={phase2.prefecture}
-							onChange={handlePhase2Change}
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						>
-							<option value="">選択してください</option>
-							<option value={SHIZUOKA_PREFECTURE}>{SHIZUOKA_PREFECTURE}</option>
-						</select>
-					</div>
-
-					<div>
-						<label
-							htmlFor="city"
-							className="block text-sm font-medium text-gray-700"
-						>
-							市区町村
-						</label>
-						<select
-							id="city"
-							name="city"
-							value={phase2.city}
-							onChange={handlePhase2Change}
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						>
-							<option value="">選択してください</option>
-							{SHIZUOKA_MUNICIPALITIES.map((city) => (
-								<option key={city} value={city}>
-									{city}
-								</option>
-							))}
-						</select>
-					</div>
-
-					<div>
-						<label
-							htmlFor="address_line1"
-							className="block text-sm font-medium text-gray-700"
-						>
-							住所1
-						</label>
-						<input
-							type="text"
-							id="address_line1"
-							name="address_line1"
-							value={phase2.address_line1}
-							onChange={handlePhase2Change}
-							placeholder="番地等"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="address_line2"
-							className="block text-sm font-medium text-gray-700"
-						>
-							住所2
-						</label>
-						<input
-							type="text"
-							id="address_line2"
-							name="address_line2"
-							value={phase2.address_line2}
-							onChange={handlePhase2Change}
-							placeholder="建物名・部屋番号"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="latitude"
-							className="block text-sm font-medium text-gray-700"
-						>
-							緯度
-						</label>
-						<input
-							type="number"
-							step="any"
-							id="latitude"
-							name="latitude"
-							value={phase2.latitude}
-							onChange={handlePhase2Change}
-							placeholder="35.0116"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-						<p className="mt-1 text-sm text-gray-500">
-							-90〜90（マップ表示用・任意）
-						</p>
-					</div>
-
-					<div>
-						<label
-							htmlFor="longitude"
-							className="block text-sm font-medium text-gray-700"
-						>
-							経度
-						</label>
-						<input
-							type="number"
-							step="any"
-							id="longitude"
-							name="longitude"
-							value={phase2.longitude}
-							onChange={handlePhase2Change}
-							placeholder="135.7681"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-						<p className="mt-1 text-sm text-gray-500">
-							-180〜180（マップ表示用・任意）
-						</p>
-					</div>
-
-					<div>
-						<label
-							htmlFor="website_url"
-							className="block text-sm font-medium text-gray-700"
-						>
-							ホームページ
-						</label>
-						<input
-							type="url"
-							id="website_url"
-							name="website_url"
-							value={phase2.website_url}
-							onChange={handlePhase2Change}
-							placeholder="https://example.com"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="instagram_url"
-							className="block text-sm font-medium text-gray-700"
-						>
-							Instagram
-						</label>
-						<input
-							type="url"
-							id="instagram_url"
-							name="instagram_url"
-							value={phase2.instagram_url}
-							onChange={handlePhase2Change}
-							placeholder="https://www.instagram.com/your_account"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="x_url"
-							className="block text-sm font-medium text-gray-700"
-						>
-							X（Twitter）
-						</label>
-						<input
-							type="url"
-							id="x_url"
-							name="x_url"
-							value={phase2.x_url}
-							onChange={handlePhase2Change}
-							placeholder="https://x.com/example"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="facebook_url"
-							className="block text-sm font-medium text-gray-700"
-						>
-							Facebook
-						</label>
-						<input
-							type="url"
-							id="facebook_url"
-							name="facebook_url"
-							value={phase2.facebook_url}
-							onChange={handlePhase2Change}
-							placeholder="https://www.facebook.com/yourpage"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
-
-					<div>
-						<label
-							htmlFor="line_url"
-							className="block text-sm font-medium text-gray-700"
-						>
-							LINE
-						</label>
-						<input
-							type="url"
-							id="line_url"
-							name="line_url"
-							value={phase2.line_url}
-							onChange={handlePhase2Change}
-							placeholder="https://line.me/R/ti/p/@example"
-							className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
-						/>
-					</div>
+					<BarProfileFields fields={phase2} onChange={handlePhase2Change} />
 
 					{/* Preview image section */}
 					<div>

--- a/apps/admin/src/components/BarProfileFields.tsx
+++ b/apps/admin/src/components/BarProfileFields.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import type { BarProfileFields as BarProfileFieldsValue } from "@/lib/bar-form";
+import {
+	SHIZUOKA_MUNICIPALITIES,
+	SHIZUOKA_PREFECTURE,
+} from "@/lib/shizuoka-cities";
+
+interface BarProfileFieldsProps {
+	fields: BarProfileFieldsValue;
+	onChange: (
+		e: React.ChangeEvent<
+			HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+		>,
+	) => void;
+}
+
+/**
+ * 店舗新規登録・編集フォームで共有する住所系・SNS 系の入力フィールド群。
+ *
+ * name / description は各フォームで placeholder 等の微差があり冒頭に単独配置されるため対象外とし、
+ * access 以降の住所・座標・SNS 入力（両フォームで完全一致）だけを共通化する。
+ */
+export default function BarProfileFields({
+	fields,
+	onChange,
+}: BarProfileFieldsProps) {
+	return (
+		<>
+			<div>
+				<label
+					htmlFor="access"
+					className="block text-sm font-medium text-gray-700"
+				>
+					アクセス
+				</label>
+				<input
+					type="text"
+					id="access"
+					name="access"
+					value={fields.access}
+					onChange={onChange}
+					placeholder="JR静岡駅北口から徒歩5分"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="phone_number"
+					className="block text-sm font-medium text-gray-700"
+				>
+					電話番号
+				</label>
+				<input
+					type="tel"
+					id="phone_number"
+					name="phone_number"
+					value={fields.phone_number}
+					onChange={onChange}
+					placeholder="054-123-4567"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="prefecture"
+					className="block text-sm font-medium text-gray-700"
+				>
+					都道府県
+				</label>
+				<select
+					id="prefecture"
+					name="prefecture"
+					value={fields.prefecture}
+					onChange={onChange}
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				>
+					<option value="">選択してください</option>
+					<option value={SHIZUOKA_PREFECTURE}>{SHIZUOKA_PREFECTURE}</option>
+				</select>
+			</div>
+
+			<div>
+				<label
+					htmlFor="city"
+					className="block text-sm font-medium text-gray-700"
+				>
+					市区町村
+				</label>
+				<select
+					id="city"
+					name="city"
+					value={fields.city}
+					onChange={onChange}
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				>
+					<option value="">選択してください</option>
+					{SHIZUOKA_MUNICIPALITIES.map((city) => (
+						<option key={city} value={city}>
+							{city}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div>
+				<label
+					htmlFor="address_line1"
+					className="block text-sm font-medium text-gray-700"
+				>
+					住所1
+				</label>
+				<input
+					type="text"
+					id="address_line1"
+					name="address_line1"
+					value={fields.address_line1}
+					onChange={onChange}
+					placeholder="番地等"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="address_line2"
+					className="block text-sm font-medium text-gray-700"
+				>
+					住所2
+				</label>
+				<input
+					type="text"
+					id="address_line2"
+					name="address_line2"
+					value={fields.address_line2}
+					onChange={onChange}
+					placeholder="建物名・部屋番号"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="latitude"
+					className="block text-sm font-medium text-gray-700"
+				>
+					緯度
+				</label>
+				<input
+					type="number"
+					step="any"
+					id="latitude"
+					name="latitude"
+					value={fields.latitude}
+					onChange={onChange}
+					placeholder="35.0116"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+				<p className="mt-1 text-sm text-gray-500">
+					-90〜90（マップ表示用・任意）
+				</p>
+			</div>
+
+			<div>
+				<label
+					htmlFor="longitude"
+					className="block text-sm font-medium text-gray-700"
+				>
+					経度
+				</label>
+				<input
+					type="number"
+					step="any"
+					id="longitude"
+					name="longitude"
+					value={fields.longitude}
+					onChange={onChange}
+					placeholder="135.7681"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+				<p className="mt-1 text-sm text-gray-500">
+					-180〜180（マップ表示用・任意）
+				</p>
+			</div>
+
+			<div>
+				<label
+					htmlFor="website_url"
+					className="block text-sm font-medium text-gray-700"
+				>
+					ホームページ
+				</label>
+				<input
+					type="url"
+					id="website_url"
+					name="website_url"
+					value={fields.website_url}
+					onChange={onChange}
+					placeholder="https://example.com"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="instagram_url"
+					className="block text-sm font-medium text-gray-700"
+				>
+					Instagram
+				</label>
+				<input
+					type="url"
+					id="instagram_url"
+					name="instagram_url"
+					value={fields.instagram_url}
+					onChange={onChange}
+					placeholder="https://www.instagram.com/your_account"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="x_url"
+					className="block text-sm font-medium text-gray-700"
+				>
+					X（Twitter）
+				</label>
+				<input
+					type="url"
+					id="x_url"
+					name="x_url"
+					value={fields.x_url}
+					onChange={onChange}
+					placeholder="https://x.com/example"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="facebook_url"
+					className="block text-sm font-medium text-gray-700"
+				>
+					Facebook
+				</label>
+				<input
+					type="url"
+					id="facebook_url"
+					name="facebook_url"
+					value={fields.facebook_url}
+					onChange={onChange}
+					placeholder="https://www.facebook.com/yourpage"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="line_url"
+					className="block text-sm font-medium text-gray-700"
+				>
+					LINE
+				</label>
+				<input
+					type="url"
+					id="line_url"
+					name="line_url"
+					value={fields.line_url}
+					onChange={onChange}
+					placeholder="https://line.me/R/ti/p/@example"
+					className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+				/>
+			</div>
+		</>
+	);
+}

--- a/apps/admin/src/lib/bar-form.ts
+++ b/apps/admin/src/lib/bar-form.ts
@@ -1,0 +1,131 @@
+import {
+	validateFacebookUrl,
+	validateInstagramUrl,
+	validateLineUrl,
+	validateWebsiteUrl,
+	validateXUrl,
+} from "@/lib/validators";
+
+/**
+ * 店舗プロフィール入力フォーム（新規登録 / 編集）で共有する入力値の型。
+ *
+ * 数値項目（latitude/longitude）も state 表現に合わせ string とする。
+ * Why not「latitude/longitude を number」: フォームの input は文字列を保持し、
+ * 保存直前に validateCoordinates で数値化する既存フローに合わせるため。
+ */
+export interface BarProfileFields {
+	name: string;
+	description: string;
+	access: string;
+	phone_number: string;
+	prefecture: string;
+	city: string;
+	address_line1: string;
+	address_line2: string;
+	latitude: string;
+	longitude: string;
+	website_url: string;
+	instagram_url: string;
+	x_url: string;
+	facebook_url: string;
+	line_url: string;
+}
+
+export const INITIAL_BAR_PROFILE_FIELDS: BarProfileFields = {
+	name: "",
+	description: "",
+	access: "",
+	phone_number: "",
+	prefecture: "",
+	city: "",
+	address_line1: "",
+	address_line2: "",
+	latitude: "",
+	longitude: "",
+	website_url: "",
+	instagram_url: "",
+	x_url: "",
+	facebook_url: "",
+	line_url: "",
+};
+
+export interface OpeningHourInput {
+	day_of_week: number;
+	open_time: string;
+	close_time: string;
+	sort_order: number;
+	is_closed: boolean;
+}
+
+export function createInitialOpeningHours(): OpeningHourInput[] {
+	return Array.from({ length: 7 }, (_, day) => ({
+		day_of_week: day,
+		open_time: "",
+		close_time: "",
+		sort_order: 0,
+		is_closed: false,
+	}));
+}
+
+/**
+ * 店舗プロフィールの SNS・ホームページ URL 群を、新規登録・編集フォーム共通の
+ * 順序・フォールバック文言で一括検証する。
+ *
+ * 検証順は website → instagram → x → facebook → line で、最初に不正だった項目の
+ * エラーを返す（既存フォームの逐次検証の順序・文言を踏襲）。
+ *
+ * Why not「validators.ts に同居」: validators.ts は URL 種別ごとの純粋な個別バリデータ群。
+ * 「検証順・フォールバック文言・一括実行」というフォーム層固有の関心事は bar-form.ts に分離する。
+ */
+export function validateBarSnsUrls(fields: BarProfileFields): {
+	isValid: boolean;
+	error?: string;
+} {
+	if (fields.website_url) {
+		const result = validateWebsiteUrl(fields.website_url);
+		if (!result.isValid) {
+			return {
+				isValid: false,
+				error: result.error || "ホームページURLの形式が正しくありません",
+			};
+		}
+	}
+	if (fields.instagram_url) {
+		const result = validateInstagramUrl(fields.instagram_url);
+		if (!result.isValid) {
+			return {
+				isValid: false,
+				error: result.error || "Instagram URLの形式が正しくありません",
+			};
+		}
+	}
+	if (fields.x_url) {
+		const result = validateXUrl(fields.x_url);
+		if (!result.isValid) {
+			return {
+				isValid: false,
+				error: result.error || "X URLの形式が正しくありません",
+			};
+		}
+	}
+	if (fields.facebook_url) {
+		const result = validateFacebookUrl(fields.facebook_url);
+		if (!result.isValid) {
+			return {
+				isValid: false,
+				error: result.error || "Facebook URLの形式が正しくありません",
+			};
+		}
+	}
+	if (fields.line_url) {
+		const result = validateLineUrl(fields.line_url);
+		if (!result.isValid) {
+			return {
+				isValid: false,
+				error: result.error || "LINE URLの形式が正しくありません",
+			};
+		}
+	}
+
+	return { isValid: true };
+}

--- a/apps/admin/src/lib/bar-form.ts
+++ b/apps/admin/src/lib/bar-form.ts
@@ -12,6 +12,11 @@ import {
  * 数値項目（latitude/longitude）も state 表現に合わせ string とする。
  * Why not「latitude/longitude を number」: フォームの input は文字列を保持し、
  * 保存直前に validateCoordinates で数値化する既存フローに合わせるため。
+ *
+ * name / description も両フォーム共通の state 項目のためこの型に含めるが、共通 UI
+ * コンポーネント BarProfileFields では描画しない（両フォームで placeholder 等に微差があり
+ * 冒頭に単独配置されるため各フォーム側に残置する）。BarProfileFields が描画するのは
+ * access 以降の住所・座標・SNS 項目のみ。
  */
 export interface BarProfileFields {
 	name: string;
@@ -67,63 +72,60 @@ export function createInitialOpeningHours(): OpeningHourInput[] {
 	}));
 }
 
+// 検証順は website → instagram → x → facebook → line。
+// 各バリデータが error を返さなかった場合のフォールバック文言もここに集約する
+// （既存フォームの逐次検証の順序・文言を踏襲）。
+const BAR_SNS_URL_VALIDATIONS: ReadonlyArray<{
+	field: keyof BarProfileFields;
+	validate: (url: string) => { isValid: boolean; error?: string };
+	fallbackError: string;
+}> = [
+	{
+		field: "website_url",
+		validate: validateWebsiteUrl,
+		fallbackError: "ホームページURLの形式が正しくありません",
+	},
+	{
+		field: "instagram_url",
+		validate: validateInstagramUrl,
+		fallbackError: "Instagram URLの形式が正しくありません",
+	},
+	{
+		field: "x_url",
+		validate: validateXUrl,
+		fallbackError: "X URLの形式が正しくありません",
+	},
+	{
+		field: "facebook_url",
+		validate: validateFacebookUrl,
+		fallbackError: "Facebook URLの形式が正しくありません",
+	},
+	{
+		field: "line_url",
+		validate: validateLineUrl,
+		fallbackError: "LINE URLの形式が正しくありません",
+	},
+];
+
 /**
  * 店舗プロフィールの SNS・ホームページ URL 群を、新規登録・編集フォーム共通の
- * 順序・フォールバック文言で一括検証する。
- *
- * 検証順は website → instagram → x → facebook → line で、最初に不正だった項目の
- * エラーを返す（既存フォームの逐次検証の順序・文言を踏襲）。
+ * 順序・フォールバック文言で一括検証する。最初に不正だった項目のエラーを返す。
  *
  * Why not「validators.ts に同居」: validators.ts は URL 種別ごとの純粋な個別バリデータ群。
  * 「検証順・フォールバック文言・一括実行」というフォーム層固有の関心事は bar-form.ts に分離する。
  */
-export function validateBarSnsUrls(fields: BarProfileFields): {
-	isValid: boolean;
-	error?: string;
-} {
-	if (fields.website_url) {
-		const result = validateWebsiteUrl(fields.website_url);
-		if (!result.isValid) {
-			return {
-				isValid: false,
-				error: result.error || "ホームページURLの形式が正しくありません",
-			};
+export function validateBarSnsUrls(
+	fields: BarProfileFields,
+): { isValid: true } | { isValid: false; error: string } {
+	for (const { field, validate, fallbackError } of BAR_SNS_URL_VALIDATIONS) {
+		const url = fields[field];
+		if (!url) {
+			continue;
 		}
-	}
-	if (fields.instagram_url) {
-		const result = validateInstagramUrl(fields.instagram_url);
+
+		const result = validate(url);
 		if (!result.isValid) {
-			return {
-				isValid: false,
-				error: result.error || "Instagram URLの形式が正しくありません",
-			};
-		}
-	}
-	if (fields.x_url) {
-		const result = validateXUrl(fields.x_url);
-		if (!result.isValid) {
-			return {
-				isValid: false,
-				error: result.error || "X URLの形式が正しくありません",
-			};
-		}
-	}
-	if (fields.facebook_url) {
-		const result = validateFacebookUrl(fields.facebook_url);
-		if (!result.isValid) {
-			return {
-				isValid: false,
-				error: result.error || "Facebook URLの形式が正しくありません",
-			};
-		}
-	}
-	if (fields.line_url) {
-		const result = validateLineUrl(fields.line_url);
-		if (!result.isValid) {
-			return {
-				isValid: false,
-				error: result.error || "LINE URLの形式が正しくありません",
-			};
+			return { isValid: false, error: result.error || fallbackError };
 		}
 	}
 


### PR DESCRIPTION
## 概要

Issue #522。管理画面(BeerSalonAdmin)の `BarNewForm.tsx` と `BarEditForm.tsx` が
コピペで二重実装していた店舗プロフィール入力を共通化し、片方だけ直して同期漏れが
起きる事故を防ぐ。**挙動・送信ペイロードは不変**（リファクタ）。

> **UI に関する注記（レビュー Medium 指摘への対応 = A案）**: 共通コンポーネント `BarProfileFields` は
> 新規登録フォーム由来の placeholder（アクセス / 電話番号 / 住所1 / 住所2）を持つため、
> **編集画面にもこれらの placeholder が新たに表示される**（旧 `BarEditForm` は当該項目に placeholder が無かった）。
> これは新規側への統一として意図的に許容する。編集画面は既存値が埋まるため placeholder はほぼ露出せず実害は軽微。
> これ以外の UI 外形・レイアウトは不変。

## 変更内容

| ファイル | 内容 |
|---|---|
| `apps/admin/src/lib/bar-form.ts`（新規） | `BarProfileFields` 型 / `INITIAL_BAR_PROFILE_FIELDS` / `createInitialOpeningHours()` / `validateBarSnsUrls()`（URL 検証順・フォールバック文言をテーブル駆動で集約。戻り型は判別可能ユニオン） |
| `apps/admin/src/components/BarProfileFields.tsx`（新規） | 住所系・SNS 系入力フィールドの共通コンポーネント |
| `apps/admin/src/app/bars/new/BarNewForm.tsx` | 上記を参照する形に置換 |
| `apps/admin/src/app/bars/[barId]/edit/BarEditForm.tsx` | 上記を参照する形に置換 |
| `apps/admin/src/__tests__/bar-form.test.ts`（新規） | 抽出ロジックの UT |

差分: 約615行の重複を除去。

### スコープ判断
- `name` / `description` は new/edit で placeholder 等に微差があり冒頭に単独配置されるため各ファイルに残置（Issue 記載スコープ＝住所・SNS 系に厳密に合わせた）。型 `BarProfileFields` には含むが共通 UI では描画しない旨を Why not コメントで明記。
- `OpeningHoursEditor` は共通化済みのため対象外。
- API 側 (`api/bars/route.ts` 等) はサーバー受信バリデーションで別関心事のため対象外。
- 横展開スキャンの結果、同種の店舗プロフィール入力フォームは web 側・他ページに存在せず、対象は本2ファイルに閉じている。

## レビュー対応（PR #525 system-architect レビュー）
- **Medium（placeholder 差分）**: A案。上記「UI に関する注記」で新規側統一として明示（コード変更なし・本文で意図を明文化）。
- **Low #2**: `validateBarSnsUrls` の戻り型を判別可能ユニオン化 → 呼び出し側の `as string` キャストを除去。
- **Low #3**: URL 検証をテーブル駆動化（検証順・文言はテーブルで厳守）。
- **Low #4**: `BarProfileFields` 型に `name`/`description` を含むが共通 UI で描画しない理由を Why not コメントで補足。

## テスト

### UT（Vitest）
- `bar-form.test.ts` 13ケース pass
  - `validateBarSnsUrls`: 全空→valid / 各SNS不正→対応エラー文言 / 複数不正時に検証順先頭(website→instagram→x→facebook→line)のエラー / 全正常→valid
  - `createInitialOpeningHours`: 長さ7・day_of_week 0-6・初期値・呼び出しごとに独立配列
- admin 全 **277 テスト green**（既存 validators / bars-api-post / bars-api-put 破壊なし）
- 型チェック・format・lint すべてクリーン

### E2E（Playwright, admin プロダクションビルドで検証）
- ✅ 店舗編集: フィールド入力(access/住所2/Instagram)→保存→詳細に反映
- ✅ 不正URL(Instagram に `https://example.com`)→保存でエラー文言表示（保存はブロック）
- ✅ 営業時間(月曜17:00~23:00)入力→保存→反映
- ✅ 新規登録画面 Step2 で共通 `BarProfileFields` 正常描画

> 注: 今回は振る舞い不変のリファクタのため E2E コードは追加せず（ロジックは UT でカバー、UI外形は不変で回帰価値が低い）。動作確認のスクリーンショットは別途コメントに添付。

## 設計ドキュメント
画面遷移・DB・API いずれも変更なしのため更新不要。

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192vz2ketSSvZmXmkc2hirb