### PR TITLE
fix(admin): #528 決済後の戻り先URLをリクエストオリジンで解決する

### DIFF
--- a/apps/admin/src/__tests__/checkout-api.test.ts
+++ b/apps/admin/src/__tests__/checkout-api.test.ts
@@ -27,9 +27,14 @@ vi.mock("@/lib/stripe", () => ({
 
 import { POST } from "@/app/api/bars/[barId]/checkout/route";
 
-function createMockRequest(): Parameters<typeof POST>[0] {
+// success_url の元になるオリジン解決を検証するため、リクエストヘッダーを差し込めるようにする。
+// resolveRequestOrigin は x-forwarded-host / x-forwarded-proto / host を Headers.get で読む。
+function createMockRequest(
+	headers: Record<string, string> = {},
+): Parameters<typeof POST>[0] {
 	return {
 		method: "POST",
+		headers: new Headers(headers),
 	} as Parameters<typeof POST>[0];
 }
 
@@ -76,6 +81,7 @@ describe("POST /api/bars/[barId]/checkout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		process.env.ADMIN_BASE_URL = "http://localhost:3001";
+		process.env.NEXT_PUBLIC_APP_URL = "";
 	});
 
 	it("未認証の場合は401を返す", async () => {
@@ -174,6 +180,103 @@ describe("POST /api/bars/[barId]/checkout", () => {
 			success_url: "http://localhost:3001/bars/1",
 			cancel_url: "http://localhost:3001/bars/1",
 		});
+	});
+
+	it("x-forwarded-host/proto がある場合、そのオリジンで success_url を生成する（決済元へ戻る）", async () => {
+		// プレビュー環境の ADMIN_BASE_URL は本番ドメインを指すが、リクエストオリジンを優先する。
+		process.env.ADMIN_BASE_URL = "https://beer-salon-admin.vercel.app";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseTables({
+			activeSub: { data: null },
+			plan: {
+				data: { id: 42, stripe_price_id: "price_test_5000" },
+				error: null,
+			},
+		});
+		mockCheckoutSessionsCreate.mockResolvedValue({
+			url: "https://checkout.stripe.com/c/pay/preview_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+				cancel_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+			}),
+		);
+	});
+
+	it("host のみ（x-forwarded-proto 無し）の場合は https で success_url を生成する", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseTables({
+			activeSub: { data: null },
+			plan: {
+				data: { id: 42, stripe_price_id: "price_test_5000" },
+				error: null,
+			},
+		});
+		mockCheckoutSessionsCreate.mockResolvedValue({
+			url: "https://checkout.stripe.com/c/pay/host_session",
+		});
+
+		const response = await POST(
+			createMockRequest({ host: "beer-salon-admin-develop.vercel.app" }),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+			}),
+		);
+	});
+
+	it("ヘッダーが無い場合は ADMIN_BASE_URL にフォールバックする", async () => {
+		process.env.ADMIN_BASE_URL = "http://localhost:3001";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseTables({
+			activeSub: { data: null },
+			plan: {
+				data: { id: 42, stripe_price_id: "price_test_5000" },
+				error: null,
+			},
+		});
+		mockCheckoutSessionsCreate.mockResolvedValue({
+			url: "https://checkout.stripe.com/c/pay/fallback_session",
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+
+		expect(response.status).toBe(200);
+		expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success_url: "http://localhost:3001/bars/1",
+			}),
+		);
 	});
 
 	it("Stripe APIエラー時は500を返し、エラーをログ出力する", async () => {

--- a/apps/admin/src/__tests__/portal-api.test.ts
+++ b/apps/admin/src/__tests__/portal-api.test.ts
@@ -27,9 +27,13 @@ vi.mock("@/lib/stripe", () => ({
 
 import { POST } from "@/app/api/bars/[barId]/portal/route";
 
-function createMockRequest(): Parameters<typeof POST>[0] {
+// return_url の元になるオリジン解決を検証するため、リクエストヘッダーを差し込めるようにする。
+function createMockRequest(
+	headers: Record<string, string> = {},
+): Parameters<typeof POST>[0] {
 	return {
 		method: "POST",
+		headers: new Headers(headers),
 	} as Parameters<typeof POST>[0];
 }
 
@@ -55,6 +59,7 @@ function mockSupabaseChain(result: { data: unknown; error: unknown }) {
 describe("POST /api/bars/[barId]/portal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		process.env.ADMIN_BASE_URL = "";
 		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3001";
 	});
 
@@ -128,6 +133,62 @@ describe("POST /api/bars/[barId]/portal", () => {
 			customer: "cus_test123",
 			return_url: "http://localhost:3001/bars/1",
 		});
+	});
+
+	it("x-forwarded-host/proto がある場合、そのオリジンで return_url を生成する（決済元へ戻る）", async () => {
+		// プレビュー環境の NEXT_PUBLIC_APP_URL は本番ドメインを指すが、リクエストオリジンを優先する。
+		process.env.NEXT_PUBLIC_APP_URL = "https://beer-salon-admin.vercel.app";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockResolvedValue({
+			url: "https://billing.stripe.com/session/preview_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+			customer: "cus_test123",
+			return_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+		});
+	});
+
+	it("ヘッダー・環境変数とも未設定の場合は500を返す", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("Stripe Customer Portalの作成に失敗しました");
+		expect(mockPortalSessionsCreate).not.toHaveBeenCalled();
+		consoleSpy.mockRestore();
 	});
 
 	it("Stripe APIエラー時は500を返し、エラーをログ出力する", async () => {

--- a/apps/admin/src/app/api/bars/[barId]/checkout/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/checkout/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
+import { resolveRequestOrigin } from "@/lib/request-origin";
 import { stripe } from "@/lib/stripe";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export async function POST(
-	_request: NextRequest,
+	request: NextRequest,
 	{ params }: { params: Promise<{ barId: string }> },
 ) {
 	const user = await getCurrentUser();
@@ -48,13 +49,15 @@ export async function POST(
 		);
 	}
 
-	const baseUrl = process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+	// 決済元のオリジン（プレビューならプレビュー、本番なら本番）へ戻すため、
+	// リクエストヘッダーからオリジンを解決する（Issue #528 課題2）。
+	const baseUrl = resolveRequestOrigin(request);
 
 	// Why not: baseUrl 未設定のまま Checkout を作ると success_url が "undefined/bars/..." になり
 	//   決済後の戻り先が壊れる。無言で壊すより 500 で早期に落とす。
 	if (!baseUrl) {
 		console.error(
-			"Stripe Checkout: ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL が未設定です",
+			"Stripe Checkout: リクエストオリジンを解決できませんでした（ヘッダー・環境変数とも未設定）",
 		);
 		return NextResponse.json(
 			{ error: "Stripe Checkoutの作成に失敗しました" },

--- a/apps/admin/src/app/api/bars/[barId]/portal/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/portal/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
+import { resolveRequestOrigin } from "@/lib/request-origin";
 import { stripe } from "@/lib/stripe";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export async function POST(
-	_request: NextRequest,
+	request: NextRequest,
 	{ params }: { params: Promise<{ barId: string }> },
 ) {
 	const user = await getCurrentUser();
@@ -34,10 +35,26 @@ export async function POST(
 		);
 	}
 
+	// 支払い方法管理からの復帰も決済元のオリジンへ戻すため、
+	// リクエストヘッダーからオリジンを解決する（Issue #528 課題2の横展開）。
+	const baseUrl = resolveRequestOrigin(request);
+
+	// Why not: baseUrl 未設定のまま Portal を作ると return_url が "undefined/bars/..." になり
+	//   復帰先が壊れる。checkout と挙動を揃え、無言で壊すより 500 で早期に落とす。
+	if (!baseUrl) {
+		console.error(
+			"Stripe Portal: リクエストオリジンを解決できませんでした（ヘッダー・環境変数とも未設定）",
+		);
+		return NextResponse.json(
+			{ error: "Stripe Customer Portalの作成に失敗しました" },
+			{ status: 500 },
+		);
+	}
+
 	try {
 		const portalSession = await stripe.billingPortal.sessions.create({
 			customer: subscription.stripe_customer_id,
-			return_url: `${process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL}/bars/${barId}`,
+			return_url: `${baseUrl}/bars/${barId}`,
 		});
 
 		return NextResponse.json({ url: portalSession.url });

--- a/apps/admin/src/lib/request-origin.test.ts
+++ b/apps/admin/src/lib/request-origin.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveRequestOrigin } from "./request-origin";
+
+// NextRequest 全体をこしらえる必要はなく、resolveRequestOrigin は headers.get のみ使う。
+function makeRequest(headers: Record<string, string>) {
+	return {
+		headers: new Headers(headers),
+	} as Parameters<typeof resolveRequestOrigin>[0];
+}
+
+describe("resolveRequestOrigin", () => {
+	const originalAdminBaseUrl = process.env.ADMIN_BASE_URL;
+	const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+	beforeEach(() => {
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+	});
+
+	afterEach(() => {
+		process.env.ADMIN_BASE_URL = originalAdminBaseUrl;
+		process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+	});
+
+	it("x-forwarded-host と x-forwarded-proto から オリジンを組む", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+		);
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("x-forwarded-proto が無ければ https を既定にする", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({ "x-forwarded-host": "example.vercel.app" }),
+		);
+		expect(origin).toBe("https://example.vercel.app");
+	});
+
+	it("x-forwarded-host が無ければ host ヘッダーを使う", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({ host: "localhost:3001", "x-forwarded-proto": "http" }),
+		);
+		expect(origin).toBe("http://localhost:3001");
+	});
+
+	it("x-forwarded-host を host より優先する", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({
+				"x-forwarded-host": "forwarded.vercel.app",
+				host: "internal-host",
+				"x-forwarded-proto": "https",
+			}),
+		);
+		expect(origin).toBe("https://forwarded.vercel.app");
+	});
+
+	it("ホスト系ヘッダーが無ければ ADMIN_BASE_URL にフォールバックする", () => {
+		process.env.ADMIN_BASE_URL = "https://beer-salon-admin.vercel.app";
+		const origin = resolveRequestOrigin(makeRequest({}));
+		expect(origin).toBe("https://beer-salon-admin.vercel.app");
+	});
+
+	it("ADMIN_BASE_URL が無ければ NEXT_PUBLIC_APP_URL にフォールバックする", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+		const origin = resolveRequestOrigin(makeRequest({}));
+		expect(origin).toBe("https://app.example.com");
+	});
+
+	it("ヘッダーも環境変数も無ければ null を返す", () => {
+		const origin = resolveRequestOrigin(makeRequest({}));
+		expect(origin).toBeNull();
+	});
+});

