### PR TITLE
docs: routing.md 776行目の beer-categories 注記の文言を整える (#585)

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -773,7 +773,7 @@ Beer Salon の画面遷移・URL 設計をまとめたドキュメント。
 以下のルートは廃止済み。実装が残っている場合は順次削除する。
 
 - `/admin/master/*`（マスタ管理画面: beer-styles, breweries, food-categories, event-categories）
-  - ※ **API の `/api/master/*` とは別物**。`GET /api/master/beer-categories`（`beer_categories` マスタ取得）は**現役**で、ビールメニュー登録フォーム（`/bars/[barId]/menus/new`）のカテゴリ・プルダウン取得に使われている（廃止対象ではない）。
+  - ※ 廃止対象はこの画面ルートのみ。API の `GET /api/master/beer-categories`（`beer_categories` マスタ取得）は**現役**で、ビールメニュー登録フォーム（`/bars/[barId]/menus/new`）のカテゴリ・プルダウン取得に使われている。
 - `/admin/users/*`（管理者ユーザー管理）
 - `/billing`（課金情報）
 


### PR DESCRIPTION
## 概要

`routing.md` 3-9 節（廃止したルート）776 行目、`GET /api/master/beer-categories` が現役である旨の注記の文言を整える。

## 背景

- 元の注記は「API の `/api/master/*` とは別物。beer-categories は現役、一方 beers は未使用」という **beers との対比構造** で書かれていた。
- #581 / PR #583 で `GET /api/master/beers` を削除し対比相手（beers）を除去したため、対比の片側だけが残り冗長になっていた。

## 変更内容

776 行目の以下を除去し、beer-categories 単独で読める形に整えた:

- 前置き `※ **API の /api/master/* とは別物**` → `※ 廃止対象はこの画面ルートのみ`（対比の名残を除去し、何が廃止対象かを明示）
- 末尾の重複 `（廃止対象ではない）` を削除（冒頭で「廃止対象はこの画面ルートのみ」と述べたため不要）

「現役」である事実・用途（ビールメニュー登録フォームでのカテゴリ取得）の記述は維持。

## 受入条件

- [x] routing.md 776 行目の文言が、beers との対比構造を残さず beer-categories 単独で読める形に整っている
- [x] コードと文書の一致（beer-categories が現役である事実）が保たれている

## テスト

ドキュメント文言のみの変更でロジック・画面・遷移に一切影響しないため、UT/E2E は対象外。文言の目視確認で担保。

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)