### PR TITLE
chore: Playwright MCP をヘッドレス起動に変更

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "Playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": ["@playwright/mcp@latest", "--headless"]
     },
     "supabase": {
       "command": "npx",


### PR DESCRIPTION
## 概要

手動E2E用の Playwright MCP がヘッドあり（デフォルト）で起動しており、CI/skill の `playwright test`（ヘッドレス）と挙動が揃っていなかった。`.mcp.json` の Playwright MCP に `--headless` を付与し、全E2E系統をヘッドレスに統一する。

## 変更内容

- `.mcp.json`: Playwright MCP の起動引数に `--headless` を追加

## E2E系統の整理（変更後）

| 系統 | モード |
|------|--------|
| CI/skill の E2E（`playwright test`） | ヘッドレス（従来どおり） |
| Playwright MCP（手動E2E） | ヘッドレス（本PRで統一） |

※ `claude-in-chrome` MCP は既存Chromeを直接操作する性質上ヘッドレス化の対象外。

## テスト

設定ファイル（MCP起動引数）1行の変更のためアプリコードの UT/E2E 追加対象外。反映には Claude Code（MCPサーバー）の再起動が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QBU15DUyToJ1q7ErYCK79