--- a/apps/admin/src/lib/request-origin.ts
+++ b/apps/admin/src/lib/request-origin.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from "next/server";
+
+// Stripe の success/cancel/return URL を「決済元のオリジン」で組むために、
+// リクエストヘッダーからオリジンを解決する。
+//
+// Why not 環境変数固定（ADMIN_BASE_URL）だけで組む:
+//   プレビュー環境の ADMIN_BASE_URL は本番ドメインを指す構成のため、
+//   環境変数固定だとプレビューで決済しても本番へ戻ってしまう（Issue #528 課題2）。
+//   Vercel は背後で x-forwarded-host / x-forwarded-proto を付与するので、
+//   これを一次ソースにして「決済元へ戻す」を満たす。
+//
+// Why not 環境変数フォールバックを完全に撤廃する:
+//   ヘッダーが取得できない実行経路（テスト・ローカルの一部）で success_url が
+//   壊れるのを避けるため、ヘッダー欠落時のみ環境変数にフォールバックする。
+//   両方とも取れない場合のみ null を返し、呼び出し側で 500 にする。
+export function resolveRequestOrigin(request: NextRequest): string | null {
+	const forwardedHost = request.headers.get("x-forwarded-host");
+	const host = forwardedHost ?? request.headers.get("host");
+
+	if (host) {
+		// Why not http 固定: プレビュー/本番は https、ローカルは http のため、
+		//   プロトコルもヘッダー由来を優先する。取れなければ https を既定にする
+		//   （Vercel 上は常に https のため）。
+		const proto = request.headers.get("x-forwarded-proto") ?? "https";
+		return `${proto}://${host}`;
+	}
+
+	const fallback =
+		process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+	return fallback || null;
+}

