### PR TITLE
fix: #559 日時編集フォームのUTC表示による9時間ずれを修正

### DIFF
--- a/apps/admin/src/app/bars/[barId]/articles/[articleId]/edit/ArticleEditForm.tsx
+++ b/apps/admin/src/app/bars/[barId]/articles/[articleId]/edit/ArticleEditForm.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toDateTimeLocalValue } from "@/lib/datetime-local";
 import type { ArticleStatus } from "@/lib/validators";
 import type { Article } from "@/types/database";
 import ArticleStatusField from "../../ArticleStatusField";
@@ -51,9 +52,7 @@ export default function ArticleEditForm({
 			setStatus(article.status);
 			setOriginalPublishedAt(article.published_at);
 			if (article.published_at) {
-				setPublishedAt(
-					new Date(article.published_at).toISOString().slice(0, 16),
-				);
+				setPublishedAt(toDateTimeLocalValue(article.published_at));
 			}
 
 			const existingImages: ImageSlot[] = [];

--- a/apps/admin/src/components/EventForm.tsx
+++ b/apps/admin/src/components/EventForm.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toDateTimeLocalValue } from "@/lib/datetime-local";
 import type { BarEvent } from "@/types/database";
 
 interface EventFormProps {
@@ -48,12 +49,8 @@ export default function EventForm({ barId, eventId }: EventFormProps) {
 				setFormData({
 					title: event.title,
 					description: event.description || "",
-					start_date: event.start_date
-						? new Date(event.start_date).toISOString().slice(0, 16)
-						: "",
-					end_date: event.end_date
-						? new Date(event.end_date).toISOString().slice(0, 16)
-						: "",
+					start_date: toDateTimeLocalValue(event.start_date),
+					end_date: toDateTimeLocalValue(event.end_date),
 					is_active: event.is_active,
 				});
 

--- a/apps/admin/src/lib/datetime-local.test.ts
+++ b/apps/admin/src/lib/datetime-local.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { toDateTimeLocalValue } from "./datetime-local";
+
+// vitest.config.ts で TZ=Asia/Tokyo を固定しているため、ローカル時刻は JST（UTC+9）として評価される。
+// 実行環境の TZ に依存すると「ローカルでは通るが CI で落ちる」テストになるため、TZ は必ず固定する。
+describe("toDateTimeLocalValue", () => {
+	it("UTC の日時をローカル時刻（JST）の datetime-local 値へ変換する", () => {
+		// 09:00 UTC は 18:00 JST。datetime-local はローカル時刻として解釈されるため 18:00 を渡す必要がある。
+		expect(toDateTimeLocalValue("2026-09-01T09:00:00+00:00")).toBe(
+			"2026-09-01T18:00",
+		);
+	});
+
+	it("日付をまたぐ場合も正しく繰り上がる", () => {
+		// 23:30 UTC は翌日 08:30 JST。
+		expect(toDateTimeLocalValue("2026-09-01T23:30:00+00:00")).toBe(
+			"2026-09-02T08:30",
+		);
+	});
+
+	it("月をまたぐ場合も正しく繰り上がる", () => {
+		// 2026-08-31 15:00 UTC は 2026-09-01 00:00 JST。
+		expect(toDateTimeLocalValue("2026-08-31T15:00:00+00:00")).toBe(
+			"2026-09-01T00:00",
+		);
+	});
+
+	it("月・日・時・分を2桁ゼロ埋めする", () => {
+		// 2026-01-04 20:05 UTC は 2026-01-05 05:05 JST。
+		expect(toDateTimeLocalValue("2026-01-04T20:05:00+00:00")).toBe(
+			"2026-01-05T05:05",
+		);
+	});
+
+	it("Date オブジェクトを受け取れる", () => {
+		expect(toDateTimeLocalValue(new Date("2026-09-01T09:00:00+00:00"))).toBe(
+			"2026-09-01T18:00",
+		);
+	});
+
+	it("null / undefined / 空文字は空文字を返す", () => {
+		expect(toDateTimeLocalValue(null)).toBe("");
+		expect(toDateTimeLocalValue(undefined)).toBe("");
+		expect(toDateTimeLocalValue("")).toBe("");
+	});
+
+	it("不正な日時文字列は空文字を返す", () => {
+		expect(toDateTimeLocalValue("not-a-date")).toBe("");
+	});
+
+	// #559 の回帰防止。
+	// 「フォームに表示 → 日時を触らず保存」で値が変化しないことが本修正の受入条件。
+	it("表示→保存の往復で日時が変化しない（9時間ずれの回帰防止）", () => {
+		const storedUtc = "2026-09-01T09:00:00.000Z";
+
+		// 編集フォームに表示する値
+		const formValue = toDateTimeLocalValue(storedUtc);
+		expect(formValue).toBe("2026-09-01T18:00");
+
+		// 日時を触らずそのまま保存した場合、送信側は new Date(formValue).toISOString() で UTC に戻す
+		const resaved = new Date(formValue).toISOString();
+
+		expect(resaved).toBe(storedUtc);
+	});
+
+	it("表示→保存を2回繰り返しても日時が累積でずれない", () => {
+		const storedUtc = "2026-09-01T09:00:00.000Z";
+
+		let current = storedUtc;
+		for (let i = 0; i < 2; i++) {
+			current = new Date(toDateTimeLocalValue(current)).toISOString();
+		}
+
+		expect(current).toBe(storedUtc);
+	});
+});

--- a/apps/admin/src/lib/datetime-local.ts
+++ b/apps/admin/src/lib/datetime-local.ts
@@ -1,0 +1,27 @@
+/**
+ * UTC の日時を `<input type="datetime-local">` に渡せる文字列（`YYYY-MM-DDTHH:mm`）へ変換する。
+ *
+ * Why not `toISOString().slice(0, 16)`:
+ * `toISOString()` は常に UTC を返すが、`datetime-local` は値をブラウザのローカル時刻として
+ * 解釈するため、そのまま渡すとUTCとローカルの時差だけずれた時刻が表示される。
+ * 保存時にローカル時刻としてUTCへ再変換されるため、編集のたびに時差分ずつ日時が巻き戻る。
+ */
+export function toDateTimeLocalValue(
+	value: Date | string | null | undefined,
+): string {
+	if (!value) {
+		return "";
+	}
+
+	const date = value instanceof Date ? value : new Date(value);
+
+	if (Number.isNaN(date.getTime())) {
+		return "";
+	}
+
+	const pad = (n: number) => String(n).padStart(2, "0");
+
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+		date.getDate(),
+	)}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
 		environment: "node",
 		globals: true,
 		exclude: ["node_modules", "tests", ".next", "**/*.integration.test.ts"],
+		// Why not 実行環境の TZ に任せるか: 日時のローカル変換を検証するテストがあるため、
+		// 開発者のマシン（JST）と CI（UTC）で結果が変わり CI だけ落ちる。
+		env: {
+			TZ: "Asia/Tokyo",
+		},
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
Closes #559

## 背景

管理画面の日時編集フォームで、**日時を触らずタイトルだけ編集して保存すると開始・終了日時が9時間巻き戻る**不具合があった。編集のたびに累積してずれるため、実害が大きい。

#554（E2E実施：イベント管理CRUD）の実施中に発見。

## 原因

編集フォームの初期値に `toISOString().slice(0, 16)` を使っていた。

`toISOString()` は必ず **UTC** を返すが、`<input type="datetime-local">` は値を**ブラウザのローカル時刻**として解釈する。そのため `09:00 UTC` がフォームに `"2026-09-01T09:00"` として入り、ユーザーには「09:00（JST）」と見える。この状態で保存すると送信側が「09:00 JST」→ `00:00 UTC` に変換するため、9時間巻き戻る。

## 変更内容

| ファイル | 変更 |
|---|---|
| `apps/admin/src/lib/datetime-local.ts` | **新規**。ローカル時刻の `YYYY-MM-DDTHH:mm` を生成する `toDateTimeLocalValue` |
| `apps/admin/src/lib/datetime-local.test.ts` | **新規**。UT 9ケース |
| `apps/admin/src/components/EventForm.tsx` | イベント編集の初期値を `toDateTimeLocalValue` に置換 |
| `.../articles/[articleId]/edit/ArticleEditForm.tsx` | 記事の予約公開日時の初期値を同様に置換 |
| `apps/admin/vitest.config.ts` | `TZ: "Asia/Tokyo"` を固定 |

送信側（ローカル時刻 → `toISOString()` でUTC保存）は**元から正しい**ため変更していない。新規作成フォームも初期値が空のため影響なし。

## テスト

UT 9ケースを追加。特に #559 の回帰防止として以下を検証している。

- **表示→保存の往復で日時が変化しない**（`09:00Z` → フォーム `18:00` → 保存 `09:00Z`）
- **2回繰り返しても累積でずれない**
- 日付・月をまたぐ繰り上がり、ゼロ埋め、null/不正値

`pnpm --filter admin test` → **35ファイル 295テスト すべてパス**。

### TZ固定について

日時のローカル変換はTZ依存のため、開発マシン（JST）では通るが**CI（UTC）でだけ落ちる**テストになりうる。これを避けるため `vitest.config.ts` で `TZ: "Asia/Tokyo"` を固定した。`TZ=UTC` を明示した実行でもパスすることを確認済み。

## E2Eでの検証について

本修正の受入条件（「日時を触らず保存しても値が変化しない」）は上記UTで往復を検証済み。マージ後に develop 環境で実操作による確認を行う予定。

## 影響範囲

- 管理画面のイベント編集・記事編集（予約公開）の**初期値表示のみ**
- DB・APIの変更なし。マイグレーション不要
- 既存の壊れたデータ（過去の編集でずれた日時）は**自動では直らない**ため、必要なら手動修正が要る

## 関連

- #560（ユーザー画面のイベント日時がUTC表示）は**別原因**（`toLocaleString` の `timeZone` 未指定）のため別PRで対応する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9coCFNKbfUFuayoe8E726