### PR TITLE
fix: #573 Stripe新API(dahlia)のcurrent_period/subscription参照ズレを是正

### DIFF
--- a/apps/admin/src/__tests__/stripe-webhook.test.ts
+++ b/apps/admin/src/__tests__/stripe-webhook.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// bar_subscriptions への insert / update / select を検証するため、テーブルごとに
-// チェーンのスパイを保持しておく。
+// bar_subscriptions / invoices への insert / update / select を検証するため、
+// テーブルごとにチェーンのスパイを保持しておく。
 const upsertSpy = vi.fn().mockResolvedValue({ data: null, error: null });
 const updateEqSpy = vi.fn().mockResolvedValue({ data: null, error: null });
 const updateSpy = vi.fn(() => ({ eq: updateEqSpy }));
 const maybeSingleSpy = vi.fn();
+const singleSpy = vi.fn();
+const invoiceInsertSpy = vi.fn().mockResolvedValue({ data: null, error: null });
 
 const mockSupabaseFrom = vi.fn();
 vi.mock("@/lib/supabase", () => ({
@@ -34,25 +36,66 @@ function createMockRequest(): Parameters<typeof POST>[0] {
 	} as unknown as Parameters<typeof POST>[0];
 }
 
-// bar_subscriptions テーブルへのアクセスを、select→maybeSingle / insert / update に
-// 振り分けるモックチェーンを組む。
-function setupBarSubscriptionsMock(existingSub: unknown) {
+// bar_subscriptions テーブルへのアクセスを、select→maybeSingle / upsert / update に
+// 振り分けるモックチェーンを組む。invoices テーブルへの insert / select→single も扱う。
+function setupBarSubscriptionsMock(
+	existingSub: unknown,
+	invoiceBarSub: unknown = { bar_id: 1, id: 10 },
+) {
 	maybeSingleSpy.mockResolvedValue({ data: existingSub });
+	singleSpy.mockResolvedValue({ data: invoiceBarSub });
 	mockSupabaseFrom.mockImplementation((table: string) => {
 		if (table === "bar_subscriptions") {
 			return {
 				select: vi.fn(() => ({
-					eq: vi.fn(() => ({ maybeSingle: maybeSingleSpy })),
+					eq: vi.fn(() => ({
+						maybeSingle: maybeSingleSpy,
+						single: singleSpy,
+					})),
 				})),
 				upsert: upsertSpy,
 				update: updateSpy,
+			};
+		}
+		if (table === "invoices") {
+			return {
+				insert: invoiceInsertSpy,
 			};
 		}
 		throw new Error(`Unexpected table: ${table}`);
 	});
 }
 
+// 新API形状（2026-05-27.dahlia）: current_period_* は items.data[0] 配下に存在し、
+// トップレベルには存在しない。
 function subscriptionCreatedEvent(metadata: Record<string, string> | null) {
+	return {
+		type: "customer.subscription.created",
+		data: {
+			object: {
+				id: "sub_test123",
+				customer: "cus_test123",
+				status: "active",
+				cancel_at_period_end: false,
+				canceled_at: null,
+				metadata,
+				items: {
+					data: [
+						{
+							current_period_start: 1_700_000_000,
+							current_period_end: 1_702_592_000,
+						},
+					],
+				},
+			},
+		},
+	};
+}
+
+// 旧API形状: current_period_* がトップレベルに存在し、items 配下は無い。
+function legacySubscriptionCreatedEvent(
+	metadata: Record<string, string> | null,
+) {
 	return {
 		type: "customer.subscription.created",
 		data: {
@@ -70,6 +113,26 @@ function subscriptionCreatedEvent(metadata: Record<string, string> | null) {
 	};
 }
 
+// current_period_* がトップレベルにも items 配下にも存在しない不正形状。
+function noPeriodSubscriptionCreatedEvent(
+	metadata: Record<string, string> | null,
+) {
+	return {
+		type: "customer.subscription.created",
+		data: {
+			object: {
+				id: "sub_test123",
+				customer: "cus_test123",
+				status: "active",
+				cancel_at_period_end: false,
+				canceled_at: null,
+				metadata,
+				items: { data: [{}] },
+			},
+		},
+	};
+}
+
 describe("POST /api/webhooks/stripe（customer.subscription.created）", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -77,6 +140,7 @@ describe("POST /api/webhooks/stripe（customer.subscription.created）", () => {
 		// clearAllMocks で実装が消えるため upsert の既定戻り値（成功）を毎回設定し直す。
 		upsertSpy.mockResolvedValue({ data: null, error: null });
 		updateEqSpy.mockResolvedValue({ data: null, error: null });
+		invoiceInsertSpy.mockResolvedValue({ data: null, error: null });
 	});
 
 	it("署名が無い場合は400を返す", async () => {
@@ -100,7 +164,7 @@ describe("POST /api/webhooks/stripe（customer.subscription.created）", () => {
 		consoleSpy.mockRestore();
 	});
 
-	it("既存行が無く metadata がある場合は stripe_subscription_id を onConflict に upsert する", async () => {
+	it("新API形状（current_period_* が items.data[0] 配下）で期間付き upsert が成立する", async () => {
 		setupBarSubscriptionsMock(null);
 		mockConstructEvent.mockReturnValue(
 			subscriptionCreatedEvent({
@@ -128,6 +192,49 @@ describe("POST /api/webhooks/stripe（customer.subscription.created）", () => {
 			{ onConflict: "stripe_subscription_id" },
 		);
 		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("旧API形状（current_period_* がトップレベル）でも互換フォールバックで upsert が成立する", async () => {
+		setupBarSubscriptionsMock(null);
+		mockConstructEvent.mockReturnValue(
+			legacySubscriptionCreatedEvent({
+				bar_id: "100001",
+				subscription_plan_id: "42",
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(upsertSpy).toHaveBeenCalledTimes(1);
+		expect(upsertSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				current_period_start: new Date(1_700_000_000 * 1000).toISOString(),
+				current_period_end: new Date(1_702_592_000 * 1000).toISOString(),
+			}),
+			{ onConflict: "stripe_subscription_id" },
+		);
+	});
+
+	it("current_period_* が両形状とも取得できない場合は upsert をスキップし 200 で受理する", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		setupBarSubscriptionsMock(null);
+		mockConstructEvent.mockReturnValue(
+			noPeriodSubscriptionCreatedEvent({
+				bar_id: "100001",
+				subscription_plan_id: "42",
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(upsertSpy).not.toHaveBeenCalled();
+		expect(updateSpy).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("current_period_* を取得できません"),
+		);
+		warnSpy.mockRestore();
 	});
 
 	it("既存行がある場合は upsert せず update する", async () => {
@@ -205,5 +312,137 @@ describe("POST /api/webhooks/stripe（customer.subscription.created）", () => {
 
 		expect(response.status).toBe(500);
 		errorSpy.mockRestore();
+	});
+});
+
+describe("POST /api/webhooks/stripe（invoice イベントの subscription 取得）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+		invoiceInsertSpy.mockResolvedValue({ data: null, error: null });
+		updateEqSpy.mockResolvedValue({ data: null, error: null });
+	});
+
+	function invoicePaidEvent(object: Record<string, unknown>) {
+		return {
+			type: "invoice.paid",
+			data: { object },
+		};
+	}
+
+	it("新API形状（parent.subscription_details.subscription）から subscriptionId を取得し invoices に insert する", async () => {
+		setupBarSubscriptionsMock(null, { bar_id: 7, id: 55 });
+		mockConstructEvent.mockReturnValue(
+			invoicePaidEvent({
+				id: "in_test123",
+				amount_paid: 5000,
+				amount_due: 5000,
+				currency: "jpy",
+				invoice_pdf: "https://example.com/invoice.pdf",
+				status_transitions: { paid_at: 1_700_000_000 },
+				parent: {
+					subscription_details: { subscription: "sub_test123" },
+				},
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(invoiceInsertSpy).toHaveBeenCalledTimes(1);
+		expect(invoiceInsertSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				bar_id: 7,
+				bar_subscription_id: 55,
+				stripe_invoice_id: "in_test123",
+				status: "paid",
+			}),
+		);
+	});
+
+	it("parent.subscription_details.subscription が展開オブジェクトでも id を取り出す", async () => {
+		setupBarSubscriptionsMock(null, { bar_id: 7, id: 55 });
+		mockConstructEvent.mockReturnValue(
+			invoicePaidEvent({
+				id: "in_test123",
+				amount_paid: 5000,
+				amount_due: 5000,
+				currency: "jpy",
+				invoice_pdf: null,
+				status_transitions: { paid_at: null },
+				parent: {
+					subscription_details: { subscription: { id: "sub_test123" } },
+				},
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(singleSpy).toHaveBeenCalled();
+		expect(invoiceInsertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("旧API形状（トップレベル subscription）でもフォールバックで取得する", async () => {
+		setupBarSubscriptionsMock(null, { bar_id: 7, id: 55 });
+		mockConstructEvent.mockReturnValue(
+			invoicePaidEvent({
+				id: "in_test123",
+				subscription: "sub_test123",
+				amount_paid: 5000,
+				amount_due: 5000,
+				currency: "jpy",
+				invoice_pdf: null,
+				status_transitions: { paid_at: null },
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(invoiceInsertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("subscription をどこからも取得できない場合は invoices に insert しない", async () => {
+		setupBarSubscriptionsMock(null, { bar_id: 7, id: 55 });
+		mockConstructEvent.mockReturnValue(
+			invoicePaidEvent({
+				id: "in_test123",
+				amount_paid: 5000,
+				amount_due: 5000,
+				currency: "jpy",
+				invoice_pdf: null,
+				status_transitions: { paid_at: null },
+				parent: { subscription_details: null },
+			}),
+		);
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(invoiceInsertSpy).not.toHaveBeenCalled();
+	});
+
+	it("invoice.payment_failed で parent 配下の subscription から past_due 更新する", async () => {
+		setupBarSubscriptionsMock(null);
+		mockConstructEvent.mockReturnValue({
+			type: "invoice.payment_failed",
+			data: {
+				object: {
+					parent: {
+						subscription_details: { subscription: "sub_test123" },
+					},
+				},
+			},
+		});
+
+		const response = await POST(createMockRequest());
+
+		expect(response.status).toBe(200);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		expect(updateEqSpy).toHaveBeenCalledWith(
+			"stripe_subscription_id",
+			"sub_test123",
+		);
 	});
 });

--- a/apps/admin/src/app/api/webhooks/stripe/route.ts
+++ b/apps/admin/src/app/api/webhooks/stripe/route.ts
@@ -77,11 +77,17 @@ async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
 
 	const sub = subscription as unknown as {
 		status: string;
-		current_period_start: number;
-		current_period_end: number;
+		current_period_start?: number;
+		current_period_end?: number;
 		cancel_at_period_end: boolean;
 		canceled_at: number | null;
 		metadata: Record<string, string> | null;
+		items?: {
+			data?: Array<{
+				current_period_start?: number;
+				current_period_end?: number;
+			}>;
+		};
 	};
 
 	const status = sub.status as
@@ -90,12 +96,26 @@ async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
 		| "past_due"
 		| "trialing"
 		| "incomplete";
-	const currentPeriodStart = new Date(
-		sub.current_period_start * 1000,
-	).toISOString();
-	const currentPeriodEnd = new Date(
-		sub.current_period_end * 1000,
-	).toISOString();
+
+	// Stripe API 2026-05-27.dahlia で current_period_* が items.data[0] 配下へ移動したため、
+	// items 配下を優先し、旧APIバージョンのイベント（トップレベル）をフォールバックで拾う。
+	const item = sub.items?.data?.[0];
+	const periodStartUnix =
+		item?.current_period_start ?? sub.current_period_start;
+	const periodEndUnix = item?.current_period_end ?? sub.current_period_end;
+
+	// current_period_* は bar_subscriptions の NOT NULL カラム。両形状とも取れない場合、
+	// throw すると 500 → Stripe が無限リトライ（本 Issue #573 の再発）になるため、
+	// 警告ログを残してスキップし 200 で受理する。
+	if (periodStartUnix == null || periodEndUnix == null) {
+		console.warn(
+			`bar_subscriptions upsert/update をスキップ: current_period_* を取得できません (subscription=${subscriptionId})`,
+		);
+		return;
+	}
+
+	const currentPeriodStart = new Date(periodStartUnix * 1000).toISOString();
+	const currentPeriodEnd = new Date(periodEndUnix * 1000).toISOString();
 	const cancelAtPeriodEnd = sub.cancel_at_period_end || false;
 	const canceledAt = sub.canceled_at
 		? new Date(sub.canceled_at * 1000).toISOString()
@@ -173,10 +193,28 @@ async function handleSubscriptionCanceled(subscription: Stripe.Subscription) {
 		.eq("stripe_subscription_id", subscriptionId);
 }
 
+// Stripe API 2026-05-27.dahlia で invoice トップレベルの subscription が廃止され、
+// parent.subscription_details.subscription へ移動した（string | Stripe.Subscription）。
+// parent 配下を優先し、旧APIバージョンのトップレベル subscription をフォールバックで拾う。
+function extractSubscriptionId(invoice: Stripe.Invoice): string | null {
+	const inv = invoice as unknown as {
+		subscription?: string | { id: string } | null;
+		parent?: {
+			subscription_details?: {
+				subscription?: string | { id: string } | null;
+			} | null;
+		} | null;
+	};
+
+	const fromParent = inv.parent?.subscription_details?.subscription;
+	const raw = fromParent ?? inv.subscription;
+	if (!raw) return null;
+	return typeof raw === "string" ? raw : raw.id;
+}
+
 async function handleInvoicePaid(invoice: Stripe.Invoice) {
 	const inv = invoice as unknown as {
 		id: string;
-		subscription: string | null;
 		amount_paid: number;
 		amount_due: number;
 		currency: string;
@@ -184,7 +222,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
 		status_transitions: { paid_at: number | null };
 	};
 
-	const subscriptionId = inv.subscription;
+	const subscriptionId = extractSubscriptionId(invoice);
 
 	if (!subscriptionId) return;
 
@@ -212,11 +250,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
 }
 
 async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
-	const inv = invoice as unknown as {
-		subscription: string | null;
-	};
-
-	const subscriptionId = inv.subscription;
+	const subscriptionId = extractSubscriptionId(invoice);
 
 	if (!subscriptionId) return;
 


### PR DESCRIPTION
## 概要

Closes #573

Stripe SDK v20.4.1（API `2026-05-27.dahlia`）で移動・廃止されたフィールドを旧API前提で参照していたため、`customer.subscription.created/updated` の webhook が **500 で失敗**し、Checkout は成立するのに `bar_subscriptions` に行が作られず課金カードが「未課金」のままだった。**環境ではなくコードのバグ**（#528/#533 の環境作業は正常）。

## 根本原因

| フィールド | 旧API | 新API (dahlia) |
|---|---|---|
| `current_period_start/end` | `subscription.current_period_*`（トップレベル） | `subscription.items.data[0].current_period_*` |
| invoice の subscription | `invoice.subscription`（トップレベル） | `invoice.parent.subscription_details.subscription`（`string \| Subscription`） |

旧コードはトップレベルを読み `new Date(undefined * 1000).toISOString()` が `RangeError` を throw → webhook 500 → Stripe が全リトライ失敗 → 未 insert。

## 変更内容

- **`handleSubscriptionUpdate`**: `current_period_*` を `items.data[0]` 配下優先で取得し、旧APIのトップレベルをフォールバック。**両形状とも欠落した場合は throw せず警告ログを残して 200 でスキップ**（`current_period_*` は NOT NULL カラムのため。500 無限リトライ＝本 Issue の再発を回避）。
- **`handleInvoicePaid` / `handleInvoicePaymentFailed`**: `subscription` を `parent.subscription_details.subscription` から取得（`string` / 展開オブジェクト両対応）し、旧トップレベル `subscription` をフォールバック。共通ヘルパー `extractSubscriptionId` に集約。
- **`stripe.ts` の `apiVersion` pin は変更なし**（clover のまま）。両形状フォールバックにより新旧どちらのイベントでも動くため、checkout 等への波及ゼロで最小リスク。

## テスト

UT 14件（webhook）／admin 全302件パス。

| ケース | 検証 |
|---|---|
| 新API形状（items配下）で期間付き upsert 成立 | 主因の是正 |
| 旧API形状（トップレベル）フォールバック成立 | 破壊的変更なしの担保 |
| 両形状とも欠落 → 200スキップ・upsertなし・警告ログ | 500無限リトライ回避 |
| invoice の subscriptionId を parent 配下から取得し invoices insert | 関連潜在バグの是正 |
| parent 配下が展開オブジェクトでも id 抽出 / 旧トップレベルもフォールバック / 取得不能なら insert しない | 各分岐 |
| invoice.payment_failed で parent 配下から past_due 更新 | 関連潜在バグの是正 |
| 既存6ケース（署名・metadata欠落・23505受理・XX000で500 等） | 回帰なし |

### E2E について
webhook は署名検証を伴うサーバー間 POST のため、ローカル Playwright では実イベントを再現できない（実決済→webhook 署名は Preview 環境が前提）。ロジック分岐は UT で網羅したため E2E コードは追加しない。実機確認は Preview（#528/#533 構築済）で実決済 → `bar_subscriptions` active 行 → 課金中バッジ、で行う。

## 設計ドキュメント

DBスキーマ・ルーティング・画面構造の変更なしのため更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)