--- a/docs/stripe-webhook-setup.md
+++ b/docs/stripe-webhook-setup.md
@@ -1,0 +1,95 @@
+# Stripe Webhook 設定手順（Preview / 本番）
+
+Issue #528 の受入条件のうち、**コードでは解決できない環境作業**をまとめる。
+決済成功を BeerSalon の DB（`bar_subscriptions`）へ反映するには、Stripe 側で webhook
+エンドポイントを登録し、その署名シークレット（`STRIPE_WEBHOOK_SECRET`）を Vercel の
+該当環境に登録する必要がある。コード側（webhook 受け口・課金バッジ切替）は実装・テスト済みで、
+本手順を完了すると決済完了 → 「課金中」バッジ切替が自動で動く。
+
+## 前提（コード側は対応済み）
+
+- Webhook 受け口: `apps/admin/src/app/api/webhooks/stripe/route.ts`
+  - 署名検証に `process.env.STRIPE_WEBHOOK_SECRET` を使用
+  - 処理イベント: `customer.subscription.created` / `.updated` / `.deleted`、`invoice.paid` / `.payment_failed`
+  - `customer.subscription.created` を受けると、Checkout の `subscription_data.metadata`
+    （`bar_id` / `subscription_plan_id`）を復元して `bar_subscriptions` へ upsert する
+  - at-least-once 配信に備え `stripe_subscription_id` の onConflict upsert で冪等化済み
+- 課金カードの「未課金 / 課金中」バッジは subscription API の結果で切り替わるため、
+  `bar_subscriptions` に active 行が入れば自動で「課金中」+ 支払い方法管理に変わる
+
+## エンドポイント URL
+
+環境ごとに以下のパスへ webhook を登録する（末尾にクエリ等は付けない）。
+
+| 環境 | Webhook エンドポイント URL |
+|---|---|
+| Preview (develop) | `https://beer-salon-admin-develop.vercel.app/api/webhooks/stripe` |
+| 本番 | `https://beer-salon-admin.vercel.app/api/webhooks/stripe` |
+
+> Preview の安定 URL が古いデプロイを指していないこと（`beer-salon-admin-develop` エイリアスが
+> 最新 develop デプロイに向いていること）を先に確認する。
+
+## 手順（Preview を例に。本番も同じ流れ）
+
+### 1. Stripe ダッシュボードで Webhook エンドポイントを登録
+
+1. Stripe ダッシュボードを **テストモード**（Preview 用）で開く
+   - 本番向けに設定するときは本番モードで行う
+2. 「開発者」→「Webhook」→「エンドポイントを追加」
+3. 「エンドポイント URL」に上表の Preview URL を入力
+4. 「リッスンするイベント」で以下を選択（コードが処理する 5 種）
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+   - `invoice.paid`
+   - `invoice.payment_failed`
+5. エンドポイントを作成する
+
+### 2. 署名シークレットを控える
+
+作成したエンドポイントの詳細画面で「署名シークレット」（`whsec_...`）を表示してコピーする。
+これが `STRIPE_WEBHOOK_SECRET` の値になる。**Preview と本番でシークレットは別物**なので取り違えない。
+
+### 3. Vercel に `STRIPE_WEBHOOK_SECRET` を登録
+
+admin プロジェクトの環境変数として、対象環境（Preview / Production）に登録する。
+
+```bash
+# Preview に登録
+vercel env add STRIPE_WEBHOOK_SECRET preview
+# → プロンプトで whsec_... を貼り付け
+
+# 本番に登録する場合
+vercel env add STRIPE_WEBHOOK_SECRET production
+```
+
+- **`SUPABASE_SERVICE_ROLE_KEY` が対象環境に正しく入っているかも併せて確認する**。
+  webhook ハンドラは `supabaseAdmin`（service_role）で `bar_subscriptions` へ書き込むため、
+  Preview の service_role キーが anon キーにすり替わっていると RLS で書き込みが無言失敗する。
+
+### 4. 再デプロイして反映
+
+環境変数は既存のデプロイには反映されないため、対象環境を再デプロイする。
+
+```bash
+# deploy.yml の再実行、または
+vercel --prebuilt   # 対象環境へ
+```
+
+## 動作確認
+
+1. Preview の管理画面に bar_owner でログインし、対象店舗の課金カードから Checkout を開始
+2. Stripe テストカード（`4242 4242 4242 4242` 等）で決済を完了
+3. Stripe ダッシュボードの「Webhook」→当該エンドポイントの「送信済みイベント」で
+   `customer.subscription.created` が **200** で配信されていることを確認
+   - 400（署名検証失敗）なら `STRIPE_WEBHOOK_SECRET` の値・環境が誤っている
+   - 500 なら Vercel Runtime Logs でハンドラのエラー（service_role キー等）を確認
+4. `bar_subscriptions` に当該 `bar_id` の `status = active` 行が作成されていることを確認
+5. 店舗詳細を再読込し、課金カードが「課金中」バッジ + 支払い方法管理に切り替わることを確認
+
+## 本番移行時の注意
+
+- 本番モードの Stripe で別エンドポイントを登録し、本番用 `STRIPE_WEBHOOK_SECRET` を
+  Production 環境に登録する（テストモードのシークレットは本番では使えない）。
+- 決済後の戻り先 URL はコード側でリクエストオリジン（`x-forwarded-host`）から解決するため、
+  本番ドメインからの決済は本番へ戻る。環境変数の戻り先設定は不要（Issue #528 課題2で対応済み）。

