### PR TITLE
refactor: #531 リクエストオリジン解決を web/admin で共通化（shared に一本化）

### DIFF
--- a/apps/admin/src/lib/request-origin.test.ts
+++ b/apps/admin/src/lib/request-origin.test.ts
@@ -8,7 +8,11 @@ function makeRequest(headers: Record<string, string>) {
 	} as Parameters<typeof resolveRequestOrigin>[0];
 }
 
-describe("resolveRequestOrigin", () => {
+// 解決ロジックの網羅は shared の resolveOriginFromHeaders の UT
+// （packages/shared/src/request-origin.test.ts）が担う。ここでは resolveRequestOrigin が
+// NextRequest のヘッダーと admin 固有の env 名 / フォールバック（null）をコアへ正しく委譲する
+// ことを確認する。
+describe("resolveRequestOrigin（コアへの委譲）", () => {
 	const originalAdminBaseUrl = process.env.ADMIN_BASE_URL;
 	const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
 
@@ -22,75 +26,29 @@ describe("resolveRequestOrigin", () => {
 		process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
 	});
 
-	it("ADMIN_BASE_URL を最優先で使う（正規化した origin を返す）", () => {
+	it("ADMIN_BASE_URL を最優先で origin として返す（env 名の注入確認）", () => {
 		process.env.ADMIN_BASE_URL = "https://beer-salon-admin-develop.vercel.app";
-		const origin = resolveRequestOrigin(makeRequest({}));
-		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
-	});
-
-	it("ADMIN_BASE_URL は x-forwarded-host より優先される（Host Header Injection 対策）", () => {
-		// env が設定されていれば、偽装された forwarded-host は無視される。
-		process.env.ADMIN_BASE_URL = "https://beer-salon-admin-develop.vercel.app";
-		const origin = resolveRequestOrigin(
-			makeRequest({
-				"x-forwarded-host": "evil.example.com",
-				"x-forwarded-proto": "https",
-			}),
+		expect(resolveRequestOrigin(makeRequest({}))).toBe(
+			"https://beer-salon-admin-develop.vercel.app",
 		);
-		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
 	});
 
-	it("ADMIN_BASE_URL が無ければ NEXT_PUBLIC_APP_URL を使う", () => {
-		process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com/path";
-		const origin = resolveRequestOrigin(makeRequest({}));
-		// new URL().origin でパスは落ちる。
-		expect(origin).toBe("https://app.example.com");
-	});
-
-	it("env が不正なURLなら無視してヘッダー解決にフォールバックする", () => {
-		process.env.ADMIN_BASE_URL = "not-a-url";
-		const origin = resolveRequestOrigin(
-			makeRequest({
-				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
-				"x-forwarded-proto": "https",
-			}),
+	it("ADMIN_BASE_URL が無ければ NEXT_PUBLIC_APP_URL にフォールバックする（env の合成順の確認）", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+		expect(resolveRequestOrigin(makeRequest({}))).toBe(
+			"https://app.example.com",
 		);
-		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
 	});
 
-	it("env 無し時は x-forwarded-host + proto で組む", () => {
-		const origin = resolveRequestOrigin(
-			makeRequest({
-				"x-forwarded-host": "beer-salon-admin-develop.vercel.app",
-				"x-forwarded-proto": "https",
-			}),
-		);
-		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
+	it("env 未設定時は NextRequest のヘッダーから組み立てる（ヘッダー取得の委譲確認）", () => {
+		expect(
+			resolveRequestOrigin(
+				makeRequest({ host: "beer-salon-admin-develop.vercel.app" }),
+			),
+		).toBe("https://beer-salon-admin-develop.vercel.app");
 	});
 
-	it("env 無し・x-forwarded-host 無しなら host を使い、localhost は http を補完する", () => {
-		const origin = resolveRequestOrigin(
-			makeRequest({ host: "localhost:3001" }),
-		);
-		expect(origin).toBe("http://localhost:3001");
-	});
-
-	it("env 無し・host が非localhost なら https を補完する", () => {
-		const origin = resolveRequestOrigin(
-			makeRequest({ host: "beer-salon-admin-develop.vercel.app" }),
-		);
-		expect(origin).toBe("https://beer-salon-admin-develop.vercel.app");
-	});
-
-	it("localhost.evil.com のような偽装ホストは localhost 扱いせず https を補完する", () => {
-		const origin = resolveRequestOrigin(
-			makeRequest({ host: "localhost.evil.com" }),
-		);
-		expect(origin).toBe("https://localhost.evil.com");
-	});
-
-	it("env もヘッダーも無ければ null を返す", () => {
-		const origin = resolveRequestOrigin(makeRequest({}));
-		expect(origin).toBeNull();
+	it("env もヘッダーも無ければ admin 固有のフォールバック null を返す", () => {
+		expect(resolveRequestOrigin(makeRequest({}))).toBeNull();
 	});
 });

--- a/apps/admin/src/lib/request-origin.ts
+++ b/apps/admin/src/lib/request-origin.ts
@@ -1,63 +1,23 @@
+import { resolveOriginFromHeaders } from "@beersalon/shared";
 import type { NextRequest } from "next/server";
-
-const isLocalHost = (host: string): boolean => {
-	// Why not startsWith: `localhost.evil.com` のような偽装ホスト名を localhost と誤判定し、
-	//   production で誤って http スキームを返す経路を作りうるため、ホスト部分のみ完全一致で判定する。
-	const hostname = host.split(":")[0];
-	if (hostname === "localhost" || hostname === "127.0.0.1") {
-		return true;
-	}
-	// Why not: IPv6 loopback (`[::1]` または `[::1]:3001`) を扱うため、`[::1]` から始まるかも許可する。
-	return host === "[::1]" || host.startsWith("[::1]:");
-};
-
-const normalizeEnvUrl = (envUrl: string): string | null => {
-	try {
-		return new URL(envUrl).origin;
-	} catch {
-		return null;
-	}
-};
 
 // Stripe の success/cancel/return URL を組むためのベースURL（origin）を解決する。
 //
-// 解決順序（apps/web の getSiteUrl と揃える）:
-// 1. ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL（最優先。`new URL().origin` で正規化。不正値は無視）
-// 2. x-forwarded-host + x-forwarded-proto（Vercel など信頼できる reverse proxy 経由時）
-// 3. host ヘッダー（localhost は http、それ以外は https を補完）
-// 4. 解決不能なら null（呼び出し側で 500）
+// 解決順序・Host Header Injection 対策は shared の `resolveOriginFromHeaders` に一本化
+// （web 側 getSiteUrl と同一コア）。このラッパーは `NextRequest` からのヘッダー取得と、
+// admin 固有の env 名（ADMIN_BASE_URL ?? NEXT_PUBLIC_APP_URL）/ フォールバック値（null）の
+// 注入だけを担う。
 //
 // Why not ヘッダー最優先（forwarded-host を一次ソースにする）:
 //   `x-forwarded-host` はクライアントが偽装しうるため、production で戻り先を乗っ取られる
-//   Host Header Injection の経路になる。web 側 getSiteUrl と同じく env を最優先にし、
-//   production では env（信頼できる固定値）を必ず設定する運用にする。プレビューで戻り先が
-//   本番へ飛ぶ問題（Issue #528 課題2）は、env をプレビュードメインに是正することで解決する。
+//   Host Header Injection の経路になる。env を最優先にし、production では env（信頼できる
+//   固定値）を必ず設定する運用にする。プレビューで戻り先が本番へ飛ぶ問題（Issue #528 課題2）は、
+//   env をプレビュードメインに是正することで解決する。
 export function resolveRequestOrigin(request: NextRequest): string | null {
-	const envUrl = process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
-	if (envUrl) {
-		const normalized = normalizeEnvUrl(envUrl);
-		if (normalized !== null) {
-			return normalized;
-		}
-		console.warn(
-			`[request-origin] ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL の値 "${envUrl}" が不正なURLのため無視します。スキーム (http(s)://) 付きのオリジンを設定してください。`,
-		);
-	}
-
-	if (process.env.NODE_ENV === "production") {
-		console.warn(
-			"[request-origin] production では ADMIN_BASE_URL の設定を推奨します（x-forwarded-host 由来の Host Header Injection を防ぐため）。",
-		);
-	}
-
-	const forwardedHost = request.headers.get("x-forwarded-host");
-	const host = forwardedHost ?? request.headers.get("host");
-
-	if (!host) {
-		return null;
-	}
-
-	const forwardedProto = request.headers.get("x-forwarded-proto");
-	const proto = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
-	return `${proto}://${host}`;
+	return resolveOriginFromHeaders((name) => request.headers.get(name), {
+		envUrl: process.env.ADMIN_BASE_URL || process.env.NEXT_PUBLIC_APP_URL,
+		fallback: null,
+		warnLabel: "request-origin",
+		envVarName: "ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL",
+	});
 }

--- a/apps/web/src/lib/site-url.test.ts
+++ b/apps/web/src/lib/site-url.test.ts
@@ -11,7 +11,10 @@ const createHeaderMap = (entries: Record<string, string>) => ({
 	get: (key: string): string | null => entries[key.toLowerCase()] ?? null,
 });
 
-describe("getSiteUrl", () => {
+// 解決ロジックの網羅は shared の resolveOriginFromHeaders の UT
+// （packages/shared/src/request-origin.test.ts）が担う。ここでは getSiteUrl が
+// next/headers のヘッダーと web 固有の env 名 / フォールバックをコアへ正しく委譲することを確認する。
+describe("getSiteUrl（コアへの委譲）", () => {
 	const originalEnv = process.env.NEXT_PUBLIC_SITE_URL;
 
 	beforeEach(() => {
@@ -25,229 +28,26 @@ describe("getSiteUrl", () => {
 		} else {
 			process.env.NEXT_PUBLIC_SITE_URL = originalEnv;
 		}
-		// Why not: NODE_ENV を直接代入すると Node の型制約で TypeError になるため vi.unstubAllEnvs で復元する。
-		vi.unstubAllEnvs();
 	});
 
-	describe("NEXT_PUBLIC_SITE_URL 優先", () => {
-		it("環境変数が設定されていればそれを返す", async () => {
-			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com";
-			mockHeaders.mockResolvedValue(createHeaderMap({}));
+	it("NEXT_PUBLIC_SITE_URL が設定されていればそれを origin として返す（env 名の注入確認）", async () => {
+		process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com";
+		mockHeaders.mockResolvedValue(createHeaderMap({}));
 
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://beersalon.com");
-		});
-
-		it("環境変数の末尾スラッシュは除去される", async () => {
-			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com/";
-			mockHeaders.mockResolvedValue(createHeaderMap({}));
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://beersalon.com");
-		});
-
-		it("環境変数にパスが含まれていても origin に正規化される", async () => {
-			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com/some/path";
-			mockHeaders.mockResolvedValue(createHeaderMap({}));
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://beersalon.com");
-		});
-
-		it("環境変数に不正値が入っていれば warn を出してヘッダー解決にフォールバックする", async () => {
-			process.env.NEXT_PUBLIC_SITE_URL = "not-a-url";
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "example.com",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
-			);
-			expect(url).toBe("https://example.com");
-
-			warnSpy.mockRestore();
-		});
+		expect(await getSiteUrl()).toBe("https://beersalon.com");
 	});
 
-	describe("x-forwarded-host / x-forwarded-proto によるフォールバック", () => {
-		it("x-forwarded-host と x-forwarded-proto が揃っていればそれを組み立てる", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					"x-forwarded-host": "example.vercel.app",
-					"x-forwarded-proto": "https",
-				}),
-			);
+	it("env 未設定時は next/headers のヘッダーから組み立てる（ヘッダー取得の委譲確認）", async () => {
+		mockHeaders.mockResolvedValue(
+			createHeaderMap({ host: "example.vercel.app" }),
+		);
 
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://example.vercel.app");
-		});
-
-		it("x-forwarded-host のみ（proto なし）で非localhost なら https を補完する", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					"x-forwarded-host": "example.vercel.app",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://example.vercel.app");
-		});
-
-		it("x-forwarded-host のみで host が localhost なら http スキームを使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					"x-forwarded-host": "localhost:3000",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("http://localhost:3000");
-		});
+		expect(await getSiteUrl()).toBe("https://example.vercel.app");
 	});
 
-	describe("host ヘッダーへのフォールバック", () => {
-		it("host: localhost:3000 のみで http スキームを使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "localhost:3000",
-				}),
-			);
+	it("ヘッダーが何も無ければ web 固有のフォールバック http://localhost:3000 を返す", async () => {
+		mockHeaders.mockResolvedValue(createHeaderMap({}));
 
-			const url = await getSiteUrl();
-
-			expect(url).toBe("http://localhost:3000");
-		});
-
-		it("host: example.com のみなら https スキームを使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "example.com",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://example.com");
-		});
-
-		it("host: localhost.evil.com は localhost と誤判定せず https を使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "localhost.evil.com",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://localhost.evil.com");
-		});
-
-		it("host: 127.0.0.1.evil.com も localhost と誤判定せず https を使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "127.0.0.1.evil.com",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("https://127.0.0.1.evil.com");
-		});
-
-		it("host: [::1] は IPv6 loopback として http スキームを使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "[::1]",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("http://[::1]");
-		});
-
-		it("host: [::1]:3000 も IPv6 loopback として http スキームを使う", async () => {
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "[::1]:3000",
-				}),
-			);
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("http://[::1]:3000");
-		});
-	});
-
-	describe("デフォルトフォールバック", () => {
-		it("ヘッダーが何も無ければ http://localhost:3000 を返す", async () => {
-			mockHeaders.mockResolvedValue(createHeaderMap({}));
-
-			const url = await getSiteUrl();
-
-			expect(url).toBe("http://localhost:3000");
-		});
-	});
-
-	describe("production での warn", () => {
-		it("NODE_ENV=production かつ NEXT_PUBLIC_SITE_URL 未設定なら warn を出す", async () => {
-			vi.stubEnv("NODE_ENV", "production");
-			process.env.NEXT_PUBLIC_SITE_URL = "";
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "example.com",
-				}),
-			);
-
-			await getSiteUrl();
-
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
-			);
-
-			warnSpy.mockRestore();
-		});
-
-		it("NODE_ENV=production でも NEXT_PUBLIC_SITE_URL が設定されていれば warn を出さない", async () => {
-			vi.stubEnv("NODE_ENV", "production");
-			process.env.NEXT_PUBLIC_SITE_URL = "https://beersalon.com";
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			mockHeaders.mockResolvedValue(createHeaderMap({}));
-
-			await getSiteUrl();
-
-			expect(warnSpy).not.toHaveBeenCalled();
-
-			warnSpy.mockRestore();
-		});
-
-		it("NODE_ENV=development では env 未設定でも warn を出さない", async () => {
-			vi.stubEnv("NODE_ENV", "development");
-			process.env.NEXT_PUBLIC_SITE_URL = "";
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			mockHeaders.mockResolvedValue(
-				createHeaderMap({
-					host: "localhost:3000",
-				}),
-			);
-
-			await getSiteUrl();
-
-			expect(warnSpy).not.toHaveBeenCalled();
-
-			warnSpy.mockRestore();
-		});
+		expect(await getSiteUrl()).toBe("http://localhost:3000");
 	});
 });

