### PR TITLE
test: #538 フリーワード検索E2Eにhydrationガードを追加

### DIFF
--- a/apps/web/e2e/bar-search.spec.ts
+++ b/apps/web/e2e/bar-search.spec.ts
@@ -63,6 +63,12 @@ test.describe("トップページ（検索ページ）", () => {
 	}) => {
 		await page.goto("/");
 
+		// 検索前の初期状態（両店舗が見える）まで hydration を待つ。
+		// これを待たずに fill+click すると、CI では検索ボタンの onClick が hydrate 前に
+		// 空振りし router.replace が発火せず URL が / のまま更新されないことがある（#419 と同経路）。
+		await expect(page.getByText("E2Eテストバー静岡")).toBeVisible();
+		await expect(page.getByText("E2Eテストバー東京")).toBeVisible();
+
 		await page.fill("#search-keyword", "東京");
 		await page.getByRole("button", { name: "検索" }).click();
 
@@ -73,6 +79,11 @@ test.describe("トップページ（検索ページ）", () => {
 
 	test("ブラウザバックで検索条件が復元される", async ({ page }) => {
 		await page.goto("/");
+
+		// 検索前の初期状態（両店舗が見える）まで hydration を待つ（フリーワード検索テストと同様）。
+		// goto 直後に fill+click すると hydrate 前で router.replace が空振りし得るため。
+		await expect(page.getByText("E2Eテストバー静岡")).toBeVisible();
+		await expect(page.getByText("E2Eテストバー東京")).toBeVisible();
 
 		await page.fill("#search-keyword", "静岡");
 		await page.getByRole("button", { name: "検索" }).click();


### PR DESCRIPTION
## 概要

Issue #538 — フリーワード検索E2E（`bar-search.spec.ts`）がCIで落ちる問題を修正する。

## 根本原因

`page.goto("/")` 直後、React のハイドレート完了前に `fill` + 検索ボタン `click` が走ると、`SearchForm` の `onClick`（`handleKeywordSearch` → 親 `handleSearch` → `router.replace`）がまだ配線されておらず空振りし、URL が `/` のまま更新されずタイムアウトする。同一ファイルの市町村フィルタテストは #419 でこの hydration ガードを入れ解消済みだが、フリーワード検索テスト（#288 で追加）には入っておらず取りこぼされていた。

## 変更内容

`apps/web/e2e/bar-search.spec.ts` のE2Eテストのみ変更（プロダクトコードは無変更）:

- **フリーワード検索テスト**: `fill`/`click` 前に両店舗（静岡・東京）の表示待ちを追加し、hydration 完了を保証
- **ブラウザバックテスト**: `goto` 直後に即 `fill`+`click` する同一パターンのため、同ガードを予防的に追加

#419 が採った「操作対象の初期状態が描画されるまで待つ」方式を踏襲。本番コードに testMode 等の分岐は持ち込まない（testing.md のハードコード禁止に整合）。

## テスト

- **UT（Vitest）**: 528件 pass（既存テスト非破壊。本件はプロダクトロジック不変のためUT追加なし）
- **E2E（Playwright）**: prodビルド + 起動済みサーバーで検証
  - 対象2テストを `--repeat-each=3` → 6/6 pass（決定論的passを確認）
  - `bar-search.spec.ts` 全9テスト → 9/9 pass（回帰なし）

## 補足

`--repeat-each` の反復中に発生していたローカルのログイン全滅は、Supabase `auth` コンテナが `Exited(128)` で落ちていた環境障害が原因（Docker Desktop 再起動で復旧）。コード変更とは無関係で、修正前の状態でも同様に落ちることを stash で確認済み。

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)