--- a/routing.md
+++ b/routing.md
@@ -742,6 +742,8 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
 - 店舗詳細ページの課金カードは、当該店舗の active サブスクリプション有無で導線を出し分ける（GET `/api/bars/[barId]/subscription` で判定）
   - **未サブスク（active 行なし）**: 「課金を開始する」ボタン → POST `/api/bars/[barId]/checkout` で Stripe Checkout セッション（mode: subscription）を生成し外部リダイレクト。決済完了後は webhook `customer.subscription.created` が `bar_subscriptions` を insert する（Checkout の `subscription_data.metadata` に埋めた `bar_id` / `subscription_plan_id` で紐付け）
   - **サブスク有り（active 行あり）**: 「支払い方法管理」ボタン → POST `/api/bars/[barId]/portal` で Stripe Customer Portal へ外部リダイレクト
+- Checkout の success/cancel URL、Portal の return_url（決済完了後の戻り先）は、リクエストヘッダー（`x-forwarded-host` / `host`、プロトコルは `x-forwarded-proto`）から**リクエスト元のオリジンを動的に解決**して組む。これにより local / Vercel Preview / production のいずれから決済しても、決済元のオリジンへ戻る（Preview で決済して本番へ飛ぶ問題を回避）。ヘッダーが取れない場合のみ `ADMIN_BASE_URL` / `NEXT_PUBLIC_APP_URL` にフォールバックし、両方とも無ければ 500（認証メールのコールバックURL解決と同じ方針）
+- webhook（`STRIPE_WEBHOOK_SECRET`）と Stripe ダッシュボードのエンドポイント登録は環境作業のため `docs/stripe-webhook-setup.md` にまとめる
 - 既に active/trialing/past_due のサブスクがある店舗で Checkout を叩くと 409（二重課金防止）
 - Checkout に渡す `stripe_price_id` は `subscription_plans`（is_active な1件）から取得する
 - 管理画面内に専用ページは設けない（店舗詳細内のカードで完結）


