### PR TITLE
docs: #521 user_auth_id の auth.users FK 記述を論理参照へ修正

### DIFF
--- a/database.md
+++ b/database.md
@@ -30,7 +30,7 @@
 
 ### 1-1. user_profiles
 
-Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロフィール。
+Supabase Auth の `auth.users` に論理的に紐づくアプリ側のユーザプロフィール。紐付けは `user_auth_id` カラムをアプリ層で `auth.uid()` と照合することで行い、DB外部キー制約は持たない。
 
 - **Table name:** `user_profiles`
 - **Description:** Beer Salon のユーザー基本情報を保持
@@ -40,7 +40,7 @@ Supabase Auth の `auth.users` にぶら下がるアプリ側のユーザプロ�
 | Column          | Type        | Constraints                           | Description                    |
 |-----------------|------------|----------------------------------------|--------------------------------|
 | id              | uuid       | PK, default gen_random_uuid()         | アプリ内でのユーザID（将来拡張用） |
-| user_auth_id         | uuid       | NOT NULL, UNIQUE, FK → auth.users(id) | Supabase Auth のユーザID       |
+| user_auth_id         | uuid       | NOT NULL, UNIQUE                        | Supabase Auth のユーザID。アプリ層で `user_auth_id = auth.uid()` により論理参照する（DB外部キー制約は無い） |
 | last_name       | text       | NOT NULL                               | 姓                            |
 | first_name      | text       | NOT NULL                               | 名                            |
 | nickname        | text       | NOT NULL                               | ニックネーム                   |


### PR DESCRIPTION
## 概要

Closes #521

`database.md` の `user_profiles.user_auth_id` に関する記述が実装と乖離していたため、ドキュメントを実態に合わせて修正する。

## 根本原因

`database.md` L43 は `user_auth_id` に `FK → auth.users(id)` 制約があると記載していたが、実装（`supabase/migrations/20241201000000_init_schema.sql`・Prisma スキーマ）に DB 外部キー制約は存在しない。実態は `user_auth_id = auth.uid()` をアプリ層（RLS ポリシー）で照合する**論理参照**であり、DB 制約としては `NOT NULL` + `UNIQUE`（UNIQUE INDEX）のみ。ドキュメントが実装より先行した乖離。

## 変更内容

| ファイル | 変更 |
|---|---|
| `database.md` | L43 Constraints 欄を `NOT NULL, UNIQUE, FK → auth.users(id)` → `NOT NULL, UNIQUE` に修正。Description に論理参照である旨を追記。L33 の説明文も「ぶら下がる」から論理参照であることが伝わる表現へ修正 |

ソースコード・マイグレーションの変更はなし（案A: ドキュメント修正を採用）。

## 検証

- 全マイグレーション（`supabase/migrations/`・`prisma/migrations/`）を grep し、`auth.users` への FK / REFERENCES 制約が一切存在しないことを再確認
- `user_auth_id` の DB 制約は `NOT NULL`（init_schema.sql L13）+ `UNIQUE INDEX`（L29）のみ
- 唯一の `auth.uid()` 参照は RLS ポリシー（`20260729000000_enable_rls_public_tables.sql`）内の `user_auth_id = auth.uid()`（アプリ層の論理照合）
- `database.md` 全体で `auth.users` への FK 記述は L43 のみであることを確認（他の FK 記述は全て `public` スキーマ内の実在テーブル間参照）

## テスト

ドキュメント修正のみでソース変更を伴わないため、UT（Vitest）/E2E（Playwright）の追加対象なし（`testing.md` のルールは機能追加・バグ修正でソースを変更した場合に発火）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)