### PR TITLE
fix: #558 ユーザー詳細ページのフォロー数/フォロワー数の逆転を修正

### DIFF
--- a/apps/web/src/actions/user.integration.test.ts
+++ b/apps/web/src/actions/user.integration.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/supabase/server", () => ({
 	}),
 }));
 
-import { followUser, unfollowUser } from "@/actions/user";
+import { followUser, getCurrentUser, unfollowUser } from "@/actions/user";
 
 const prisma = new PrismaClient({
 	adapter: new PrismaPg(
@@ -95,5 +95,42 @@ describe("followUser / unfollowUser (Integration)", () => {
 			},
 		});
 		expect(relation).toBeNull();
+	});
+});
+
+// #558 の回帰防止。
+// schema.prisma の @relation 名が逆に割り当てられており、following に「フォロワー数」が、
+// followedBy に「フォロー数」が入っていた。カウントの取り違えはリレーション名を辿らないと
+// 気づけないため、実DBで「A が B をフォローした」状態を作って両者の数を突き合わせる。
+describe("フォロー数 / フォロワー数のカウント (Integration)", () => {
+	it("A が B をフォローしたとき、A はフォロー1・フォロワー0、B はフォロー0・フォロワー1になる", async () => {
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		await followUser(bob.userProfileId);
+
+		// フォローした側（A）
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		const aliceProfile = await getCurrentUser();
+
+		expect(aliceProfile?.followingCount).toBe(1);
+		expect(aliceProfile?.followersCount).toBe(0);
+
+		// フォローされた側（B）
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: bob.authUserId } },
+		});
+		const bobProfile = await getCurrentUser();
+
+		expect(bobProfile?.followingCount).toBe(0);
+		expect(bobProfile?.followersCount).toBe(1);
+
+		// 後片付け
+		mockGetUser.mockResolvedValueOnce({
+			data: { user: { id: alice.authUserId } },
+		});
+		await unfollowUser(bob.userProfileId);
 	});
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,8 +29,10 @@ model UserProfile {
   postLikes       PostLike[]
   posts           Post[]
   userCoupons     UserCoupon[]
-  following       UserFollowRelation[] @relation("Followee")
-  followedBy      UserFollowRelation[] @relation("Follower")
+  // following は「自分が follower 側の行」＝自分がフォローしている相手。
+  // followedBy は「自分が followee 側の行」＝自分をフォローしている相手。
+  following       UserFollowRelation[] @relation("Follower")
+  followedBy      UserFollowRelation[] @relation("Followee")
   viewHistories   ViewHistory[]
 
   @@map("user_profiles")


### PR DESCRIPTION
Closes #558

## 背景

ユーザー詳細ページ（`/users/[userId]`）で、フォロー数とフォロワー数が**入れ替わって表示**されていた。

「A が B をフォローしている」状態で B のページを開くと、正しくは「0フォロー / 1フォロワー」のところ **「1フォロー / 0フォロワー」** と表示される。

#550（E2E実施：フォロー→タイムライン→通知）の実施中に発見。

## 原因

`prisma/schema.prisma` の `UserProfile` 側で、`@relation` 名の割当が逆になっていた。

```prisma
// 修正前
following       UserFollowRelation[] @relation("Followee")   // ← 逆
followedBy      UserFollowRelation[] @relation("Follower")   // ← 逆
```

`UserFollowRelation` 側の定義（L358-359）を見ると、`"Followee"` は `followeeId` に紐づくリレーション、つまり**自分がフォローされている側**を指す。それが `following`（自分がフォローしている数）に割り当てられていたため、`_count` の値が入れ替わっていた。

### 一覧ページが正しく動いていた理由

`/users/[userId]/following`・`/followers` の各一覧ページは、リレーション名ではなく **FK を直接指定**して取得している（`user.ts` L75, L115 等）。

```ts
where: { followerId: userProfile.id }   // フォロー中一覧
where: { followeeId: userProfile.id }   // フォロワー一覧
```

そのため一覧は正しく、**カウントだけが食い違う**という分かりにくい状態になっていた。

## 変更内容

```prisma
// 修正後（意味を明示するコメントを追加）
following       UserFollowRelation[] @relation("Follower")
followedBy      UserFollowRelation[] @relation("Followee")
```

`apps/web/src/actions/user.ts` の代入側（L46-47, L212-213）は、リレーション名が正しくなったことで**意味が合うため変更していない**。

### なぜ user.ts 側の入れ替えにしなかったか

`user.ts` の代入を入れ替える案もあったが、それだと「`following` という名前なのにフォロワー数が入る」という**命名と実体の逆転が残る**ため、将来別の箇所で同じ誤用が起きうる。命名と実体を一致させる方針を採った。

## マイグレーションについて

**不要です。** `@relation` の名前は Prisma がリレーションを識別するための内部的な名前であり、DBのテーブル構造・カラム・外部キーには影響しません。実際に `user_follow_relations` テーブルの定義は一切変更していません。

なお生成物（`apps/web/src/generated/prisma`）は `.gitignore` 対象のためコミットに含まれませんが、CI の各ワークフロー（`ci.yml` / `e2e.yml`）で `prisma generate` が実行されるため反映されます。

## テスト

実DBに接続する統合テストを追加（`user.integration.test.ts`）。

「A が B をフォローする」関係を実際に作り、**両者のカウントを突き合わせて**検証している。

- A（フォローした側）→ フォロー **1** / フォロワー **0**
- B（フォローされた側）→ フォロー **0** / フォロワー **1**

カウントの取り違えはリレーション名を辿らないと気づけないため、片側だけでなく**両者を検証**する形にした。

### Red→Green の確認

スキーマを修正前の状態に戻すと、追加したテストが `expected +0 to be 1` で**失敗する**ことを確認済み。

### 実行結果

- `pnpm --filter web test` → **55ファイル 514テスト すべてパス**
- 統合テスト全体 → **11ファイル 49テスト すべてパス**（スキーマ変更による既存機能への影響が無いことを確認）

## E2Eでの検証について

受入条件（カウントが正しい・一覧の件数と一致する）は上記統合テストで実DBに接続して検証済み。マージ後に develop 環境で実表示の確認を行う予定。

## 影響範囲

- `_count.following` / `_count.followedBy` を使う箇所（`user.ts` の2関数）のみ
- 一覧ページはFK直指定のため**影響なし**（統合テストで確認済み）
- DBのデータ・構造への影響なし

## 関連

- #550 のE2E実施結果コメントに、発見時の状況を記録済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9coCFNKbfUFuayoe8E726