### PR TITLE
fix: #564 日時表示の timeZone 指定漏れによる UTC 環境でのずれを修正

### DIFF
--- a/apps/admin/src/app/bars/[barId]/articles/[articleId]/ArticleDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/articles/[articleId]/ArticleDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateTimeWithSecondsJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -69,18 +70,6 @@ export default function ArticleDetail({
 		}
 	};
 
-	const formatDate = (dateString: string) => {
-		const date = new Date(dateString);
-		return date.toLocaleString("ja-JP", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			second: "2-digit",
-		});
-	};
-
 	if (loading) {
 		return (
 			<div className="animate-pulse space-y-4">
@@ -131,10 +120,10 @@ export default function ArticleDetail({
 
 			<p className="text-sm text-gray-500">
 				{article.status === "scheduled" && article.published_at
-					? `公開予定: ${formatDate(article.published_at)}`
+					? `公開予定: ${formatDateTimeWithSecondsJst(article.published_at)}`
 					: article.published_at
-						? formatDate(article.published_at)
-						: formatDate(article.created_at)}
+						? formatDateTimeWithSecondsJst(article.published_at)
+						: formatDateTimeWithSecondsJst(article.created_at)}
 			</p>
 
 			{imageUrls.length > 0 && (

--- a/apps/admin/src/app/bars/[barId]/coupons/CouponList.tsx
+++ b/apps/admin/src/app/bars/[barId]/coupons/CouponList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateJst } from "@beersalon/shared";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import type { BarCoupon } from "@/types/database";
@@ -45,12 +46,8 @@ export default function CouponList({ barId, userRole }: CouponListProps) {
 
 	const formatPeriod = (coupon: BarCoupon) => {
 		if (!coupon.valid_from && !coupon.valid_until) return "期間なし";
-		const from = coupon.valid_from
-			? new Date(coupon.valid_from).toLocaleDateString("ja-JP")
-			: "";
-		const until = coupon.valid_until
-			? new Date(coupon.valid_until).toLocaleDateString("ja-JP")
-			: "";
+		const from = formatDateJst(coupon.valid_from);
+		const until = formatDateJst(coupon.valid_until);
 		if (from && until) return `${from} 〜 ${until}`;
 		if (from) return `${from} 〜`;
 		return `〜 ${until}`;

--- a/apps/admin/src/app/bars/[barId]/coupons/[couponId]/CouponDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/coupons/[couponId]/CouponDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateLongJst } from "@beersalon/shared";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -71,14 +72,6 @@ export default function CouponDetail({
 		return `${c.discount_value.toLocaleString()}円引き`;
 	};
 
-	const formatDate = (dateString: string) => {
-		return new Date(dateString).toLocaleDateString("ja-JP", {
-			year: "numeric",
-			month: "long",
-			day: "numeric",
-		});
-	};
-
 	if (loading) {
 		return (
 			<div className="animate-pulse space-y-4">
@@ -143,11 +136,11 @@ export default function CouponDetail({
 					<h3 className="text-sm font-medium text-gray-500 mb-1">有効期間</h3>
 					<p className="text-sm text-gray-900">
 						{coupon.valid_from && coupon.valid_until
-							? `${formatDate(coupon.valid_from)} 〜 ${formatDate(coupon.valid_until)}`
+							? `${formatDateLongJst(coupon.valid_from)} 〜 ${formatDateLongJst(coupon.valid_until)}`
 							: coupon.valid_from
-								? `${formatDate(coupon.valid_from)} 〜`
+								? `${formatDateLongJst(coupon.valid_from)} 〜`
 								: coupon.valid_until
-									? `〜 ${formatDate(coupon.valid_until)}`
+									? `〜 ${formatDateLongJst(coupon.valid_until)}`
 									: "期間なし"}
 					</p>
 				</div>

--- a/apps/admin/src/app/bars/[barId]/events/EventList.tsx
+++ b/apps/admin/src/app/bars/[barId]/events/EventList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateTimeLongJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
@@ -36,17 +37,6 @@ export default function EventList({ barId, userRole }: EventListProps) {
 	useEffect(() => {
 		fetchEvents();
 	}, [fetchEvents]);
-
-	const formatDate = (dateString: string) => {
-		const date = new Date(dateString);
-		return date.toLocaleDateString("ja-JP", {
-			year: "numeric",
-			month: "long",
-			day: "numeric",
-			hour: "2-digit",
-			minute: "2-digit",
-		});
-	};
 
 	if (loading) {
 		return (
@@ -124,11 +114,11 @@ export default function EventList({ barId, userRole }: EventListProps) {
 									{event.title}
 								</h3>
 								<p className="text-sm text-gray-600 mt-1">
-									{formatDate(event.start_date)}
+									{formatDateTimeLongJst(event.start_date)}
 								</p>
 								{event.end_date && (
 									<p className="text-xs text-gray-500">
-										〜 {formatDate(event.end_date)}
+										〜 {formatDateTimeLongJst(event.end_date)}
 									</p>
 								)}
 							</div>

--- a/apps/admin/src/app/bars/[barId]/events/[eventId]/EventDetail.tsx
+++ b/apps/admin/src/app/bars/[barId]/events/[eventId]/EventDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateTimeLongJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -65,16 +66,6 @@ export default function EventDetail({
 		}
 	};
 
-	const formatDate = (dateString: string) => {
-		return new Date(dateString).toLocaleString("ja-JP", {
-			year: "numeric",
-			month: "long",
-			day: "numeric",
-			hour: "2-digit",
-			minute: "2-digit",
-		});
-	};
-
 	if (loading) {
 		return (
 			<div className="animate-pulse space-y-4">
@@ -124,7 +115,7 @@ export default function EventDetail({
 				<div>
 					<h3 className="text-sm font-medium text-gray-500 mb-1">開始日時</h3>
 					<p className="text-sm text-gray-900">
-						{formatDate(event.start_date)}
+						{formatDateTimeLongJst(event.start_date)}
 					</p>
 				</div>
 
@@ -132,7 +123,7 @@ export default function EventDetail({
 					<div>
 						<h3 className="text-sm font-medium text-gray-500 mb-1">終了日時</h3>
 						<p className="text-sm text-gray-900">
-							{formatDate(event.end_date)}
+							{formatDateTimeLongJst(event.end_date)}
 						</p>
 					</div>
 				)}

--- a/apps/web/e2e/bar-detail-tabs.spec.ts
+++ b/apps/web/e2e/bar-detail-tabs.spec.ts
@@ -159,6 +159,51 @@ test.describe("店舗詳細ページ", () => {
 		});
 	});
 
+	test.describe("日時表示のタイムゾーン (#564)", () => {
+		// seed.e2e.sql が JST 08:00（= UTC 前日 23:00）固定のクーポン/イベントを投入する前提。
+		// timeZone 指定が漏れると、サーバー TZ が UTC の環境で日付が 2026/9/1 に巻き戻る。
+		// ローカル（JST）では両者が一致してしまうため、日付そのものを固定値で検証する。
+		test("クーポンの有効期間が JST の日付で表示される", async ({ page }) => {
+			await page.goto("/bars/100001");
+
+			const couponTab = page.getByRole("button", { name: "クーポン" });
+			await expect(couponTab).toBeVisible();
+			await couponTab.click();
+
+			const coupon = page
+				.locator("div")
+				.filter({ hasText: "E2E JST境界クーポン" })
+				.last();
+			await expect(coupon).toBeVisible();
+
+			await expect(coupon).toContainText("開始: 2026/9/2");
+			await expect(coupon).not.toContainText("開始: 2026/9/1");
+			await expect(coupon).toContainText("終了: 2026/12/2");
+		});
+
+		test("イベントの開始日時が JST の日付・時刻で表示される", async ({
+			page,
+		}) => {
+			await page.goto("/bars/100001");
+
+			const eventTab = page.getByRole("button", { name: "イベント" });
+			await expect(eventTab).toBeVisible();
+			await eventTab.click();
+
+			const event = page
+				.locator("div")
+				.filter({ hasText: "E2E JST境界イベント" })
+				.last();
+			await expect(event).toBeVisible();
+
+			// 日付が巻き戻らないこと、かつ時刻が9時間ずれない（23:00 にならない）こと。
+			await expect(event).toContainText("2026/09/02");
+			await expect(event).toContainText("08:00");
+			await expect(event).not.toContainText("2026/09/01");
+			await expect(event).not.toContainText("23:00");
+		});
+	});
+
 	test.describe("ヒーロースライダー (#485)", () => {
 		// seed.e2e.sql が bar 100002 に 動画1 + 画像2 のスライダーメディアを投入する前提。
 		// Why not: bar 100001 は admin の slider regression テスト (#318) が「slider 0枚から

--- a/apps/web/src/app/mypage/edit/page.tsx
+++ b/apps/web/src/app/mypage/edit/page.tsx
@@ -1,3 +1,4 @@
+import { formatDateLongJst } from "@beersalon/shared";
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/actions/user";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
@@ -52,11 +53,7 @@ export default async function ProfileEditPage() {
 								lastName: userProfile.lastName,
 								firstName: userProfile.firstName,
 								email: authUser.email || "",
-								birthday: userProfile.birthday.toLocaleDateString("ja-JP", {
-									year: "numeric",
-									month: "long",
-									day: "numeric",
-								}),
+								birthday: formatDateLongJst(userProfile.birthday),
 								gender: genderLabel,
 								prefecture: userProfile.prefecture,
 							}}

--- a/apps/web/src/app/signup/confirm/page.tsx
+++ b/apps/web/src/app/signup/confirm/page.tsx
@@ -1,3 +1,4 @@
+import { formatDateLongJst } from "@beersalon/shared";
 import { cookies } from "next/headers";
 import Image from "next/image";
 import { redirect } from "next/navigation";
@@ -81,11 +82,7 @@ export default async function ConfirmPage() {
 						<div className="border-b pb-3">
 							<p className="text-sm text-gray-500 mb-1">生年月日</p>
 							<p className="text-lg font-medium">
-								{new Date(profileData.birthday).toLocaleDateString("ja-JP", {
-									year: "numeric",
-									month: "long",
-									day: "numeric",
-								})}
+								{formatDateLongJst(profileData.birthday)}
 							</p>
 						</div>
 

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -1,3 +1,4 @@
+import { formatDateJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -148,7 +149,7 @@ export default async function UserDetailPage({ params }: UserDetailPageProps) {
 												{post.bar.name}
 											</Link>
 											<span className="text-muted-foreground tracking-wide">
-												{new Date(post.createdAt).toLocaleDateString("ja-JP")}
+												{formatDateJst(post.createdAt)}
 											</span>
 										</div>
 										<div className="flex justify-end">

--- a/apps/web/src/components/bar/tabs/articles-tab.test.tsx
+++ b/apps/web/src/components/bar/tabs/articles-tab.test.tsx
@@ -54,13 +54,11 @@ describe("ArticlesTab", () => {
 			).toBeInTheDocument();
 		});
 
-		it("投稿日が表示される", () => {
+		// Why not 期待値に toLocaleDateString を再利用しないか: 実装と期待値の両辺が
+		// 同時に変わる自己参照アサーションになり、TZ 指定漏れのようなバグを検出できないため。
+		it("投稿日が JST の日付で表示される", () => {
 			render(<ArticlesTab articles={[baseArticle]} />);
-			expect(
-				screen.getByText(
-					new Date(baseArticle.publishedAt).toLocaleDateString("ja-JP"),
-				),
-			).toBeInTheDocument();
+			expect(screen.getByText("2026/6/15")).toBeInTheDocument();
 		});
 
 		it("記事リンクが /articles/[articleId] を指す", () => {
@@ -89,11 +87,7 @@ describe("ArticlesTab", () => {
 		it("publishedAtがnullの場合は投稿日が表示されない", () => {
 			const article = { ...baseArticle, publishedAt: null };
 			render(<ArticlesTab articles={[article]} />);
-			expect(
-				screen.queryByText(
-					new Date("2026-06-15T10:00:00+09:00").toLocaleDateString("ja-JP"),
-				),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText("2026/6/15")).not.toBeInTheDocument();
 		});
 
 		it("複数記事が表示される", () => {

--- a/apps/web/src/components/bar/tabs/articles-tab.tsx
+++ b/apps/web/src/components/bar/tabs/articles-tab.tsx
@@ -1,3 +1,4 @@
+import { formatDateJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -48,7 +49,7 @@ export function ArticlesTab({ articles }: ArticlesTabProps) {
 					</p>
 					{article.publishedAt && (
 						<p className="text-xs text-gray-500">
-							{new Date(article.publishedAt).toLocaleDateString("ja-JP")}
+							{formatDateJst(article.publishedAt)}
 						</p>
 					)}
 				</Link>

--- a/apps/web/src/components/bar/tabs/coupons-tab.tsx
+++ b/apps/web/src/components/bar/tabs/coupons-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateJst } from "@beersalon/shared";
 import { useState } from "react";
 import { toast } from "sonner";
 import { obtainCoupon } from "@/actions/coupon";
@@ -109,16 +110,10 @@ export function CouponsTab({ coupons }: CouponsTabProps) {
 						{(coupon.validFrom || coupon.validUntil) && (
 							<div className="text-xs text-gray-500 border-t border-gray-200 pt-2">
 								{coupon.validFrom && (
-									<p>
-										開始:{" "}
-										{new Date(coupon.validFrom).toLocaleDateString("ja-JP")}
-									</p>
+									<p>開始: {formatDateJst(coupon.validFrom)}</p>
 								)}
 								{coupon.validUntil && (
-									<p>
-										終了:{" "}
-										{new Date(coupon.validUntil).toLocaleDateString("ja-JP")}
-									</p>
+									<p>終了: {formatDateJst(coupon.validUntil)}</p>
 								)}
 							</div>
 						)}

--- a/apps/web/src/components/bar/tabs/events-tab.tsx
+++ b/apps/web/src/components/bar/tabs/events-tab.tsx
@@ -1,3 +1,4 @@
+import { formatDateTimeJst } from "@beersalon/shared";
 import Image from "next/image";
 
 interface BarEvent {
@@ -11,20 +12,6 @@ interface BarEvent {
 
 interface EventsTabProps {
 	events: BarEvent[];
-}
-
-// Why not ロケール指定（ja-JP）だけに任せるか: ロケールは表記形式の指定であって
-// タイムゾーンの指定ではないため、timeZone 未指定だと実行環境の TZ が使われる。
-// サーバー（Vercel）は UTC のため、JST で登録した日時が9時間ずれて表示される。
-function formatEventDateTime(date: Date | string): string {
-	return new Date(date).toLocaleString("ja-JP", {
-		timeZone: "Asia/Tokyo",
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-		hour: "2-digit",
-		minute: "2-digit",
-	});
 }
 
 export function EventsTab({ events }: EventsTabProps) {
@@ -61,10 +48,8 @@ export function EventsTab({ events }: EventsTabProps) {
 							<p className="text-gray-700 mb-3">{event.description}</p>
 						)}
 						<div className="text-xs text-gray-500 border-t border-gray-200 pt-2">
-							<p>開始: {formatEventDateTime(event.startDate)}</p>
-							{event.endDate && (
-								<p>終了: {formatEventDateTime(event.endDate)}</p>
-							)}
+							<p>開始: {formatDateTimeJst(event.startDate)}</p>
+							{event.endDate && <p>終了: {formatDateTimeJst(event.endDate)}</p>}
 						</div>
 					</div>
 				</div>

--- a/apps/web/src/components/bar/tabs/posts-tab.tsx
+++ b/apps/web/src/components/bar/tabs/posts-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateJst } from "@beersalon/shared";
 import Image from "next/image";
 import Link from "next/link";
 import { LikeButton } from "@/components/post/like-button";
@@ -50,7 +51,7 @@ export function PostsTab({ posts, barId, barName }: PostsTabProps) {
 							{post.user.nickname}
 						</Link>
 						<span className="text-gray-500 text-sm ml-2">
-							{new Date(post.createdAt).toLocaleDateString("ja-JP")}
+							{formatDateJst(post.createdAt)}
 						</span>
 					</div>
 

--- a/apps/web/src/components/mypage/my-coupons-list.tsx
+++ b/apps/web/src/components/mypage/my-coupons-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateJst } from "@beersalon/shared";
 import { Ticket } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -148,7 +149,7 @@ export function MyCouponsList({ coupons }: MyCouponsListProps) {
 							{coupon.validUntil && (
 								<div className="text-sm text-subtext">
 									<span className="font-medium">有効期限：</span>
-									{new Date(coupon.validUntil).toLocaleDateString("ja-JP")}
+									{formatDateJst(coupon.validUntil)}
 								</div>
 							)}
 

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -130,11 +130,17 @@ describe("formatRelativeTime", () => {
 			expect(formatRelativeTime(target, now)).toBe("6日前");
 		});
 
+		// Why not 期待値に toLocaleDateString を再利用しないか: 実装と期待値の両辺が
+		// 同時に変わる自己参照アサーションになり、TZ 指定漏れのようなバグを検出できないため。
 		it("7日以上は日付表記を返す", () => {
 			const target = new Date("2026-07-10T12:00:00Z");
-			expect(formatRelativeTime(target, now)).toBe(
-				target.toLocaleDateString("ja-JP"),
-			);
+			expect(formatRelativeTime(target, now)).toBe("2026/7/10");
+		});
+
+		it("7日以上かつ JST 早朝のデータで日付が前日に巻き戻らない", () => {
+			// JST 2026-07-10 08:00（= UTC 07-09 23:00）。TZ 指定が漏れると 2026/7/9 になる。
+			const target = new Date("2026-07-10T08:00:00+09:00");
+			expect(formatRelativeTime(target, now)).toBe("2026/7/10");
 		});
 
 		it("ISO文字列を受け取れる", () => {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { formatDateJst } from "@beersalon/shared";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -34,5 +35,5 @@ export function formatRelativeTime(
 		return `${diffDay}日前`;
 	}
 
-	return target.toLocaleDateString("ja-JP");
+	return formatDateJst(target);
 }

--- a/database.md
+++ b/database.md
@@ -10,6 +10,15 @@
 - 画像は Supabase Storage に保存し、DB には `image_url` / `storage_path` などの文字列のみ保持する
 - タイムスタンプは `created_at`, `updated_at`（`timestamptz`）
 
+### 日時表示のタイムゾーン方針
+
+- `timestamptz` は UTC の「瞬間」を保持する。**表示は必ず日本時間（JST）に変換する**。
+- 画面で日時を整形するときは `@beersalon/shared` の JST フォーマッタ（`formatDateJst` / `formatDateLongJst` / `formatDateTimeJst` / `formatDateTimeLongJst` / `formatDateTimeWithSecondsJst`）を使う。`toLocaleDateString` / `toLocaleString` を直接呼ばない。
+  - `toLocaleDateString("ja-JP")` の第1引数は**ロケール（表記形式）であってタイムゾーンではない**。`timeZone` を省略すると実行環境の TZ が使われ、サーバー TZ が UTC の Vercel 上で日時が9時間巻き戻る。
+  - ローカル開発（Mac = JST）では再現せず、日付のみ表示する箇所は JST 00:00〜08:59 のデータでしか症状が出ないため見落としやすい（Issue #560 / #564）。
+- `birthday` のみ `date` 型。Prisma は UTC 深夜で返すが、JST 変換は +09:00 で同日内に収まるため日付はずれない。
+- 日時の TZ 検証テストは、実行環境の TZ に依存しない固定の期待値で書く。期待値に `toLocaleDateString` を再利用すると実装と両辺が同時に変わり、TZ 指定漏れを検出できない。
+
 ### Row-Level Security（RLS）方針
 
 - `public` スキーマの全テーブルで RLS を有効化し、既定は deny-by-default（ポリシー無し＝ `anon` / `authenticated` は全操作拒否）とする。ブラウザに露出する anon 公開鍵だけで機微データが読み書きされることを防ぐ。

--- a/packages/shared/src/format-date.test.ts
+++ b/packages/shared/src/format-date.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+	APP_TIME_ZONE,
+	formatDateJst,
+	formatDateLongJst,
+	formatDateTimeJst,
+	formatDateTimeLongJst,
+	formatDateTimeWithSecondsJst,
+} from "./format-date";
+
+/**
+ * このテストは実行環境の TZ を書き換えない。
+ *
+ * `process.env.TZ` の実行時書き換えは Node の Intl キャッシュが効いて不安定なうえ、
+ * フォーマッタが `timeZone` を明示指定している以上、TZ に依存しないことこそが検証対象になる。
+ * ローカル（JST）でも CI（UTC）でも同じ期待値で通ることが、この不具合が再発していない証拠になる。
+ */
+describe("JST フォーマッタ", () => {
+	// JST 08:00 = UTC 前日 23:00。timeZone 未指定だと日付が1日巻き戻る境界データ。
+	const jstEarlyMorning = "2026-09-02T08:00:00+09:00";
+
+	describe("formatDateJst", () => {
+		it("JST 08:00 のデータを前日に戻さず当日の日付で返す", () => {
+			expect(formatDateJst(jstEarlyMorning)).toBe("2026/9/2");
+		});
+
+		it("JST 00:00（日付の下側の境界）で日付が巻き戻らない", () => {
+			expect(formatDateJst("2026-09-02T00:00:00+09:00")).toBe("2026/9/2");
+		});
+
+		it("JST 08:59（UTC とずれる時間帯の上端）で日付が巻き戻らない", () => {
+			expect(formatDateJst("2026-09-02T08:59:59+09:00")).toBe("2026/9/2");
+		});
+
+		it("JST 09:00（UTC と日付が一致し始める時刻）で日付が変わらない", () => {
+			expect(formatDateJst("2026-09-02T09:00:00+09:00")).toBe("2026/9/2");
+		});
+
+		it("JST 23:59（日付の上側の境界）で翌日に進まない", () => {
+			expect(formatDateJst("2026-09-02T23:59:59+09:00")).toBe("2026/9/2");
+		});
+
+		it("UTC 表記で渡された同一時刻も JST の日付として解釈する", () => {
+			// UTC 2026-09-01T23:00:00Z は JST 2026-09-02T08:00:00 と同一の瞬間。
+			expect(formatDateJst("2026-09-01T23:00:00Z")).toBe("2026/9/2");
+		});
+
+		it("Date インスタンスを受け取れる", () => {
+			expect(formatDateJst(new Date(jstEarlyMorning))).toBe("2026/9/2");
+		});
+
+		it("エポックミリ秒を受け取れる", () => {
+			expect(formatDateJst(new Date(jstEarlyMorning).getTime())).toBe(
+				"2026/9/2",
+			);
+		});
+	});
+
+	describe("formatDateLongJst", () => {
+		it("JST 08:00 のデータを和文表記で当日として返す", () => {
+			expect(formatDateLongJst(jstEarlyMorning)).toBe("2026年9月2日");
+		});
+
+		it("@db.Date 由来の UTC 深夜値を同じ日付のまま返す", () => {
+			// Prisma は DATE 型を UTC 深夜（1996-05-20T00:00:00Z）で返す。
+			// JST 変換は +09:00 なので同日内に収まり、生年月日は前後しない。
+			expect(formatDateLongJst("1996-05-20T00:00:00Z")).toBe("1996年5月20日");
+		});
+	});
+
+	describe("formatDateTimeLongJst", () => {
+		it("JST 08:00 の時刻を9時間ずらさずに返す", () => {
+			const result = formatDateTimeLongJst(jstEarlyMorning);
+			expect(result).toContain("2026年9月2日");
+			expect(result).toContain("08:00");
+			expect(result).not.toContain("23:00");
+		});
+	});
+
+	describe("formatDateTimeJst", () => {
+		it("JST 08:00 の日付と時刻を桁揃えで返す", () => {
+			const result = formatDateTimeJst(jstEarlyMorning);
+			expect(result).toContain("2026/09/02");
+			expect(result).toContain("08:00");
+		});
+
+		it("JST 00:30 が前日 15:30 にならない", () => {
+			const result = formatDateTimeJst("2026-09-02T00:30:00+09:00");
+			expect(result).toContain("2026/09/02");
+			expect(result).toContain("00:30");
+			expect(result).not.toContain("09/01");
+		});
+	});
+
+	describe("formatDateTimeWithSecondsJst", () => {
+		it("秒まで含めて JST で返す", () => {
+			const result = formatDateTimeWithSecondsJst("2026-09-02T08:00:45+09:00");
+			expect(result).toContain("2026/09/02");
+			expect(result).toContain("08:00:45");
+		});
+	});
+
+	describe("異常系", () => {
+		const formatters = [
+			["formatDateJst", formatDateJst],
+			["formatDateLongJst", formatDateLongJst],
+			["formatDateTimeLongJst", formatDateTimeLongJst],
+			["formatDateTimeJst", formatDateTimeJst],
+			["formatDateTimeWithSecondsJst", formatDateTimeWithSecondsJst],
+		] as const;
+
+		for (const [name, formatter] of formatters) {
+			it(`${name} は null に対して既定の空文字を返す`, () => {
+				expect(formatter(null)).toBe("");
+			});
+
+			it(`${name} は undefined に対して既定の空文字を返す`, () => {
+				expect(formatter(undefined)).toBe("");
+			});
+
+			it(`${name} は空文字に対して既定の空文字を返す`, () => {
+				expect(formatter("")).toBe("");
+			});
+
+			it(`${name} は不正な日付文字列で例外を投げずフォールバックを返す`, () => {
+				expect(formatter("not-a-date", "未設定")).toBe("未設定");
+			});
+
+			it(`${name} は指定したフォールバック文字列を返す`, () => {
+				expect(formatter(null, "未設定")).toBe("未設定");
+			});
+		}
+	});
+
+	describe("APP_TIME_ZONE", () => {
+		it("Asia/Tokyo を指す", () => {
+			expect(APP_TIME_ZONE).toBe("Asia/Tokyo");
+		});
+	});
+});

--- a/packages/shared/src/format-date.ts
+++ b/packages/shared/src/format-date.ts
@@ -1,0 +1,128 @@
+/**
+ * 日時を日本時間（JST）で整形するフォーマッタ群。
+ *
+ * `toLocaleDateString("ja-JP")` の第1引数はロケール（表記形式）の指定であって
+ * タイムゾーンの指定ではない。`timeZone` を省略すると Intl は実行環境の TZ に
+ * フォールバックするため、サーバー TZ が UTC の環境（Vercel）では
+ * `Timestamptz` の値が9時間巻き戻って描画される。
+ *
+ * ローカル開発（Mac = JST）ではフォールバック先がたまたま正解になるため再現せず、
+ * 日付のみ表示する箇所は JST 00:00〜08:59 のデータでしか症状が出ないため
+ * 見落とされやすい。個別に `timeZone` を書き足す方式では今後追加する画面で
+ * 同じ漏れが再発するため、web / admin 双方からこのモジュールを参照する。
+ */
+
+/**
+ * Why not ユーザーのローカルタイムゾーンに追従させるか: 静岡県のバー向けサービスであり、
+ * 多タイムゾーン対応の要件が README・database.md のいずれにも存在しない。
+ * 将来ユーザー別 TZ が必要になった際の差し替え点をこの1箇所に絞る。
+ */
+export const APP_TIME_ZONE = "Asia/Tokyo";
+
+export type DateInput = Date | string | number;
+
+const toDate = (value: DateInput): Date =>
+	value instanceof Date ? value : new Date(value);
+
+const isValidDate = (date: Date): boolean => !Number.isNaN(date.getTime());
+
+const format = (
+	value: DateInput | null | undefined,
+	options: Intl.DateTimeFormatOptions,
+	fallback: string,
+): string => {
+	if (value === null || value === undefined || value === "") {
+		return fallback;
+	}
+
+	const date = toDate(value);
+	// Why not 不正な日付で例外を投げるか: 描画中の表示ロジックで throw すると
+	// 日付1件の不整合でページ全体が落ちるため、フォールバック文字列に丸める。
+	if (!isValidDate(date)) {
+		return fallback;
+	}
+
+	return new Intl.DateTimeFormat("ja-JP", {
+		timeZone: APP_TIME_ZONE,
+		...options,
+	}).format(date);
+};
+
+/** `2026/9/2` 形式。投稿日・クーポン有効期間などの短縮表記に使う。 */
+export function formatDateJst(
+	value: DateInput | null | undefined,
+	fallback = "",
+): string {
+	return format(
+		value,
+		{ year: "numeric", month: "numeric", day: "numeric" },
+		fallback,
+	);
+}
+
+/** `2026年9月2日` 形式。生年月日・クーポン有効期限などの読み下し表記に使う。 */
+export function formatDateLongJst(
+	value: DateInput | null | undefined,
+	fallback = "",
+): string {
+	return format(
+		value,
+		{ year: "numeric", month: "long", day: "numeric" },
+		fallback,
+	);
+}
+
+/** `2026年9月2日 8:00` 形式。イベント日時など日付と時刻を併記する箇所に使う。 */
+export function formatDateTimeLongJst(
+	value: DateInput | null | undefined,
+	fallback = "",
+): string {
+	return format(
+		value,
+		{
+			year: "numeric",
+			month: "long",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+		},
+		fallback,
+	);
+}
+
+/** `2026/09/02 08:00` 形式。管理画面の一覧・詳細で日時を桁揃えして並べる箇所に使う。 */
+export function formatDateTimeJst(
+	value: DateInput | null | undefined,
+	fallback = "",
+): string {
+	return format(
+		value,
+		{
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+		},
+		fallback,
+	);
+}
+
+/** `2026/09/02 08:00:00` 形式。秒まで必要な監査的な表示に使う。 */
+export function formatDateTimeWithSecondsJst(
+	value: DateInput | null | undefined,
+	fallback = "",
+): string {
+	return format(
+		value,
+		{
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+		},
+		fallback,
+	);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,12 @@
+export {
+	APP_TIME_ZONE,
+	type DateInput,
+	formatDateJst,
+	formatDateLongJst,
+	formatDateTimeJst,
+	formatDateTimeLongJst,
+	formatDateTimeWithSecondsJst,
+} from "./format-date";
 export { logRequest } from "./middleware-logger";
 export {
 	resolveOriginFromHeaders,

--- a/supabase/seed.e2e.sql
+++ b/supabase/seed.e2e.sql
@@ -141,6 +141,31 @@ SELECT setval(
   GREATEST((SELECT MAX(id) FROM articles), 100002001)
 );
 
+-- クーポン/イベント: JST 08:00（= UTC 前日 23:00）固定。
+-- timeZone 指定が漏れると UTC 環境で日付が1日巻き戻るため、TZ ずれを検出できる境界値として使う。
+-- CURRENT_TIMESTAMP を使わないのは、実行時刻によっては境界をまたがず検証にならないため。
+INSERT INTO bar_coupons (id, bar_id, title, description, discount_type, discount_value, valid_from, valid_until, is_active)
+VALUES
+  (100001101, 100001, 'E2E JST境界クーポン', 'JST早朝の日付表示検証用', 'fixed_amount', 500,
+   TIMESTAMPTZ '2026-09-02 08:00:00+09', TIMESTAMPTZ '2026-12-02 08:00:00+09', true)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval(
+  pg_get_serial_sequence('bar_coupons', 'id'),
+  GREATEST((SELECT MAX(id) FROM bar_coupons), 100001101)
+);
+
+INSERT INTO bar_events (id, bar_id, title, description, start_date, end_date, is_active)
+VALUES
+  (100001201, 100001, 'E2E JST境界イベント', 'JST早朝の日時表示検証用',
+   TIMESTAMPTZ '2026-09-02 08:00:00+09', TIMESTAMPTZ '2026-09-02 20:00:00+09', true)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval(
+  pg_get_serial_sequence('bar_events', 'id'),
+  GREATEST((SELECT MAX(id) FROM bar_events), 100001201)
+);
+
 -- 閲覧履歴: 100001 を 2ユーザー閲覧（=2）、100002 を 1ユーザー閲覧（混入しないこと）
 INSERT INTO view_histories (user_id, bar_id)
 VALUES


### PR DESCRIPTION
Closes #564

## 概要

`toLocaleDateString` / `toLocaleString` の第1引数 `"ja-JP"` は**ロケール（表記形式）の指定であってタイムゾーンの指定ではない**。`timeZone` を省略すると Intl は実行環境の TZ にフォールバックするため、サーバー TZ が UTC の Vercel 上で `Timestamptz` の値が9時間巻き戻って表示されていた。

ローカル開発（Mac = JST）ではフォールバック先がたまたま正解になるため再現しない。

## 修正方針

個別に `timeZone: "Asia/Tokyo"` を書き足すと今後追加する画面で同じ漏れが再発する（#560 が単独修正で終わったために本 Issue が起票された事実が、その再発を一度実証している）。

`packages/shared` に JST 固定フォーマッタを新設し、web / admin 双方の呼び出しを集約した。`request-origin` / `middleware-logger` と同じ共通化パターンに乗せている。

| 関数 | 出力例 | 用途 |
|---|---|---|
| `formatDateJst` | `2026/9/2` | 投稿日・クーポン有効期間 |
| `formatDateLongJst` | `2026年9月2日` | 生年月日・クーポン有効期限 |
| `formatDateTimeJst` | `2026/09/02 08:00` | イベント日時（ユーザー画面） |
| `formatDateTimeLongJst` | `2026年9月2日 08:00` | イベント日時（管理画面） |
| `formatDateTimeWithSecondsJst` | `2026/09/02 08:00:00` | 記事の日時（管理画面） |

## 対象箇所（計15箇所）

Issue 記載の13箇所に加え、**同一原因で漏れていた admin の2箇所**を含む。時刻まで表示するため9時間ずれており、ここだけ残すと横断棚卸しの目的を果たさないため同時修正した（スコープ拡大はユーザー承認済み）。

- `apps/admin/src/app/bars/[barId]/events/[eventId]/EventDetail.tsx`（Issue 未記載）
- `apps/admin/src/app/bars/[barId]/articles/[articleId]/ArticleDetail.tsx`（Issue 未記載）

あわせて #560 で `events-tab.tsx` に入れたローカル実装も共通フォーマッタへ寄せ、二重実装を解消した。

## 検証

### TZ=UTC（Vercel 相当）での Red-Green 実証

E2E 用 seed に **JST 08:00（= UTC 前日 23:00）固定**のクーポン/イベントを追加し、境界データで検証した。

| 状態 | 結果 |
|---|---|
| 修正前コード + `TZ=UTC` | ❌ `開始: 2026/9/1`（Issue の症状を再現） |
| 修正後コード + `TZ=UTC` | ✅ `開始: 2026/9/2` |
| 修正後コード + `TZ=Asia/Tokyo` | ✅ `開始: 2026/9/2` |

UT でも `format-date.ts` から `timeZone` 指定を一時的に外すと `TZ=UTC` で11件が失敗することを確認済み（テストが実際にバグを検出できることの証明）。

### 既存 UT の自己参照アサーション是正

`utils.test.ts:136` と `articles-tab.test.tsx:61,94` が期待値に `toLocaleDateString("ja-JP")` を再利用しており、**実装と期待値の両辺が同時に変わるため TZ 指定漏れを検出できない**状態だった。固定文字列へ是正した。

### テスト結果

- UT: **882件パス**（shared 70 / admin 295 / web 517）。`TZ=UTC` / `TZ=Asia/Tokyo` の両方で shared 70件パス
- E2E: **65件パス**（web 48 / admin 17）。新規2件を含む
- typecheck / lint: エラーなし

## 影響範囲

- **価格の3桁区切り**（`toLocaleString()` の数値用途9箇所）: 対象外。引数なし数値呼び出しで別物のため無傷
- **`birthday`（`@db.Date`）**: Prisma は UTC 深夜で返すが、JST 変換は +09:00 で同日内に収まるため日付はずれない
- **DB データ**: 影響なし（表示層のみの変更）
- **SSR/ハイドレーション**: TZ 固定によりサーバー・クライアント間の描画差が消え、副次的に改善

## スコープ外（別Issue化）

`notification-card.tsx` の `formatRelativeTime` は `utils.ts` と重複定義だが、集約すると7日超の表示が「30日前」→「2026/7/10」に変わる**表示仕様の変更**になる。日付フォーマッタを使っておらず TZ ずれは原理的に発生しないため、本 Issue の受入条件外として別Issue化する（ユーザー判断）。

## 設計ドキュメント

`database.md` に「日時表示のタイムゾーン方針」を追記。共通フォーマッタの使用義務と、自己参照アサーションを避ける旨を再発防止として明記した。

## 補足: admin E2E の既存データ依存

検証中、admin の `dashboard.spec.ts` 等3件が失敗したが、**develop 素の状態でも同一の失敗が再現**することを確認済み（本PRとは無関係）。原因は web E2E が共有DBに残したデータで指標の絶対数がずれるため。`supabase db reset` 後は17件すべてパスする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9coCFNKbfUFuayoe8E726