### PR DESCRIPTION
## 概要

Issue #528 のうち **コード側で解決する課題2（決済後の戻り先URLが本番を指す）** に対応する。
Checkout の success/cancel URL と Portal の return_url を、環境変数固定（`ADMIN_BASE_URL`）から
リクエストヘッダー（`x-forwarded-host` / `x-forwarded-proto`）由来のオリジン解決へ切り替えた。

課題1（webhook 未設定）は Issue の受入条件どおり **環境作業**であり、コードは実装・テスト済みのため
本 PR ではコード変更せず、`docs/stripe-webhook-setup.md` に設定手順書としてまとめた。

## 根本原因

- checkout/portal 両ルートが success/return URL を `process.env.ADMIN_BASE_URL || NEXT_PUBLIC_APP_URL` の
  **環境変数固定**で組んでいた。プレビュー環境のこの変数は本番ドメインを指す構成のため、
  プレビューで決済しても本番へ戻っていた（決済元リクエストのオリジンを解決していなかった）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `apps/admin/src/lib/request-origin.ts` | 新規。`x-forwarded-host`（無ければ `host`）+ `x-forwarded-proto`（無ければ https）でオリジンを解決。取得不可時のみ環境変数フォールバック、両方無しで null |
| `apps/admin/src/app/api/bars/[barId]/checkout/route.ts` | `request` を使い success/cancel URL をオリジン解決由来に |
| `apps/admin/src/app/api/bars/[barId]/portal/route.ts` | return_url をオリジン解決由来に。未解決時 500 を checkout と揃えて追加（横展開） |
| `apps/admin/src/lib/request-origin.test.ts` | 新規。オリジン解決の全分岐 UT |
| `apps/admin/src/__tests__/checkout-api.test.ts` | forwarded-host / host のみ / フォールバックのケース追加 |
| `apps/admin/src/__tests__/portal-api.test.ts` | 同上 + ヘッダー・環境変数とも無しの 500 ケース追加 |
| `docs/stripe-webhook-setup.md` | 新規。webhook エンドポイント登録・`STRIPE_WEBHOOK_SECRET` 登録手順（環境作業） |
| `routing.md` | 戻り先URLのオリジン解決方針・webhook手順書参照を追記 |

## 設計判断

- 認証メールのコールバックURL解決（routing.md 既存記載）と**同じ方針**に揃えた。
  Vercel は背後で `x-forwarded-host` / `x-forwarded-proto` を付与するのでこれを一次ソースにする。
- 環境変数フォールバックは撤廃せず残す（ヘッダーが取れない実行経路で success_url が壊れるのを回避）。
  両方欠落時のみ 500。

## テスト

- UT: `pnpm --filter @beersalon/admin test` → **289 passed**（新規追加分含む・typecheck/lint green）
- E2E: 本変更の本質（`x-forwarded-host` からプレビュードメインへ戻る）は localhost では
  forwarded ヘッダーが付かず再現不可。分岐は UT で全網羅済みのため、テストピラミッド原則に沿い
  E2E コードは追加せず、実地確認はプレビューでの手動検証（`docs/stripe-webhook-setup.md`）に委ねる。

## リスク

- 本番も同じオリジン解決に切り替わるが、Vercel 本番の `x-forwarded-host` は本番ドメインを返すため結果は同一。
- ローカル（localhost:3001）は `host` ヘッダーが `localhost:3001` を返すため従来と一致。

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM7w8Bws7TGm6Feo7Njrfj