--- a/apps/web/src/lib/site-url.ts
+++ b/apps/web/src/lib/site-url.ts
@@ -1,25 +1,7 @@
+import { resolveOriginFromHeaders } from "@beersalon/shared";
 import { headers } from "next/headers";
 
 const DEFAULT_SITE_URL = "http://localhost:3000";
-
-const isLocalHost = (host: string): boolean => {
-	// Why not: startsWith だと `localhost.evil.com` のような偽装ホスト名を localhost と誤判定し、
-	// production で誤って http スキームを返す経路を作りうるため、ホスト部分のみ完全一致で判定する。
-	const hostname = host.split(":")[0];
-	if (hostname === "localhost" || hostname === "127.0.0.1") {
-		return true;
-	}
-	// Why not: IPv6 loopback (`[::1]` または `[::1]:3000`) を扱うため、`[::1]` から始まるかも許可する。
-	return host === "[::1]" || host.startsWith("[::1]:");
-};
-
-const normalizeEnvUrl = (envUrl: string): string | null => {
-	try {
-		return new URL(envUrl).origin;
-	} catch {
-		return null;
-	}
-};
 
 /**
  * 認証メール（新規登録確認・パスワード再設定）の `emailRedirectTo` / `redirectTo` に
@@ -30,46 +12,16 @@ const normalizeEnvUrl = (envUrl: string): string | null => {
  * キャッシュは行わない。リクエスト内で複数回呼んでも問題ないが、頻繁に呼ぶ場合は
  * 呼び出し元でローカル変数に保持してよい。
  *
- * 解決順序:
- * 1. `NEXT_PUBLIC_SITE_URL`（最優先。`new URL().origin` で正規化する。不正値は無視）
- * 2. `x-forwarded-host` + `x-forwarded-proto`（Vercel など信頼できる reverse proxy 経由時）
- * 3. `host` ヘッダー（localhost は http、それ以外は https を補完）
- * 4. `http://localhost:3000`（デフォルトフォールバック）
- *
- * production 環境で `NEXT_PUBLIC_SITE_URL` が未設定の場合、`x-forwarded-host` 由来の
- * Host Header Injection 攻撃に対する耐性が信頼できる reverse proxy に依存するため、
- * production では `NEXT_PUBLIC_SITE_URL` を必ず設定すること（未設定時は warn を出す）。
+ * 解決順序・Host Header Injection 対策は shared の `resolveOriginFromHeaders` に一本化。
+ * このラッパーは `next/headers` からのヘッダー取得と、web 固有の env 名 / フォールバック値の
+ * 注入だけを担う。
  */
 export async function getSiteUrl(): Promise<string> {
-	const envUrl = process.env.NEXT_PUBLIC_SITE_URL;
-	if (envUrl && envUrl.length > 0) {
-		const normalized = normalizeEnvUrl(envUrl);
-		if (normalized !== null) {
-			return normalized;
-		}
-		console.warn(
-			`[site-url] NEXT_PUBLIC_SITE_URL の値 "${envUrl}" が不正なURLのため無視します。スキーム (http(s)://) 付きのオリジンを設定してください。`,
-		);
-	}
-
-	if (process.env.NODE_ENV === "production") {
-		console.warn(
-			"[site-url] production では NEXT_PUBLIC_SITE_URL の設定を推奨します（x-forwarded-host 由来の Host Header Injection を防ぐため）。",
-		);
-	}
-
-	// Why not: 環境変数で固定値を持たせず動的解決にしているのは、Vercel のプレビュー環境ごとに
-	// ドメインが変わるため。`NEXT_PUBLIC_SITE_URL` 未設定時はリクエストヘッダーから組み立てる。
 	const headerList = await headers();
-	const forwardedHost = headerList.get("x-forwarded-host");
-	const forwardedProto = headerList.get("x-forwarded-proto");
-	const host = forwardedHost ?? headerList.get("host");
-
-	if (!host) {
-		return DEFAULT_SITE_URL;
-	}
-
-	const protocol = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
-
-	return `${protocol}://${host}`;
+	return resolveOriginFromHeaders((name) => headerList.get(name), {
+		envUrl: process.env.NEXT_PUBLIC_SITE_URL,
+		fallback: DEFAULT_SITE_URL,
+		warnLabel: "site-url",
+		envVarName: "NEXT_PUBLIC_SITE_URL",
+	});
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,9 @@
 export { logRequest } from "./middleware-logger";
 export {
+	resolveOriginFromHeaders,
+	type ResolveOriginOptions,
+} from "./request-origin";
+export {
 	SHIZUOKA_PREFECTURE,
 	SHIZUOKA_CITIES,
 	SHIZUOKA_TOWNS,

--- a/packages/shared/src/request-origin.test.ts
+++ b/packages/shared/src/request-origin.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type ResolveOriginOptions,
+	resolveOriginFromHeaders,
+} from "./request-origin";
+
+// ヘッダー取得コールバックを、キーは小文字で引くマップから生成する。
+const createGetHeader =
+	(entries: Record<string, string>) =>
+	(name: string): string | null =>
+		entries[name.toLowerCase()] ?? null;
+
+// web 相当（fallback = デフォルトURL文字列）
+const webOptions = (
+	envUrl: string | null | undefined,
+): ResolveOriginOptions<string> => ({
+	envUrl,
+	fallback: "http://localhost:3000",
+	warnLabel: "site-url",
+	envVarName: "NEXT_PUBLIC_SITE_URL",
+});
+
+// admin 相当（fallback = null）
+const adminOptions = (
+	envUrl: string | null | undefined,
+): ResolveOriginOptions<null> => ({
+	envUrl,
+	fallback: null,
+	warnLabel: "request-origin",
+	envVarName: "ADMIN_BASE_URL / NEXT_PUBLIC_APP_URL",
+});
+
+describe("resolveOriginFromHeaders", () => {
+	afterEach(() => {
+		// Why not: NODE_ENV を直接代入すると Node の型制約で TypeError になるため vi.unstubAllEnvs で復元する。
+		vi.unstubAllEnvs();
+	});
+
+	describe("env 最優先", () => {
+		it("env が設定されていれば origin に正規化して返す（ヘッダーより優先）", () => {
+			const url = resolveOriginFromHeaders(
+				createGetHeader({ host: "example.com" }),
+				webOptions("https://beersalon.com"),
+			);
+			expect(url).toBe("https://beersalon.com");
+		});
+
+		it("env の末尾スラッシュ・パスは origin に正規化される", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({}),
+					webOptions("https://beersalon.com/"),
+				),
+			).toBe("https://beersalon.com");
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({}),
+					webOptions("https://beersalon.com/some/path"),
+				),
+			).toBe("https://beersalon.com");
+		});
+
+		it("env が偽装 x-forwarded-host より優先される（Host Header Injection 対策）", () => {
+			const url = resolveOriginFromHeaders(
+				createGetHeader({
+					"x-forwarded-host": "evil.example.com",
+					"x-forwarded-proto": "https",
+				}),
+				adminOptions("https://admin.example.com"),
+			);
+			expect(url).toBe("https://admin.example.com");
+		});
+
+		it("env が不正なURLなら warn を出してヘッダー解決にフォールバックする", () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const url = resolveOriginFromHeaders(
+				createGetHeader({ host: "example.com" }),
+				webOptions("not-a-url"),
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
+			);
+			expect(url).toBe("https://example.com");
+			warnSpy.mockRestore();
+		});
+	});
+
+	describe("x-forwarded-host / x-forwarded-proto によるフォールバック", () => {
+		it("x-forwarded-host + x-forwarded-proto が揃っていればそれを組み立てる", () => {
+			const url = resolveOriginFromHeaders(
+				createGetHeader({
+					"x-forwarded-host": "example.vercel.app",
+					"x-forwarded-proto": "https",
+				}),
+				webOptions(""),
+			);
+			expect(url).toBe("https://example.vercel.app");
+		});
+
+		it("x-forwarded-host のみ（proto なし）で非localhost なら https を補完する", () => {
+			const url = resolveOriginFromHeaders(
+				createGetHeader({ "x-forwarded-host": "example.vercel.app" }),
+				webOptions(""),
+			);
+			expect(url).toBe("https://example.vercel.app");
+		});
+
+		it("x-forwarded-host が localhost なら http スキームを使う", () => {
+			const url = resolveOriginFromHeaders(
+				createGetHeader({ "x-forwarded-host": "localhost:3000" }),
+				webOptions(""),
+			);
+			expect(url).toBe("http://localhost:3000");
+		});
+	});
+
+	describe("host ヘッダーへのフォールバック", () => {
+		it("host: localhost:3000 のみで http スキームを使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "localhost:3000" }),
+					webOptions(""),
+				),
+			).toBe("http://localhost:3000");
+		});
+
+		it("host: 127.0.0.1 は loopback として http スキームを使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "127.0.0.1:3001" }),
+					adminOptions(""),
+				),
+			).toBe("http://127.0.0.1:3001");
+		});
+
+		it("host: example.com のみなら https スキームを使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "example.com" }),
+					webOptions(""),
+				),
+			).toBe("https://example.com");
+		});
+
+		it("host: localhost.evil.com は localhost と誤判定せず https を使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "localhost.evil.com" }),
+					webOptions(""),
+				),
+			).toBe("https://localhost.evil.com");
+		});
+
+		it("host: 127.0.0.1.evil.com も localhost と誤判定せず https を使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "127.0.0.1.evil.com" }),
+					webOptions(""),
+				),
+			).toBe("https://127.0.0.1.evil.com");
+		});
+
+		it("host: [::1] は IPv6 loopback として http スキームを使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "[::1]" }),
+					webOptions(""),
+				),
+			).toBe("http://[::1]");
+		});
+
+		it("host: [::1]:3000 も IPv6 loopback として http スキームを使う", () => {
+			expect(
+				resolveOriginFromHeaders(
+					createGetHeader({ host: "[::1]:3000" }),
+					webOptions(""),
+				),
+			).toBe("http://[::1]:3000");
+		});
+	});
+
+	describe("fallback（host が無い場合）", () => {
+		it("web 相当: ヘッダーが何も無ければ fallback の URL 文字列を返す", () => {
+			expect(
+				resolveOriginFromHeaders(createGetHeader({}), webOptions("")),
+			).toBe("http://localhost:3000");
+		});
+
+		it("admin 相当: ヘッダーが何も無ければ fallback の null を返す", () => {
+			expect(
+				resolveOriginFromHeaders(createGetHeader({}), adminOptions("")),
+			).toBeNull();
+		});
+	});
+
+	describe("production での warn", () => {
+		it("NODE_ENV=production かつ env 未設定なら warn を出す", () => {
+			vi.stubEnv("NODE_ENV", "production");
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			resolveOriginFromHeaders(
+				createGetHeader({ host: "example.com" }),
+				webOptions(""),
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("NEXT_PUBLIC_SITE_URL"),
+			);
+			warnSpy.mockRestore();
+		});
+
+		it("NODE_ENV=production でも env が設定されていれば warn を出さない", () => {
+			vi.stubEnv("NODE_ENV", "production");
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			resolveOriginFromHeaders(
+				createGetHeader({}),
+				webOptions("https://beersalon.com"),
+			);
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it("NODE_ENV=development では env 未設定でも warn を出さない", () => {
+			vi.stubEnv("NODE_ENV", "development");
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			resolveOriginFromHeaders(
+				createGetHeader({ host: "localhost:3000" }),
+				webOptions(""),
+			);
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+	});
+});

--- a/packages/shared/src/request-origin.ts
+++ b/packages/shared/src/request-origin.ts
@@ -1,0 +1,93 @@
+/**
+ * リクエストからオリジン（origin）を動的に解決するコアロジック。
+ *
+ * web（認証メールのコールバックURL）と admin（Stripe の戻り先URL）で二重実装されていた
+ * オリジン解決を一本化する。両アプリでヘッダー取得手段が異なる（web は `next/headers` の
+ * async な `headers()`、admin は `NextRequest` 引数）ため、この関数は `next` に依存せず
+ * `getHeader: (name) => string | null` コールバックだけを受け取る純粋関数とする
+ * （`middleware-logger.ts` の `RequestLike` 方式に倣い、shared を framework 非依存に保つ）。
+ *
+ * 解決順序:
+ * 1. env（最優先。`new URL().origin` で正規化する。不正値は warn を出して無視）
+ * 2. `x-forwarded-host` + `x-forwarded-proto`（Vercel など信頼できる reverse proxy 経由時）
+ * 3. `host` ヘッダー（localhost は http、それ以外は https を補完）
+ * 4. host が無ければ `options.fallback`（web は既定URL、admin は null）
+ *
+ * production 環境で env が未設定の場合、`x-forwarded-host` 由来の Host Header Injection
+ * 攻撃に対する耐性が信頼できる reverse proxy に依存するため、production では env を必ず
+ * 設定すること（未設定時は warn を出す）。
+ */
+
+const isLocalHost = (host: string): boolean => {
+	// Why not startsWith: `localhost.evil.com` のような偽装ホスト名を localhost と誤判定し、
+	//   production で誤って http スキームを返す経路を作りうるため、ホスト部分のみ完全一致で判定する。
+	const hostname = host.split(":")[0];
+	if (hostname === "localhost" || hostname === "127.0.0.1") {
+		return true;
+	}
+	// Why not: IPv6 loopback (`[::1]` または `[::1]:3000`) を扱うため、`[::1]` から始まるかも許可する。
+	return host === "[::1]" || host.startsWith("[::1]:");
+};
+
+const normalizeEnvUrl = (envUrl: string): string | null => {
+	try {
+		return new URL(envUrl).origin;
+	} catch {
+		return null;
+	}
+};
+
+export interface ResolveOriginOptions<TFallback extends string | null> {
+	/** env 最優先値。web は `NEXT_PUBLIC_SITE_URL`、admin は `ADMIN_BASE_URL ?? NEXT_PUBLIC_APP_URL`。 */
+	envUrl: string | null | undefined;
+	/** host が解決できないときの返り値。web は既定URL文字列、admin は null。 */
+	fallback: TFallback;
+	/** warn メッセージ先頭のラベル（例: "site-url" / "request-origin"）。 */
+	warnLabel: string;
+	/** env 変数名（warn メッセージ用。例: "NEXT_PUBLIC_SITE_URL"）。 */
+	envVarName: string;
+}
+
+/**
+ * ヘッダー取得コールバックと options から origin を解決する。
+ *
+ * @param getHeader ヘッダー名（小文字）を受け取り値を返す関数。存在しなければ null。
+ * @param options env値・fallback・warnラベルなど web/admin の差分を注入する。
+ * @returns 解決した origin 文字列。host が無い場合は `options.fallback`。
+ */
+export function resolveOriginFromHeaders<TFallback extends string | null>(
+	getHeader: (name: string) => string | null,
+	options: ResolveOriginOptions<TFallback>,
+): string | TFallback {
+	const { envUrl, fallback, warnLabel, envVarName } = options;
+
+	if (envUrl && envUrl.length > 0) {
+		const normalized = normalizeEnvUrl(envUrl);
+		if (normalized !== null) {
+			return normalized;
+		}
+		console.warn(
+			`[${warnLabel}] ${envVarName} の値 "${envUrl}" が不正なURLのため無視します。スキーム (http(s)://) 付きのオリジンを設定してください。`,
+		);
+	}
+
+	if (process.env.NODE_ENV === "production") {
+		console.warn(
+			`[${warnLabel}] production では ${envVarName} の設定を推奨します（x-forwarded-host 由来の Host Header Injection を防ぐため）。`,
+		);
+	}
+
+	// Why not: 環境変数で固定値を持たせず動的解決にしているのは、Vercel のプレビュー環境ごとに
+	// ドメインが変わるため。env 未設定時はリクエストヘッダーから組み立てる。
+	const forwardedHost = getHeader("x-forwarded-host");
+	const host = forwardedHost ?? getHeader("host");
+
+	if (!host) {
+		return fallback;
+	}
+
+	const forwardedProto = getHeader("x-forwarded-proto");
+	const protocol = forwardedProto ?? (isLocalHost(host) ? "http" : "https");
+
+	return `${protocol}://${host}`;
+}


### PR DESCRIPTION
## 概要

「Vercel プレビューでドメインが変わるためリクエストからオリジンを動的解決する」ロジックが web (`getSiteUrl`) と admin (`resolveRequestOrigin`) に二重実装されていた問題を解消し、`packages/shared` に一本化する。

## 対応内容

- `packages/shared/src/request-origin.ts` に純粋関数 `resolveOriginFromHeaders(getHeader, options)` を新設。`isLocalHost` / `normalizeEnvUrl` / 優先順位(env→forwarded-host→host→fallback) を集約。
- web/admin の差分（env 名・no-host フォールバック値・warn ラベル）は `options` で注入し吸収。
- shared は `next` 非依存を維持（`middleware-logger.ts` の `RequestLike` 方式に倣い `getHeader: (name) => string | null` を受ける）。
- `apps/web/src/lib/site-url.ts` / `apps/admin/src/lib/request-origin.ts` は、それぞれ `next/headers` / `NextRequest` からヘッダーを取ってコアへ委譲する薄いラッパーへ縮小（公開シグネチャは不変）。

## 受入条件

- [x] オリジン解決のコアロジックが `packages/shared` に一本化
- [x] web の認証メールリダイレクトと admin の Stripe 戻り先URLが同一コアを使用
- [x] Host Header Injection 対策（env最優先・localhost偽装弾き）が両アプリで担保
- [x] 既存の web site-url UT / admin request-origin UT が新構成でも green

## テスト

- shared コア UT を新設（env最優先・偽装ホスト弾き `localhost.evil.com`/`127.0.0.1.evil.com`・IPv6 loopback・env正規化・no-host時のfallback注入・production warn）: 19 tests green
- web `getSiteUrl` / admin `resolveRequestOrigin` UT を委譲確認へ縮退: それぞれ green
- `pnpm test` 全 green（web 514 tests ほか）

## 破壊的変更

なし。両ラッパーの公開シグネチャ（`getSiteUrl(): Promise<string>` / `resolveRequestOrigin(request): string | null`）と解決結果を維持。呼び出し元は無変更。

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Erc1Wz3mUwi36uNDNbPbbc