### PR TITLE
fix(admin): #528 決済後の戻り先URLをenv優先のオリジン解決にする

### DIFF
--- a/apps/admin/src/__tests__/checkout-api.test.ts
+++ b/apps/admin/src/__tests__/checkout-api.test.ts
@@ -27,9 +27,13 @@ vi.mock("@/lib/stripe", () => ({
 
 import { POST } from "@/app/api/bars/[barId]/checkout/route";
 
-function createMockRequest(): Parameters<typeof POST>[0] {
+// success_url の元になるオリジン解決を検証するため、リクエストヘッダーを差し込めるようにする。
+function createMockRequest(
+	headers: Record<string, string> = {},
+): Parameters<typeof POST>[0] {
 	return {
 		method: "POST",
+		headers: new Headers(headers),
 	} as Parameters<typeof POST>[0];
 }
 
@@ -76,6 +80,7 @@ describe("POST /api/bars/[barId]/checkout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		process.env.ADMIN_BASE_URL = "http://localhost:3001";
+		process.env.NEXT_PUBLIC_APP_URL = "";
 	});
 
 	it("未認証の場合は401を返す", async () => {
@@ -174,6 +179,78 @@ describe("POST /api/bars/[barId]/checkout", () => {
 			success_url: "http://localhost:3001/bars/1",
 			cancel_url: "http://localhost:3001/bars/1",
 		});
+	});
+
+	it("ADMIN_BASE_URL は偽装された x-forwarded-host より優先される（Host Header Injection 対策）", async () => {
+		process.env.ADMIN_BASE_URL = "https://beer-salon-admin-develop.vercel.app";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseTables({
+			activeSub: { data: null },
+			plan: {
+				data: { id: 42, stripe_price_id: "price_test_5000" },
+				error: null,
+			},
+		});
+		mockCheckoutSessionsCreate.mockResolvedValue({
+			url: "https://checkout.stripe.com/c/pay/env_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "evil.example.com",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+				cancel_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+			}),
+		);
+	});
+
+	it("env 未設定時は x-forwarded-host からオリジンを解決する", async () => {
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseTables({
+			activeSub: { data: null },
+			plan: {
+				data: { id: 42, stripe_price_id: "price_test_5000" },
+				error: null,
+			},
+		});
+		mockCheckoutSessionsCreate.mockResolvedValue({
+			url: "https://checkout.stripe.com/c/pay/header_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+			}),
+		);
 	});
 
 	it("Stripe APIエラー時は500を返し、エラーをログ出力する", async () => {

--- a/apps/admin/src/__tests__/portal-api.test.ts
+++ b/apps/admin/src/__tests__/portal-api.test.ts
@@ -27,9 +27,13 @@ vi.mock("@/lib/stripe", () => ({
 
 import { POST } from "@/app/api/bars/[barId]/portal/route";
 
-function createMockRequest(): Parameters<typeof POST>[0] {
+// return_url の元になるオリジン解決を検証するため、リクエストヘッダーを差し込めるようにする。
+function createMockRequest(
+	headers: Record<string, string> = {},
+): Parameters<typeof POST>[0] {
 	return {
 		method: "POST",
+		headers: new Headers(headers),
 	} as Parameters<typeof POST>[0];
 }
 
@@ -55,6 +59,7 @@ function mockSupabaseChain(result: { data: unknown; error: unknown }) {
 describe("POST /api/bars/[barId]/portal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		process.env.ADMIN_BASE_URL = "";
 		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3001";
 	});
 
@@ -128,6 +133,94 @@ describe("POST /api/bars/[barId]/portal", () => {
 			customer: "cus_test123",
 			return_url: "http://localhost:3001/bars/1",
 		});
+	});
+
+	it("env は偽装された x-forwarded-host より優先される（Host Header Injection 対策）", async () => {
+		process.env.NEXT_PUBLIC_APP_URL =
+			"https://beer-salon-admin-develop.vercel.app";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockResolvedValue({
+			url: "https://billing.stripe.com/session/env_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "evil.example.com",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+			customer: "cus_test123",
+			return_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+		});
+	});
+
+	it("env 未設定時は x-forwarded-host から return_url を解決する", async () => {
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+		mockPortalSessionsCreate.mockResolvedValue({
+			url: "https://billing.stripe.com/session/header_session",
+		});
+
+		const response = await POST(
+			createMockRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+			createMockParams("1"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+			customer: "cus_test123",
+			return_url: "https://beer-salon-admin-develop.vercel.app/bars/1",
+		});
+	});
+
+	it("env・ヘッダーとも未設定の場合は500を返す", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			role: "bar_owner",
+			barId: 1,
+		});
+		mockCanAccessBar.mockReturnValue(true);
+		mockSupabaseChain({
+			data: { stripe_customer_id: "cus_test123" },
+			error: null,
+		});
+
+		const response = await POST(createMockRequest(), createMockParams("1"));
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body.error).toBe("Stripe Customer Portalの作成に失敗しました");
+		expect(mockPortalSessionsCreate).not.toHaveBeenCalled();
+		consoleSpy.mockRestore();
 	});
 
 	it("Stripe APIエラー時は500を返し、エラーをログ出力する", async () => {

--- a/apps/admin/src/app/api/bars/[barId]/checkout/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/checkout/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
+import { resolveRequestOrigin } from "@/lib/request-origin";
 import { stripe } from "@/lib/stripe";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export async function POST(
-	_request: NextRequest,
+	request: NextRequest,
 	{ params }: { params: Promise<{ barId: string }> },
 ) {
 	const user = await getCurrentUser();
@@ -48,13 +49,15 @@ export async function POST(
 		);
 	}
 
-	const baseUrl = process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+	// 戻り先オリジンは env（ADMIN_BASE_URL）を最優先に解決する。プレビューで本番へ飛ぶ問題は
+	// env をプレビュードメインに是正することで解決する（Issue #528 課題2）。
+	const baseUrl = resolveRequestOrigin(request);
 
-	// Why not: baseUrl 未設定のまま Checkout を作ると success_url が "undefined/bars/..." になり
+	// Why not: baseUrl 未解決のまま Checkout を作ると success_url が "undefined/bars/..." になり
 	//   決済後の戻り先が壊れる。無言で壊すより 500 で早期に落とす。
 	if (!baseUrl) {
 		console.error(
-			"Stripe Checkout: ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL が未設定です",
+			"Stripe Checkout: リクエストオリジンを解決できませんでした（環境変数・ヘッダーとも未設定）",
 		);
 		return NextResponse.json(
 			{ error: "Stripe Checkoutの作成に失敗しました" },

--- a/apps/admin/src/app/api/bars/[barId]/portal/route.ts
+++ b/apps/admin/src/app/api/bars/[barId]/portal/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { canAccessBar, getCurrentUser } from "@/lib/auth";
+import { resolveRequestOrigin } from "@/lib/request-origin";
 import { stripe } from "@/lib/stripe";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export async function POST(
-	_request: NextRequest,
+	request: NextRequest,
 	{ params }: { params: Promise<{ barId: string }> },
 ) {
 	const user = await getCurrentUser();
@@ -34,10 +35,25 @@ export async function POST(
 		);
 	}
 
+	// 支払い方法管理からの復帰先も env 最優先で解決する（Issue #528 課題2の横展開）。
+	const baseUrl = resolveRequestOrigin(request);
+
+	// Why not: baseUrl 未解決のまま Portal を作ると return_url が "undefined/bars/..." になり
+	//   復帰先が壊れる。checkout と挙動を揃え、無言で壊すより 500 で早期に落とす。
+	if (!baseUrl) {
+		console.error(
+			"Stripe Portal: リクエストオリジンを解決できませんでした（環境変数・ヘッダーとも未設定）",
+		);
+		return NextResponse.json(
+			{ error: "Stripe Customer Portalの作成に失敗しました" },
+			{ status: 500 },
+		);
+	}
+
 	try {
 		const portalSession = await stripe.billingPortal.sessions.create({
 			customer: subscription.stripe_customer_id,
-			return_url: `${process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL}/bars/${barId}`,
+			return_url: `${baseUrl}/bars/${barId}`,
 		});
 
 		return NextResponse.json({ url: portalSession.url });

--- a/apps/admin/src/lib/request-origin.test.ts
+++ b/apps/admin/src/lib/request-origin.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveRequestOrigin } from "./request-origin";
+
+// NextRequest 全体をこしらえる必要はなく、resolveRequestOrigin は headers.get のみ使う。
+function makeRequest(headers: Record<string, string>) {
+	return {
+		headers: new Headers(headers),
+	} as Parameters<typeof resolveRequestOrigin>[0];
+}
+
+describe("resolveRequestOrigin", () => {
+	const originalAdminBaseUrl = process.env.ADMIN_BASE_URL;
+	const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+	beforeEach(() => {
+		process.env.ADMIN_BASE_URL = "";
+		process.env.NEXT_PUBLIC_APP_URL = "";
+	});
+
+	afterEach(() => {
+		process.env.ADMIN_BASE_URL = originalAdminBaseUrl;
+		process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+	});
+
+	it("ADMIN_BASE_URL を最優先で使う（正規化した origin を返す）", () => {
+		process.env.ADMIN_BASE_URL = "https://beer-salon-admin-develop.vercel.app";
+		const origin = resolveRequestOrigin(makeRequest({}));
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("ADMIN_BASE_URL は x-forwarded-host より優先される（Host Header Injection 対策）", () => {
+		// env が設定されていれば、偽装された forwarded-host は無視される。
+		process.env.ADMIN_BASE_URL = "https://beer-salon-admin-develop.vercel.app";
+		const origin = resolveRequestOrigin(
+			makeRequest({
+				"x-forwarded-host": "evil.example.com",
+				"x-forwarded-proto": "https",
+			}),
+		);
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("ADMIN_BASE_URL が無ければ NEXT_PUBLIC_APP_URL を使う", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com/path";
+		const origin = resolveRequestOrigin(makeRequest({}));
+		// new URL().origin でパスは落ちる。
+		expect(origin).toBe("https://app.example.com");
+	});
+
+	it("env が不正なURLなら無視してヘッダー解決にフォールバックする", () => {
+		process.env.ADMIN_BASE_URL = "not-a-url";
+		const origin = resolveRequestOrigin(
+			makeRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+		);
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("env 無し時は x-forwarded-host + proto で組む", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({
+				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
+				"x-forwarded-proto": "https",
+			}),
+		);
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("env 無し・x-forwarded-host 無しなら host を使い、localhost は http を補完する", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({ host: "localhost:3001" }),
+		);
+		expect(origin).toBe("http://localhost:3001");
+	});
+
+	it("env 無し・host が非localhost なら https を補完する", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({ host: "beer-salon-admin-develop.vercel.app" }),
+		);
+		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	});
+
+	it("localhost.evil.com のような偽装ホストは localhost 扱いせず https を補完する", () => {
+		const origin = resolveRequestOrigin(
+			makeRequest({ host: "localhost.evil.com" }),
+		);
+		expect(origin).toBe("https://localhost.evil.com");
+	});
+
+	it("env もヘッダーも無ければ null を返す", () => {
+		const origin = resolveRequestOrigin(makeRequest({}));
+		expect(origin).toBeNull();
+	});
+});

--- a/apps/admin/src/lib/request-origin.ts
+++ b/apps/admin/src/lib/request-origin.ts
@@ -1,0 +1,63 @@
+import type { NextRequest } from "next/server";
+
+const isLocalHost = (host: string): boolean => {
+	// Why not startsWith: `localhost.evil.com` のような偽装ホスト名を localhost と誤判定し、
+	//   production で誤って http スキームを返す経路を作りうるため、ホスト部分のみ完全一致で判定する。
+	const hostname = host.split(":")[0];
+	if (hostname === "localhost" || hostname === "127.0.0.1") {
+		return true;
+	}
+	// Why not: IPv6 loopback (`[::1]` または `[::1]:3001`) を扱うため、`[::1]` から始まるかも許可する。
+	return host === "[::1]" || host.startsWith("[::1]:");
+};
+
+const normalizeEnvUrl = (envUrl: string): string | null => {
+	try {
+		return new URL(envUrl).origin;
+	} catch {
+		return null;
+	}
+};
+
+// Stripe の success/cancel/return URL を組むためのベースURL（origin）を解決する。
+//
+// 解決順序（apps/web の getSiteUrl と揃える）:
+// 1. ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL（最優先。`new URL().origin` で正規化。不正値は無視）
+// 2. x-forwarded-host + x-forwarded-proto（Vercel など信頼できる reverse proxy 経由時）
+// 3. host ヘッダー（localhost は http、それ以外は https を補完）
+// 4. 解決不能なら null（呼び出し側で 500）
+//
+// Why not ヘッダー最優先（forwarded-host を一次ソースにする）:
+//   `x-forwarded-host` はクライアントが偽装しうるため、production で戻り先を乗っ取られる
+//   Host Header Injection の経路になる。web 側 getSiteUrl と同じく env を最優先にし、
+//   production では env（信頼できる固定値）を必ず設定する運用にする。プレビューで戻り先が
+//   本番へ飛ぶ問題（Issue #528 課題2）は、env をプレビュードメインに是正することで解決する。
+export function resolveRequestOrigin(request: NextRequest): string | null {
+	const envUrl = process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+	if (envUrl) {
+		const normalized = normalizeEnvUrl(envUrl);
+		if (normalized !== null) {
+			return normalized;
+		}
+		console.warn(
+			`[request-origin] ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL の値 "${envUrl}" が不正なURLのため無視します。スキーム (http(s)://) 付きのオリジンを設定してください。`,
+		);
+	}
+
+	if (process.env.NODE_ENV === "production") {
+		console.warn(
+			"[request-origin] production では ADMIN_BASE_URL の設定を推奨します（x-forwarded-host 由来の Host Header Injection を防ぐため）。",
+		);
+	}
+
+	const forwardedHost = request.headers.get("x-forwarded-host");
+	const host = forwardedHost ?? request.headers.get("host");
+
+	if (!host) {
+		return null;
+	}
+
+	const forwardedProto = request.headers.get("x-forwarded-proto");
+	const proto = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
+	return `${proto}://${host}`;
+}

--- a/docs/stripe-webhook-setup.md
+++ b/docs/stripe-webhook-setup.md
@@ -1,0 +1,134 @@
+# Stripe 決済まわりの環境設定手順（Preview / 本番）
+
+Issue #528 のうち、**コードでは解決できない環境作業**をまとめる。対象は次の2つ。
+
+1. **戻り先URL用の env 是正**（課題2の環境側対応）: admin の `ADMIN_BASE_URL` /
+   `NEXT_PUBLIC_APP_URL`（Preview）が本番ドメインを指しているのを、プレビュードメインへ直す。
+2. **webhook 設定**（課題1）: Stripe ダッシュボードで webhook エンドポイントを登録し、
+   実際の署名シークレット（`STRIPE_WEBHOOK_SECRET`）を Preview / 本番に登録する。
+
+コード側（オリジン解決・webhook 受け口・課金バッジ切替）は実装・テスト済み。本手順を完了すると、
+決済完了 → 「課金中」バッジ切替、および決済後に決済元オリジンへ戻る挙動が揃う。
+
+---
+
+## 1. 戻り先URL用の env 是正（課題2の環境側対応）
+
+### 背景
+
+admin のオリジン解決 `resolveRequestOrigin`（`apps/admin/src/lib/request-origin.ts`）は、
+Host Header Injection を防ぐため **env（`ADMIN_BASE_URL` → `NEXT_PUBLIC_APP_URL`）を最優先**に解決する
+（web 側 `getSiteUrl` と揃えた方針）。したがって Preview の戻り先を正しくするには、
+**Preview 環境の env をプレビュードメインに設定する**必要がある。
+
+### 現状（2026-08-03 時点の実測）
+
+`vercel env pull --environment=preview`（apps/admin）で確認した値:
+
+| env（admin Preview） | 現状の値 | あるべき値 |
+|---|---|---|
+| `ADMIN_BASE_URL` | `https://beer-salon-admin.vercel.app`（本番） | `https://beer-salon-admin-develop.vercel.app` |
+| `NEXT_PUBLIC_APP_URL` | `https://beer-salon-admin.vercel.app`（本番） | `https://beer-salon-admin-develop.vercel.app` |
+
+プレビューの安定URLは `beer-salon-admin-develop.vercel.app`（`vercel alias ls` で最新 Preview デプロイを指す）。
+
+### 手順
+
+```bash
+cd apps/admin
+
+# 既存の Preview 値を差し替える（remove → add）
+vercel env rm ADMIN_BASE_URL preview
+vercel env add ADMIN_BASE_URL preview
+# → プロンプトで https://beer-salon-admin-develop.vercel.app を入力
+
+vercel env rm NEXT_PUBLIC_APP_URL preview
+vercel env add NEXT_PUBLIC_APP_URL preview
+# → 同上
+```
+
+### 反映（env 変更は再デプロイ＋alias付け替えが必要）
+
+env 変更は既存デプロイに反映されない。かつ `vercel redeploy` では固定 alias が自動で付け替わらない。
+
+```bash
+# develop を push して deploy.yml 経由で再デプロイ（推奨。alias まで面倒を見る）
+# または手動の場合は redeploy 後に必ず alias を付け替える:
+vercel alias set <新しいPreviewデプロイURL> beer-salon-admin-develop.vercel.app
+```
+
+### 本番について
+
+本番（Production）の `ADMIN_BASE_URL` は `https://beer-salon-admin.vercel.app`（本番ドメイン）で正しい。
+本番からの決済は env（本番ドメイン）優先で本番へ戻るため、本番側の是正は不要。
+
+---
+
+## 2. Webhook 設定（課題1）
+
+### 前提（コード側は対応済み）
+
+- Webhook 受け口: `apps/admin/src/app/api/webhooks/stripe/route.ts`
+  - 署名検証に `process.env.STRIPE_WEBHOOK_SECRET` を使用
+  - 処理イベント: `customer.subscription.created` / `.updated` / `.deleted`、`invoice.paid` / `.payment_failed`
+  - `customer.subscription.created` を受けると Checkout の `subscription_data.metadata`
+    （`bar_id` / `subscription_plan_id`）を復元して `bar_subscriptions` へ upsert（onConflict で冪等化済み）
+- 課金カードの「未課金 / 課金中」バッジは subscription API の結果で切り替わるため、
+  `bar_subscriptions` に active 行が入れば自動で「課金中」+ 支払い方法管理に変わる
+
+### 現状（2026-08-03 時点の実測）
+
+`STRIPE_WEBHOOK_SECRET`（Preview）は**登録済みだが値が `whsec_dummy_for_now` というダミー**。
+このままでは署名検証が通らず webhook が 400 で弾かれる。Stripe 側のエンドポイント登録も未の可能性が高い。
+→ **「未登録→登録」ではなく「ダミー→実シークレット差し替え + Stripe endpoint 登録」が必要**。
+
+### エンドポイント URL
+
+| 環境 | Webhook エンドポイント URL |
+|---|---|
+| Preview (develop) | `https://beer-salon-admin-develop.vercel.app/api/webhooks/stripe` |
+| 本番 | `https://beer-salon-admin.vercel.app/api/webhooks/stripe` |
+
+### 手順（Preview を例に。本番も同じ流れ）
+
+1. Stripe ダッシュボードを **テストモード**（Preview 用）で開く
+2. 「開発者」→「Webhook」→「エンドポイントを追加」
+3. 「エンドポイント URL」に上表の Preview URL を入力
+4. 「リッスンするイベント」で以下5種を選択:
+   - `customer.subscription.created` / `customer.subscription.updated` / `customer.subscription.deleted`
+   - `invoice.paid` / `invoice.payment_failed`
+5. エンドポイントを作成し、詳細画面の「署名シークレット」（`whsec_...`）をコピー
+6. Vercel の Preview 環境の `STRIPE_WEBHOOK_SECRET` を実シークレットに差し替える:
+
+```bash
+cd apps/admin
+vercel env rm STRIPE_WEBHOOK_SECRET preview   # ダミー値を削除
+vercel env add STRIPE_WEBHOOK_SECRET preview  # 実 whsec_... を入力
+```
+
+7. 再デプロイ（上記「反映」と同じ。develop push → deploy.yml）で反映
+
+> **`SUPABASE_SERVICE_ROLE_KEY` が対象環境に正しく入っているかも確認する**。webhook ハンドラは
+> `supabaseAdmin`（service_role）で `bar_subscriptions` に書き込むため、service_role キーが
+> anon キーにすり替わっていると RLS で書き込みが無言失敗する。
+
+---
+
+## 動作確認
+
+1. Preview の管理画面に bar_owner でログインし、対象店舗の課金カードから Checkout を開始
+2. Stripe テストカード（`4242 4242 4242 4242` 等）で決済を完了
+3. **決済完了後、プレビュー（`beer-salon-admin-develop.vercel.app`）へ戻る**ことを確認（課題2）
+   - 本番へ飛ぶ場合は env 是正（手順1）の再デプロイ・alias 付け替えが未反映
+4. Stripe ダッシュボードの Webhook →当該エンドポイントの「送信済みイベント」で
+   `customer.subscription.created` が **200** で配信されていることを確認（課題1）
+   - 400（署名検証失敗）なら `STRIPE_WEBHOOK_SECRET` がダミーのまま／値・環境が誤り
+   - 500 なら Vercel Runtime Logs でハンドラのエラー（service_role キー等）を確認
+5. `bar_subscriptions` に当該 `bar_id` の `status = active` 行が作成されていることを確認
+6. 店舗詳細を再読込し、課金カードが「課金中」バッジ + 支払い方法管理に切り替わることを確認
+
+## 本番移行時の注意
+
+- 本番モードの Stripe で別エンドポイントを登録し、本番用 `STRIPE_WEBHOOK_SECRET` を
+  Production 環境に登録する（テストモードのシークレットは本番では使えない）。
+- 戻り先 URL は env（本番は `beer-salon-admin.vercel.app`）優先で本番へ戻るため、本番側の env 是正は不要。

--- a/routing.md
+++ b/routing.md
@@ -742,6 +742,7 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
 - 店舗詳細ページの課金カードは、当該店舗の active サブスクリプション有無で導線を出し分ける（GET `/api/bars/[barId]/subscription` で判定）
   - **未サブスク（active 行なし）**: 「課金を開始する」ボタン → POST `/api/bars/[barId]/checkout` で Stripe Checkout セッション（mode: subscription）を生成し外部リダイレクト。決済完了後は webhook `customer.subscription.created` が `bar_subscriptions` を insert する（Checkout の `subscription_data.metadata` に埋めた `bar_id` / `subscription_plan_id` で紐付け）
   - **サブスク有り（active 行あり）**: 「支払い方法管理」ボタン → POST `/api/bars/[barId]/portal` で Stripe Customer Portal へ外部リダイレクト
+- Checkout の success/cancel URL、Portal の return_url（決済後の戻り先）は `resolveRequestOrigin`（`apps/admin/src/lib/request-origin.ts`）で解決する。解決順序は **env（`ADMIN_BASE_URL` → `NEXT_PUBLIC_APP_URL`）最優先 → `x-forwarded-host`+`x-forwarded-proto` → `host`（localhost は http）→ 解決不能なら 500**。web の `getSiteUrl`（認証メールのコールバックURL）と同じく env 最優先で、`x-forwarded-host` 由来の Host Header Injection を防ぐ。プレビューで戻り先が本番へ飛ぶ問題は、Preview の env をプレビュードメイン（`beer-salon-admin-develop.vercel.app`）に是正することで解決する（env・webhook の環境作業は `docs/stripe-webhook-setup.md`）
 - 既に active/trialing/past_due のサブスクがある店舗で Checkout を叩くと 409（二重課金防止）
 - Checkout に渡す `stripe_price_id` は `subscription_plans`（is_active な1件）から取得する
 - 管理画面内に専用ページは設けない（店舗詳細内のカードで完結）


### PR DESCRIPTION
## 概要

Issue #528 のうち **コード側で解決する課題2（決済後の戻り先URLが本番を指す）** に対応する。
Checkout の success/cancel URL と Portal の return_url を、環境変数固定から `resolveRequestOrigin` による
**env 最優先のオリジン解決**へ切り替えた。

> 本PRは、先にクローズした PR #529（header優先の初回実装）の作り直し。pr-review で web 既存
> `getSiteUrl` と優先順位が逆（Host Header Injection 保護なし）と指摘され、**env優先へ揃える方針**に転換した。

## 根本原因（実測で確定）

`vercel env pull`（admin Preview）で確認したところ、Preview の `ADMIN_BASE_URL` /
`NEXT_PUBLIC_APP_URL` が **本番ドメイン `beer-salon-admin.vercel.app` を指していた**。
success/return URL をこの env 固定で組むため、プレビューで決済しても本番へ戻っていた。

## 設計方針（env 最優先の理由）

- `x-forwarded-host` はクライアントが偽装しうるため、header 最優先だと production で戻り先を乗っ取られる
  Host Header Injection の経路になる。
- web 側 `apps/web/src/lib/site-url.ts`（`getSiteUrl`）が既に **env 最優先**で同じ問題を解いており、
  admin もこれに揃えた。解決順序: **env（`ADMIN_BASE_URL` → `NEXT_PUBLIC_APP_URL`）→ `x-forwarded-host`+proto → `host`（localhost は http）→ 解決不能なら 500**。
- プレビューで戻り先が本番へ飛ぶ問題は、**Preview の env をプレビュードメインに是正**することで解決する
  （env 是正手順は `docs/stripe-webhook-setup.md`）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `apps/admin/src/lib/request-origin.ts` | 新規。env最優先のオリジン解決。`localhost.evil.com` 偽装を弾く完全一致判定・不正env無視を含む |
| `apps/admin/src/app/api/bars/[barId]/checkout/route.ts` | success/cancel URL をヘルパー由来に |
| `apps/admin/src/app/api/bars/[barId]/portal/route.ts` | return_url をヘルパー由来に。未解決時500を checkout と揃えて追加（横展開） |
| `apps/admin/src/lib/request-origin.test.ts` | 新規。全分岐UT（env優先・偽装ヘッダー無視・不正env・ヘッダーフォールバック・localhost偽装弾き・null） |
| `apps/admin/src/__tests__/checkout-api.test.ts` / `portal-api.test.ts` | env優先ケース・ヘッダーフォールバック・500ケース追加 |
| `docs/stripe-webhook-setup.md` | 新規。Preview env是正（本番→プレビュードメイン）+ webhook設定（`STRIPE_WEBHOOK_SECRET` がダミー値のため実シークレット差替）手順 |
| `routing.md` | 戻り先URLの解決方針を追記 |

## 課題1（webhook）の扱い

コード（webhook 受け口・upsert冪等化・課金バッジ切替）は実装・テスト済みのため**コード変更なし**。
実測で `STRIPE_WEBHOOK_SECRET`（Preview）は登録済みだが値が `whsec_dummy_for_now` というダミーと判明。
「ダミー→実シークレット差替 + Stripe endpoint登録」を手順書にまとめた（Issue受入条件の環境作業分離）。

## テスト

- UT: `pnpm --filter @beersalon/admin test` → **291 passed**（typecheck/lint green）
- E2E: 本変更の本質（Vercelプレビューでの実挙動）は localhost では forwarded ヘッダーが付かず再現不可。
  分岐は UT で全網羅済みのため E2E コードは追加せず、実地確認は `docs/stripe-webhook-setup.md` に委ねる。

## 後続

- web/admin のオリジン解決を `packages/shared` に共通化するリファクタは **別Issue #531** に切り出し済み。

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM7w8Bws7TGm6Feo7Njrfj