### PR TITLE
feat: #577 getBarDetail のネスト posts に表示上限 take を付与

### DIFF
--- a/apps/web/e2e/bar-detail-tabs.spec.ts
+++ b/apps/web/e2e/bar-detail-tabs.spec.ts
@@ -163,7 +163,9 @@ test.describe("店舗詳細ページ", () => {
 		// seed.e2e.sql が bar 100001 に「E2E投稿A/B」の2件を投入する前提。
 		// getBarDetail の include.posts に take 上限(50)を付与した後も、
 		// 投稿タブが従来どおり表示・スクロールできる（デグレなし）ことを検証する。
-		test("投稿タブに紐づく投稿が表示され、スクロールできる", async ({ page }) => {
+		test("投稿タブに紐づく投稿が表示され、スクロールできる", async ({
+			page,
+		}) => {
 			await page.goto("/bars/100001");
 
 			const postsTab = page.getByRole("button", { name: "タグ付けされた投稿" });

--- a/apps/web/e2e/bar-detail-tabs.spec.ts
+++ b/apps/web/e2e/bar-detail-tabs.spec.ts
@@ -159,6 +159,30 @@ test.describe("店舗詳細ページ", () => {
 		});
 	});
 
+	test.describe("タグ付けされた投稿タブの上限適用 (#577)", () => {
+		// seed.e2e.sql が bar 100001 に「E2E投稿A/B」の2件を投入する前提。
+		// getBarDetail の include.posts に take 上限(50)を付与した後も、
+		// 投稿タブが従来どおり表示・スクロールできる（デグレなし）ことを検証する。
+		test("投稿タブに紐づく投稿が表示され、スクロールできる", async ({ page }) => {
+			await page.goto("/bars/100001");
+
+			const postsTab = page.getByRole("button", { name: "タグ付けされた投稿" });
+			await expect(postsTab).toBeVisible();
+			await postsTab.click();
+
+			// seed の2件が両方描画される（上限適用で欠落していない）
+			await expect(page.getByText("E2E投稿A(100001)")).toBeVisible();
+			await expect(page.getByText("E2E投稿B(100001)")).toBeVisible();
+
+			// 他店(100002)の投稿は混入しない
+			await expect(page.getByText("E2E投稿C(100002)")).toHaveCount(0);
+
+			// ページ末尾までスクロールしても投稿本文が可視のまま（スクロール導線が壊れていない）
+			await page.mouse.wheel(0, 2000);
+			await expect(page.getByText("E2E投稿B(100001)")).toBeVisible();
+		});
+	});
+
 	test.describe("日時表示のタイムゾーン (#564)", () => {
 		// seed.e2e.sql が JST 08:00（= UTC 前日 23:00）固定のクーポン/イベントを投入する前提。
 		// timeZone 指定が漏れると、サーバー TZ が UTC の環境で日付が 2026/9/1 に巻き戻る。

--- a/apps/web/src/actions/bar-detail-post-limit.test.ts
+++ b/apps/web/src/actions/bar-detail-post-limit.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mockGetUser,
+		},
+	})),
+}));
+
+const mockBarFindUnique = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+	prisma: {
+		userProfile: {
+			findUnique: vi.fn(),
+		},
+		bar: {
+			findUnique: (...args: unknown[]) => mockBarFindUnique(...args),
+		},
+	},
+}));
+
+import { getBarDetail } from "./bar";
+import { USER_POST_LIST_LIMIT } from "./list-limits";
+
+// 整形処理が map する全 relation を最小構成で満たす bar オブジェクトを組む。
+// posts 以外の件数はここでは検証対象外なので空配列で埋め、posts の take 検証にノイズを持ち込まない。
+function buildBar(posts: unknown[]) {
+	return {
+		id: BigInt(1),
+		latitude: null,
+		longitude: null,
+		barImages: [],
+		openingHours: [],
+		barPaymentMethods: [],
+		beerMenus: [],
+		foodMenus: [],
+		posts,
+		articles: [],
+		coupons: [],
+		barEvents: [],
+	};
+}
+
+function buildPost(index: number) {
+	return {
+		id: BigInt(index + 1),
+		barId: BigInt(1),
+		_count: { postLikes: 0 },
+		postLikes: [],
+		postImages: [],
+	};
+}
+
+describe("getBarDetail の投稿 take 上限", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+		mockBarFindUnique.mockResolvedValue(buildBar([]));
+	});
+
+	it("include.posts に take 上限を渡す", async () => {
+		await getBarDetail("1");
+
+		expect(mockBarFindUnique).toHaveBeenCalledWith(
+			expect.objectContaining({
+				include: expect.objectContaining({
+					posts: expect.objectContaining({
+						take: USER_POST_LIST_LIMIT,
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("投稿は新しい順（createdAt 降順）で頭打ちにする", async () => {
+		// take で切り捨てる際に直近投稿が残るよう、降順を維持していることを検証する
+		await getBarDetail("1");
+
+		expect(mockBarFindUnique).toHaveBeenCalledWith(
+			expect.objectContaining({
+				include: expect.objectContaining({
+					posts: expect.objectContaining({
+						orderBy: { createdAt: "desc" },
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("上限を超える投稿があっても返却件数は take で頭打ちになる", async () => {
+		// Prisma のネスト take はサブクエリ側で件数を制限するため、モックも take 件数分だけ返す挙動を再現する
+		mockBarFindUnique.mockImplementation(
+			async (args: { include: { posts: { take: number } } }) =>
+				buildBar(
+					Array.from({ length: args.include.posts.take }, (_, i) =>
+						buildPost(i),
+					),
+				),
+		);
+
+		const result = await getBarDetail("1");
+
+		expect(result?.posts).toHaveLength(USER_POST_LIST_LIMIT);
+	});
+});

--- a/apps/web/src/actions/bar.ts
+++ b/apps/web/src/actions/bar.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import {
 	BAR_LIST_LIMIT,
 	FAVORITE_BAR_LIST_LIMIT,
+	USER_POST_LIST_LIMIT,
 	VIEW_HISTORY_LIST_LIMIT,
 } from "./list-limits";
 
@@ -220,6 +221,7 @@ export async function getBarDetail(barId: string) {
 				orderBy: {
 					createdAt: "desc",
 				},
+				take: USER_POST_LIST_LIMIT,
 			},
 			articles: {
 				where: {


### PR DESCRIPTION
## 概要

Closes #577

`getBarDetail`（`apps/web/src/actions/bar.ts`）のネスト `include.posts` に表示上限 `take` を付与する。#571 が top-level `findMany` の cap を対応したのに対し、`posts` はネスト include のため別 Issue として切り出されていた。

## 根本原因

`include.posts` は `orderBy: { createdAt: "desc" }` はあるが `take` が無く、店舗に紐づく全投稿を返していた。投稿の増加に対して転送量・レンダリング負荷が線形に増える。

## 変更内容

- `apps/web/src/actions/bar.ts`: `include.posts` に `take: USER_POST_LIST_LIMIT`（既存定数 = 50）を付与。`createdAt` 降順は維持。import に定数を追加
- `apps/web/src/actions/bar-detail-post-limit.test.ts`（新規）: take 上限の UT
- `apps/web/e2e/bar-detail-tabs.spec.ts`: 上限適用後も投稿タブが表示・スクロールできることを検証する E2E を追加

### 設計判断

- 新規定数は追加せず既存 `USER_POST_LIST_LIMIT` を流用。「店舗詳細の投稿」も「ユーザー投稿一覧」も同じユーザー投稿という同種データで、別値にする根拠が現時点で無い（Issue でも流用可と明記）
- 「もっと見る」/ページングは入れない。#571 でタイムライン以外はページング未定と整理済みのため本 Issue スコープ外

## 破壊的変更

なし。返り値の shape・型は不変で、呼び出し側（`/bars/[barId]` 投稿タブ）は無改修。件数が上限で頭打ちになるのみ（新しい順なので直近投稿が残る）。

## テスト

- UT: `include.posts.take` に上限が渡ること / 返却件数が上限で頭打ちになること / `createdAt` 降順維持 → 3件 pass（web 全 545 件 pass）
- E2E: `bar-detail-tabs.spec.ts` の投稿タブテスト追加。同ファイル全13件 pass（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)